### PR TITLE
Support '-' (single hyphen) as alias for stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ You can also [build](#building) Joker from the source code.
 
 `joker --lint <filename>` - lint a source file. See [Linter mode](#linter-mode) for more details.
 
+`joker -` - execute a script on standard input (os.Stdin). (Supersedes `--`, which will be changed to mean "end of Joker options" in the future.)
+
 ## Documentation
 
 [Standard library reference](https://candid82.github.io/joker/)

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func (ctx *ReplContext) PushException(exc Object) {
 
 func processFile(filename string, phase Phase) error {
 	var reader *Reader
-	if filename == "--" {
+	if filename == "-" || filename == "--" {
 		reader = NewReader(bufio.NewReader(os.Stdin), "<stdin>")
 		filename = ""
 	} else {


### PR DESCRIPTION
The documentation could be expanded and clarified further, but this is a quick PR to add support so a release could be made and downstream clients encouraged to switch over to using `-`.