### PR TITLE
linter: Adding missing ClojureScript this-as macro

### DIFF
--- a/core/data/linter_cljs.joke
+++ b/core/data/linter_cljs.joke
@@ -348,13 +348,14 @@
 (defn system-time [])
 (defn bytes [x])
 (defn compare-symbols [a b])
+(def this-as)
 
 (def *known-macros*
   (apply
    joker.core/conj
    *known-macros*
    'cljs.core.async.macros/go-loop 'cljs.core.async.macros/alt! 'cljs.core.async.macros/alt!! 'cljs.core.async.macros/alts!
-   'cljs.core.async.macros/alts!!
+   'cljs.core.async.macros/alts!! 'this-as
    (:known-macros joker.core/*linter-config*)))
 
 (joker.core/in-ns 'user)


### PR DESCRIPTION
Adds a linter exception for this-as, a ClojureScript macro that lets you bind JavaScript 'this' to a local variable.