### PR TITLE
Support (undocumented) --debug=stdout and --debug=stderr options

### DIFF
--- a/tests/run-flag-tests.joke
+++ b/tests/run-flag-tests.joke
@@ -130,4 +130,28 @@
   "tests/flags/script-flags.joke -- something that is not a flag"
   "[-- something that is not a flag]")
 
+;; (testing :out "--eval option not printing nil result (FAKE)"
+;;          "--debug=stdout --eval '(println (+ 3 4))'"
+;;          "7")
+
+(testing :out "--eval option not printing nil result"
+         "--eval nil"
+         "")
+
+(testing :out "--eval option printing non-nil result (a string)"
+         "--eval '\"foo\"'"
+         "\"foo\"")
+
+(testing :out "--eval option printing non-nil result (a keyword)"
+         "--eval :bar"
+         ":bar")
+
+(testing :out "--eval option printing non-nil result (a number)"
+         "--eval 96"
+         "96")
+
+(testing :out "--eval option printing non-nil result (a symbol)"
+         "--eval 'xyzzy"
+         "xyzzy")
+
 (joker.os/exit exit-code)

--- a/tests/run-flag-tests.joke
+++ b/tests/run-flag-tests.joke
@@ -130,28 +130,4 @@
   "tests/flags/script-flags.joke -- something that is not a flag"
   "[-- something that is not a flag]")
 
-;; (testing :out "--eval option not printing nil result (FAKE)"
-;;          "--debug=stdout --eval '(println (+ 3 4))'"
-;;          "7")
-
-(testing :out "--eval option not printing nil result"
-         "--eval nil"
-         "")
-
-(testing :out "--eval option printing non-nil result (a string)"
-         "--eval '\"foo\"'"
-         "\"foo\"")
-
-(testing :out "--eval option printing non-nil result (a keyword)"
-         "--eval :bar"
-         ":bar")
-
-(testing :out "--eval option printing non-nil result (a number)"
-         "--eval 96"
-         "96")
-
-(testing :out "--eval option printing non-nil result (a symbol)"
-         "--eval 'xyzzy"
-         "xyzzy")
-
 (joker.os/exit exit-code)


### PR DESCRIPTION
These helped me see more clearly what was going wrong with the "fake"
test I'd added to tests/run-flag-tests.joke.