### PR TITLE
Add nix installation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ brew install candid82/brew/joker
 
 If you use Arch Linux, there is [AUR package](https://aur.archlinux.org/packages/joker/).
 
+If you use [Nix](https://nixos.org/nix/), then you can install Joker with
+
+```
+nix-env -i joker
+```
+
 On other platforms (or if you prefer manual installation), download a [precompiled binary](https://github.com/candid82/joker/releases) for your platform and put it on your PATH.
 
 You can also [build](#building) Joker from the source code.


### PR DESCRIPTION
I've added instructions for installing Joker when using [Nix](https://nixos.org/nix/). Hope the wording sounds ok.

Version 0.8.6 is currently provided in nixpkgs and I've already submitted a PR to bump it to version 0.8.7.

