### PR TITLE
Make CircleCI run tests properly in forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,9 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.9.4
+    working_directory: /go/src/github.com/candid82/joker
     steps:
       - checkout
-      - run:
-          command: pwd
-      - run:
-          name: mkdir
-          command: mkdir -p /go/src/github.com/${CIRCLE_PROJECT_USERNAME}
-      - run:
-          name: ln
-          command: ln -s /home/circleci/project /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       - run:
           name: go get readline
           command: go get -d -v github.com/chzyer/readline


### PR DESCRIPTION
In forks of this project, `CIRCLE_PROJECT_USERNAME` is not `candid82` and so references in code or elsewhere to `candid82/joker` will fail. The solution is to work in and check out directly to the directory in `GOPATH`. This simplifies the config and makes it possible to test this project from a fork.