### PR TITLE
Add joker versions of clojure.template and clojure.walk

### DIFF
--- a/core/data/template.joke
+++ b/core/data/template.joke
@@ -1,0 +1,55 @@
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+;;; template.clj - anonymous functions that pre-evaluate sub-expressions
+
+;; By Stuart Sierra
+;; June 23, 2009
+
+;; CHANGE LOG
+;;
+;; June 23, 2009: complete rewrite, eliminated _1,_2,... argument
+;; syntax
+;;
+;; January 20, 2009: added "template?" and checks for valid template
+;; expressions.
+;;
+;; December 15, 2008: first version
+
+
+(ns ^{:doc "Macros that expand to repeated copies of a template expression."
+       :author "Stuart Sierra"}
+  joker.template
+  (:require [joker.walk :as walk]))
+
+(defn apply-template
+  "For use in macros.  argv is an argument list, as in defn.  expr is
+  a quoted expression using the symbols in argv.  values is a sequence
+  of values to be used for the arguments.
+
+  apply-template will recursively replace argument symbols in expr
+  with their corresponding values, returning a modified expr.
+
+  Example: (apply-template '[x] '(+ x x) '[2])
+           ;=> (+ 2 2)"
+  [argv expr values]
+  (assert (vector? argv))
+  (assert (every? symbol? argv))
+  (walk/postwalk-replace (zipmap argv values) expr))
+
+(defmacro do-template
+  "Repeatedly copies expr (in a do block) for each group of arguments
+  in values.  values are automatically partitioned by the number of
+  arguments in argv, an argument vector as in defn.
+
+  Example: (macroexpand '(do-template [x y] (+ y x) 2 4 3 5))
+           ;=> (do (+ 4 2) (+ 5 3))"
+  [argv expr & values]
+  (let [c (count argv)]
+    `(do ~@(map (fn [a] (apply-template argv expr a)) 
+                (partition c values)))))

--- a/core/data/walk.joke
+++ b/core/data/walk.joke
@@ -1,0 +1,132 @@
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+;;; walk.clj - generic tree walker with replacement
+
+;; by Stuart Sierra
+;; December 15, 2008
+
+;; CHANGE LOG:
+;;
+;; * December 15, 2008: replaced 'walk' with 'prewalk' & 'postwalk'
+;;
+;; * December 9, 2008: first version
+
+
+(ns
+  ^{:author "Stuart Sierra",
+     :doc "This file defines a generic tree walker for Clojure data
+structures.  It takes any data structure (list, vector, map, set,
+seq), calls a function on every element, and uses the return value
+of the function in place of the original.  This makes it fairly
+easy to write recursive search-and-replace functions, as shown in
+the examples.
+
+Note: \"walk\" supports all Clojure data structures EXCEPT maps
+created with sorted-map-by.  There is no (obvious) way to retrieve
+the sorting function."}
+  joker.walk)
+
+(defn walk
+  "Traverses form, an arbitrary data structure.  inner and outer are
+  functions.  Applies inner to each element of form, building up a
+  data structure of the same type, then applies outer to the result.
+  Recognizes all Clojure data structures. Consumes seqs as with doall."
+
+  {:added "1.1"}
+  [inner outer form]
+  (cond
+   (list? form) (outer (apply list (map inner form)))
+;; Joker uses simple vectors for map entries (e.g. try `(type (first {:a 1 :b 2}))`):
+;;   (instance? clojure.lang.IMapEntry form)
+;;   (outer (clojure.lang.MapEntry/create (inner (key form)) (inner (val form))))
+   (seq? form) (outer (doall (map inner form)))
+;; Joker does not yet support records:
+;;   (instance? clojure.lang.IRecord form)
+;;     (outer (reduce (fn [r x] (conj r (inner x))) form form))
+   (coll? form) (outer (into (empty form) (map inner form)))
+   :else (outer form)))
+
+(defn postwalk
+  "Performs a depth-first, post-order traversal of form.  Calls f on
+  each sub-form, uses f's return value in place of the original.
+  Recognizes all Clojure data structures. Consumes seqs as with doall."
+  {:added "1.1"}
+  [f form]
+  (walk (partial postwalk f) f form))
+
+(defn prewalk
+  "Like postwalk, but does pre-order traversal."
+  {:added "1.1"}
+  [f form]
+  (walk (partial prewalk f) identity (f form)))
+
+
+;; Note: I wanted to write:
+;;
+;; (defn walk
+;;   [f form]
+;;   (let [pf (partial walk f)]
+;;     (if (coll? form)
+;;       (f (into (empty form) (map pf form)))
+;;       (f form))))
+;;
+;; but this throws a ClassCastException when applied to a map.
+
+
+(defn postwalk-demo
+  "Demonstrates the behavior of postwalk by printing each form as it is
+  walked.  Returns form."
+  {:added "1.1"}
+  [form]
+  (postwalk (fn [x] (print "Walked: ") (prn x) x) form))
+
+(defn prewalk-demo
+  "Demonstrates the behavior of prewalk by printing each form as it is
+  walked.  Returns form."
+  {:added "1.1"}
+  [form]
+  (prewalk (fn [x] (print "Walked: ") (prn x) x) form))
+
+(defn keywordize-keys
+  "Recursively transforms all map keys from strings to keywords."
+  {:added "1.1"}
+  [m]
+  (let [f (fn [[k v]] (if (string? k) [(keyword k) v] [k v]))]
+    ;; only apply to maps
+    (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
+
+(defn stringify-keys
+  "Recursively transforms all map keys from keywords to strings."
+  {:added "1.1"}
+  [m]
+  (let [f (fn [[k v]] (if (keyword? k) [(name k) v] [k v]))]
+    ;; only apply to maps
+    (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
+
+(defn prewalk-replace
+  "Recursively transforms form by replacing keys in smap with their
+  values.  Like clojure/replace but works on any data structure.  Does
+  replacement at the root of the tree first."
+  {:added "1.1"}
+  [smap form]
+  (prewalk (fn [x] (if (contains? smap x) (smap x) x)) form))
+
+(defn postwalk-replace
+  "Recursively transforms form by replacing keys in smap with their
+  values.  Like clojure/replace but works on any data structure.  Does
+  replacement at the leaves of the tree first."
+  {:added "1.1"}
+  [smap form]
+  (postwalk (fn [x] (if (contains? smap x) (smap x) x)) form))
+
+(defn macroexpand-all
+  "Recursively performs all possible macroexpansions in form."
+  {:added "1.1"}
+  [form]
+  (prewalk (fn [x] (if (seq? x) (macroexpand x) x)) form))

--- a/core/gen_data/gen_data.go
+++ b/core/gen_data/gen_data.go
@@ -41,6 +41,14 @@ var files []FileInfo = []FileInfo{
 		filename: "repl.joke",
 	},
 	{
+		name:     "<joker.walk>",
+		filename: "walk.joke",
+	},
+	{
+		name:     "<joker.template>",
+		filename: "template.joke",
+	},
+	{
 		name:     "<joker.core>",
 		filename: "linter_all.joke",
 	},

--- a/core/procs.go
+++ b/core/procs.go
@@ -24,6 +24,8 @@ var (
 	timeData        []byte
 	mathData        []byte
 	replData        []byte
+	walkData        []byte
+	templateData    []byte
 	linter_allData  []byte
 	linter_cljxData []byte
 	linter_cljData  []byte
@@ -1543,8 +1545,11 @@ func processData(data []byte) {
 
 func ProcessCoreData() {
 	processData(coreData)
+	/* Might be faster startup if the rest of these were deferred until actually :require'd? */
 	processData(timeData)
 	processData(mathData)
+	processData(walkData)
+	processData(templateData)
 }
 
 func ProcessReplData() {


### PR DESCRIPTION
These are used by the (forthcoming) `joker.test`. Seemed easier to port than to rewrite around them.