### PR TITLE
Add tests of the --eval flag

### DIFF
--- a/tests/run-flag-tests.joke
+++ b/tests/run-flag-tests.joke
@@ -130,4 +130,28 @@
   "tests/flags/script-flags.joke -- something that is not a flag"
   "[-- something that is not a flag]")
 
+;; (testing :out "--eval option not printing nil result (FAKE)"
+;;          "--debug=stdout --eval '(println (+ 3 4))'"
+;;          "7")
+
+(testing :out "--eval option not printing nil result"
+         "--eval nil"
+         "")
+
+(testing :out "--eval option printing non-nil result (a string)"
+         "--eval '\"foo\"'"
+         "\"foo\"")
+
+(testing :out "--eval option printing non-nil result (a keyword)"
+         "--eval :bar"
+         ":bar")
+
+(testing :out "--eval option printing non-nil result (a number)"
+         "--eval 96"
+         "96")
+
+(testing :out "--eval option printing non-nil result (a symbol)"
+         "--eval 'xyzzy"
+         "xyzzy")
+
 (joker.os/exit exit-code)


### PR DESCRIPTION
One is "fake" and wouldn't work anyway because of limitations in how
the `testing` function parses string args. I'm leaving it in for now
in case I get time to try adding support for a test passing a vector
of args instead of a string, or some other simple solution.