### PR TITLE
fix :include-macros

### DIFF
--- a/core/data/linter_cljs.joke
+++ b/core/data/linter_cljs.joke
@@ -378,7 +378,7 @@
 
 (defn- load-libs-options__
   []
-  #{:as :reload :reload-all :require :use :verbose :refer :default :refer-macros :exclude :only :rename})
+  #{:as :reload :reload-all :require :use :verbose :refer :default :refer-macros :exclude :only :rename :include-macros})
 
 (joker.core/in-ns 'user)
 


### PR DESCRIPTION
Starting with 0.9.5 an exception is thrown when linting a cljs file that uses `:include-macros` in its `:require` form.

`bar.cljs:2:31: Exception: Unsupported option(s) supplied: :include-macros`

from https://clojurescript.org/guides/ns-forms#_sugar
> Similarly, there is `:include-macros` sugar that you can use to signal that the macros namespace should be required using the same specifications as the runtime namespace. So for example, this works:
> ```clj
> (ns bar.core
>  (:require [foo.core :as foo :include-macros true]))
>
> (foo/add 2 3)
> (foo/subtract 7 4)
> ```
This PR adds `:include-macros` to the list of allowed options.