### PR TITLE
Print result of evaluating -e <expr> if not nil

### DIFF
--- a/core/procs.go
+++ b/core/procs.go
@@ -38,6 +38,7 @@ const (
 	READ Phase = iota
 	PARSE
 	EVAL
+	PRINT_IF_NOT_NIL
 )
 
 const VERSION = "v0.10.0"
@@ -1482,10 +1483,16 @@ func ProcessReader(reader *Reader, filename string, phase Phase) error {
 		if phase == PARSE {
 			continue
 		}
-		_, err = TryEval(expr)
+		obj, err = TryEval(expr)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return err
+		}
+		if phase == EVAL {
+			continue
+		}
+		if _, ok := obj.(Nil); !ok {
+			fmt.Println(obj.ToString(true))
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func usage(out *os.File) {
 	fmt.Fprintf(out, "Joker - %s\n\n", VERSION)
 	fmt.Fprintln(out, "Usage: joker [args]                                 starts a repl")
 	fmt.Fprintln(out, "   or: joker [args] --repl [-- <repl-args>]         starts a repl with args")
-	fmt.Fprintln(out, "   or: joker [args] --expr <expr> [-- <expr-args>]  input is <expr>")
+	fmt.Fprintln(out, "   or: joker [args] --expr <expr> [-- <expr-args>]  evalute <expr>, print if non-nil")
 	fmt.Fprintln(out, "   or: joker [args] <filename> [<script-args>]      input from file")
 	fmt.Fprintln(out, "   or: joker [args] --lint <filename>               lint the code in file")
 	fmt.Fprintln(out, "\nNotes:")
@@ -378,6 +378,7 @@ func parseArgs(args []string) {
 			if i < length-1 && notOption(args[i+1]) {
 				i += 1 // shift
 				expr = args[i]
+				phase = PRINT_IF_NOT_NIL
 				if i < length-1 && args[i+1] == "--" {
 					i += 2 // shift 2
 					noFileFlag = true
@@ -526,7 +527,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: Cannot provide arguments to code while linting it.\n")
 			ExitJoker(4)
 		}
-		if phase != EVAL {
+		if phase != EVAL && phase != PRINT_IF_NOT_NIL {
 			fmt.Fprintf(os.Stderr, "Error: Cannot provide arguments to code without evaluating it.\n")
 			ExitJoker(5)
 		}


### PR DESCRIPTION
Fixes: https://github.com/candid82/joker/issues/109

Note that this leaves `main.go` in a bit of a dodgy state in terms of code cleanliness, because `EVAL` not only means different things (as it did before), but there's a shiny new `Phase` value, `PRINT_IF_NOT_NIL`, that has a new meaning, but in only one context.

I'm up for cleaning that up, but wanted to keep this PR scoped to just fixing the issue at hand.