### PR TITLE
Fix e.g. (use 'joker.math)

### DIFF
--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3181,7 +3181,9 @@
 (defonce ^:dynamic
   ^{:private true
     :doc "A set of symbols representing loaded libs"}
-  *loaded-libs* #{'joker.core 'joker.os 'joker.base64 'joker.json 'joker.string 'joker.yaml})
+  *loaded-libs* #{'joker.base64 'joker.core 'joker.html 'joker.http 'joker.json
+                  'joker.math 'joker.os 'joker.string 'joker.time 'joker.url
+                  'joker.yaml})
 
 (defonce ^:dynamic
   ^{:private true

--- a/std/generate-std.joke
+++ b/std/generate-std.joke
@@ -1,4 +1,4 @@
-(def namespaces ['string 'json 'base64 'os 'time 'yaml 'http 'math 'html 'url])
+(def namespaces ['base64 'html 'http 'json 'math 'os 'string 'time 'url 'yaml])
 
 (apply require namespaces)
 


### PR DESCRIPTION
`joker.math/pi` works in the current version, but this fix allows one to `(require '[joker.math :as m])` and such. Ditto the other libs added.

(Also sorted the libs so it's easier to see what's missing.)