### PR TITLE
New script to test evaluation of forms from input files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,6 @@ jobs:
       - run:
           name: flag tests
           command: ./flag-tests.sh
+      - run:
+          name: eval tests
+          command: ./eval-tests.sh

--- a/eval-tests.sh
+++ b/eval-tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./joker tests/run-eval-tests.joke "$@"

--- a/tests/eval/read-line/input.joke
+++ b/tests/eval/read-line/input.joke
@@ -1,0 +1,12 @@
+;;; Move this into core.joke?
+(defmacro while-let
+ "Continue processing an expression as long as it is true"
+ [binding & forms]
+  `(loop []
+     (when-let ~binding
+       ~@forms
+       (recur))))
+
+(with-in-str (slurp "lines.txt")
+  (while-let [line (read-line)]
+    (println line)))

--- a/tests/eval/read-line/lines.txt
+++ b/tests/eval/read-line/lines.txt
@@ -1,0 +1,3 @@
+This is test input.
+Would be cool to automate this for all tests.
+But sh/sh-from don't support the :in keyword yet.

--- a/tests/eval/read-line/stdout.txt
+++ b/tests/eval/read-line/stdout.txt
@@ -1,0 +1,3 @@
+This is test input.
+Would be cool to automate this for all tests.
+But sh/sh-from don't support the :in keyword yet.

--- a/tests/run-eval-tests.joke
+++ b/tests/run-eval-tests.joke
@@ -1,0 +1,53 @@
+(defn slurp-or
+  [path alt]
+  (try
+    (slurp path)
+    (catch Error e
+      alt)))
+
+(def exit-code 0)
+
+(defn have-option
+  "Quick and dirty options parser."
+  [opt]
+  (some #(= opt %) *command-line-args*))
+
+(def verbose (or (have-option "--verbose") (have-option "-v")))
+
+(let [test-dirs (->> (joker.os/ls "tests/eval")
+                     (filter :dir?)
+                     (map :name))
+      pwd (get (joker.os/env) "PWD")
+      exe (str pwd "/joker")]
+  (doseq [test-dir test-dirs]
+    (when verbose
+      (println (str "Running test " test-dir)))
+    (let [dir (str "tests/eval/" test-dir "/")
+          filename "input.joke"
+          res (joker.os/sh-from dir exe filename) ; Someday add: :in "input.txt" (no :in support yet)
+          out (:out res)
+          err (:err res)
+          rc (:exit res)
+          expected-out (slurp-or (str dir "stdout.txt") "")
+          expected-err (slurp-or (str dir "stderr.txt") "")
+          expected-rc (if-let [rc (slurp-or (str dir "rc.txt") false)]
+                        (int (bigint (with-in-str rc (read-line))))
+                        0)]
+      (when-not (and (= expected-out out) (= expected-err err) (= expected-rc rc))
+        (println "FAILED:" test-dir)
+        (when-not (= expected-out out)
+          (println "EXPECTED STDOUT:")
+          (println expected-out)
+          (println "ACTUAL STDOUT:")
+          (println out))
+        (when-not (= expected-err err)
+          (println "EXPECTED STDERR:")
+          (println expected-err)
+          (println "ACTUAL STDERR:")
+          (println err))
+        (when-not (= expected-rc rc)
+          (println "EXPECTED RC:" expected-rc)
+          (println "ACTUAL RC:" rc))
+        (var-set #'exit-code 1)))))
+
+(joker.os/exit exit-code)


### PR DESCRIPTION
Pretty much just `linter-tests.sh` and friends, modified to support testing of fairly arbitrary input files (named `input.joke`) that are evaluated.

An `input.joke` file should be able to easily shell out and run `joker` on some other file in the same directory, as it is run in the test directory and can look at the first element of `(joker.os/args)` to find the name of the executable.

This is crude but promises to be effective as a start.