### PR TITLE
Fix (read-line) so it works inside (with-in-str ...)

### DIFF
--- a/core/procs.go
+++ b/core/procs.go
@@ -1127,6 +1127,8 @@ func readLine(inp io.Reader) (s string, e error) {
 				}
 			}
 			s = s[0:l]
+		} else if s != "" && e == io.EOF {
+			e = nil
 		}
 	default:
 		msg := fmt.Sprintf("Expected %s, got %T", "*core.BufferedReader or *core.Buffer", inp)

--- a/core/procs.go
+++ b/core/procs.go
@@ -1103,7 +1103,7 @@ var procReadString Proc = func(args []Object) Object {
 	return readFromReader(strings.NewReader(EnsureString(args, 0).S))
 }
 
-type stringReader interface{ ReadString(delim byte) (s string, e error)}
+type stringReader interface{ ReadString(delim byte) (s string, e error) }
 func readLine(r stringReader) (s string, e error) {
 	s, e = r.ReadString('\n')
 	if e == nil {

--- a/core/procs.go
+++ b/core/procs.go
@@ -1122,7 +1122,7 @@ func readLine(inp io.Reader) (s string, e error) {
 			l := len(s)
 			if s[l-1] == '\n' {
 				l -= 1
-				if s[l-1] == '\r' {
+				if l > 0 && s[l-1] == '\r' {
 					l -= 1
 				}
 			}


### PR DESCRIPTION
This is not the elegant solution for which we were hoping, but it seems to work well, the key being to ensure the underlying `io.Reader` object, whatever its concrete implementation, is maintained such that a `(read-line)` reads only as far as necessary ("unreading" as appropriate) so the next `(read-line)` (or `(read)`) call works properly.

Fixes: https://github.com/candid82/joker/issues/129