### PR TITLE
Fix Test Comparisons on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,5 @@
 # Set the default behavior.
-* text=auto
+* text eol=lf
 
-# Unix line endings on .txt files.
-*.txt text eol=lf
-
-# Unix line endings on .go files.
-*.go text eol=lf
-
-# Unix line endings on .html files.
-*.html text eol=lf
-
-# Unix line endings on .joke files.
-*.joke text eol=lf
-
-# Unix line endings on .tmpl files.
-*.tmpl text eol=lf
+# DOS line endings on .bat files.
+*.bat text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 
 # Unix line endings on .txt files.
 *.txt text eol=lf
+
+# Unix line endings on .go files.
+*.go text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 
 # Unix line endings on .go files.
 *.go text eol=lf
+
+# Unix line endings on .html files.
+*.html text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,6 @@
 
 # Unix line endings on .html files.
 *.html text eol=lf
+
+# Unix line endings on .joke files.
+*.joke text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior.
+* text=auto
+
+# Unix line endings on .txt files.
+*.txt text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@
 
 # Unix line endings on .joke files.
 *.joke text eol=lf
+
+# Unix line endings on .tmpl files.
+*.tmpl text eol=lf

--- a/docs/joker.core.html
+++ b/docs/joker.core.html
@@ -1173,7 +1173,7 @@
 <div><code>(* x y)</code></div>
 <div><code>(* x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns the product of nums. (*) returns 1. Does not auto-promote<br>  ints, will overflow. See also: *'</p>
+  <p class="var-docstr">Returns the product of nums. (*) returns 1. Does not auto-promote<br>  ints, will overflow. See also: *'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L762">source</a>
 </li>
 <li>
@@ -1185,7 +1185,7 @@
 <div><code>(*' x y)</code></div>
 <div><code>(*' x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns the product of nums. (*) returns 1. Supports arbitrary precision.<br>  See also: *</p>
+  <p class="var-docstr">Returns the product of nums. (*) returns 1. Supports arbitrary precision.<br>  See also: *</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L752">source</a>
 </li>
 <li>
@@ -1225,7 +1225,7 @@
   <span class="var-type Nil">Nil</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">A sequence of the supplied command line arguments, or nil if<br>  none were supplied</p>
+  <p class="var-docstr">A sequence of the supplied command line arguments, or nil if<br>  none were supplied</p>
   
 </li>
 <li>
@@ -1241,7 +1241,7 @@
   <span class="var-type IOWriter">IOWriter</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">A File object representing standard error for print operations.<br><br>  Defaults to stderr.</p>
+  <p class="var-docstr">A File object representing standard error for print operations.<br><br>  Defaults to stderr.</p>
   
 </li>
 <li>
@@ -1249,7 +1249,7 @@
   <span class="var-type String">String</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">The path of the file being evaluated, as a String.<br><br>  When there is no file, e.g. in the REPL, the value is not defined.</p>
+  <p class="var-docstr">The path of the file being evaluated, as a String.<br><br>  When there is no file, e.g. in the REPL, the value is not defined.</p>
   
 </li>
 <li>
@@ -1257,7 +1257,7 @@
   <span class="var-type Bool">Bool</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">When set to true, output will be flushed whenever a newline is printed.<br><br>    Defaults to true.</p>
+  <p class="var-docstr">When set to true, output will be flushed whenever a newline is printed.<br><br>    Defaults to true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2118">source</a>
 </li>
 <li>
@@ -1265,7 +1265,7 @@
   <span class="var-type BufferedReader">BufferedReader</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">A File object representing standard input for read operations.<br><br>  Defaults to stdin.</p>
+  <p class="var-docstr">A File object representing standard input for read operations.<br><br>  Defaults to stdin.</p>
   
 </li>
 <li>
@@ -1305,7 +1305,7 @@
   <span class="var-type IOWriter">IOWriter</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">A File object representing standard output for print operations.<br><br>  Defaults to stdout.</p>
+  <p class="var-docstr">A File object representing standard output for print operations.<br><br>  Defaults to stdout.</p>
   
 </li>
 <li>
@@ -1313,7 +1313,7 @@
   <span class="var-type Bool">Bool</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">When set to logical false, strings and characters will be printed with<br>  non-alphanumeric characters converted to the appropriate escape sequences.<br><br>  Defaults to true</p>
+  <p class="var-docstr">When set to logical false, strings and characters will be printed with<br>  non-alphanumeric characters converted to the appropriate escape sequences.<br><br>  Defaults to true</p>
   
 </li>
 <li>
@@ -1325,7 +1325,7 @@
 <div><code>(+ x y)</code></div>
 <div><code>(+ x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns the sum of nums. (+) returns 0. Does not auto-promote<br>  ints, will overflow. See also: +'</p>
+  <p class="var-docstr">Returns the sum of nums. (+) returns 0. Does not auto-promote<br>  ints, will overflow. See also: +'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L742">source</a>
 </li>
 <li>
@@ -1337,7 +1337,7 @@
 <div><code>(+' x y)</code></div>
 <div><code>(+' x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns the sum of nums. (+) returns 0. Supports arbitrary precision.<br>  See also: +</p>
+  <p class="var-docstr">Returns the sum of nums. (+) returns 0. Supports arbitrary precision.<br>  See also: +</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L732">source</a>
 </li>
 <li>
@@ -1348,7 +1348,7 @@
 <div><code>(- x y)</code></div>
 <div><code>(- x y & more)</code></div>
 </pre>
-  <p class="var-docstr">If no ys are supplied, returns the negation of x, else subtracts<br>  the ys from x and returns the result. Does not auto-promote<br>  ints, will overflow. See also: -'</p>
+  <p class="var-docstr">If no ys are supplied, returns the negation of x, else subtracts<br>  the ys from x and returns the result. Does not auto-promote<br>  ints, will overflow. See also: -'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L791">source</a>
 </li>
 <li>
@@ -1359,7 +1359,7 @@
 <div><code>(-' x y)</code></div>
 <div><code>(-' x y & more)</code></div>
 </pre>
-  <p class="var-docstr">If no ys are supplied, returns the negation of x, else subtracts<br>  the ys from x and returns the result. Supports arbitrary precision.<br>  See also: -</p>
+  <p class="var-docstr">If no ys are supplied, returns the negation of x, else subtracts<br>  the ys from x and returns the result. Supports arbitrary precision.<br>  See also: -</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L781">source</a>
 </li>
 <li>
@@ -1368,7 +1368,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(-> x & forms)</code></div>
 </pre>
-  <p class="var-docstr">Threads the expr through the forms. Inserts x as the<br>  second item in the first form, making a list of it if it is not a<br>  list already. If there are more forms, inserts the first form as the<br>  second item in second form, etc.</p>
+  <p class="var-docstr">Threads the expr through the forms. Inserts x as the<br>  second item in the first form, making a list of it if it is not a<br>  list already. If there are more forms, inserts the first form as the<br>  second item in second form, etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1211">source</a>
 </li>
 <li>
@@ -1377,7 +1377,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(->> x & forms)</code></div>
 </pre>
-  <p class="var-docstr">Threads the expr through the forms. Inserts x as the<br>  last item in the first form, making a list of it if it is not a<br>  list already. If there are more forms, inserts the first form as the<br>  last item in second form, etc.</p>
+  <p class="var-docstr">Threads the expr through the forms. Inserts x as the<br>  last item in the first form, making a list of it if it is not a<br>  list already. If there are more forms, inserts the first form as the<br>  last item in second form, etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1229">source</a>
 </li>
 <li>
@@ -1388,7 +1388,7 @@
 <div><code>(/ x y)</code></div>
 <div><code>(/ x y & more)</code></div>
 </pre>
-  <p class="var-docstr">If no denominators are supplied, returns 1/numerator,<br>  else returns numerator divided by all of the denominators.</p>
+  <p class="var-docstr">If no denominators are supplied, returns 1/numerator,<br>  else returns numerator divided by all of the denominators.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L772">source</a>
 </li>
 <li>
@@ -1399,7 +1399,7 @@
 <div><code>(< x y)</code></div>
 <div><code>(< x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums are in monotonically increasing order,<br>  otherwise false.</p>
+  <p class="var-docstr">Returns non-nil if nums are in monotonically increasing order,<br>  otherwise false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L679">source</a>
 </li>
 <li>
@@ -1410,7 +1410,7 @@
 <div><code>(<= x y)</code></div>
 <div><code>(<= x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums are in monotonically non-decreasing order,<br>  otherwise false.</p>
+  <p class="var-docstr">Returns non-nil if nums are in monotonically non-decreasing order,<br>  otherwise false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L801">source</a>
 </li>
 <li>
@@ -1421,7 +1421,7 @@
 <div><code>(= x y)</code></div>
 <div><code>(= x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Equality. Returns true if x equals y, false if not. Works for nil, and compares<br>  numbers and collections in a type-independent manner.  Immutable data<br>  structures define = as a value, not an identity,<br>  comparison.</p>
+  <p class="var-docstr">Equality. Returns true if x equals y, false if not. Works for nil, and compares<br>  numbers and collections in a type-independent manner.  Immutable data<br>  structures define = as a value, not an identity,<br>  comparison.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L596">source</a>
 </li>
 <li>
@@ -1432,7 +1432,7 @@
 <div><code>(== x y)</code></div>
 <div><code>(== x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums all have the equivalent<br>  value (type-independent), otherwise false</p>
+  <p class="var-docstr">Returns non-nil if nums all have the equivalent<br>  value (type-independent), otherwise false</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L840">source</a>
 </li>
 <li>
@@ -1443,7 +1443,7 @@
 <div><code>(> x y)</code></div>
 <div><code>(> x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums are in monotonically decreasing order,<br>  otherwise false.</p>
+  <p class="var-docstr">Returns non-nil if nums are in monotonically decreasing order,<br>  otherwise false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L814">source</a>
 </li>
 <li>
@@ -1454,7 +1454,7 @@
 <div><code>(>= x y)</code></div>
 <div><code>(>= x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums are in monotonically non-increasing order,<br>  otherwise false.</p>
+  <p class="var-docstr">Returns non-nil if nums are in monotonically non-increasing order,<br>  otherwise false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L827">source</a>
 </li>
 <li>
@@ -1463,7 +1463,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(alias alias namespace-sym)</code></div>
 </pre>
-  <p class="var-docstr">Add an alias in the current namespace to another<br>  namespace. Arguments are two symbols: the alias to be used, and<br>  the symbolic name of the target namespace. Use :as in the ns macro in preference<br>  to calling this directly.</p>
+  <p class="var-docstr">Add an alias in the current namespace to another<br>  namespace. Arguments are two symbols: the alias to be used, and<br>  the symbolic name of the target namespace. Use :as in the ns macro in preference<br>  to calling this directly.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2409">source</a>
 </li>
 <li>
@@ -1481,7 +1481,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(alter-meta! ref f & args)</code></div>
 </pre>
-  <p class="var-docstr">Atomically sets the metadata for a namespace/var/atom to be:<br><br>  (apply f its-current-meta args)<br><br>  f must be free of side-effects</p>
+  <p class="var-docstr">Atomically sets the metadata for a namespace/var/atom to be:<br><br>  (apply f its-current-meta args)<br><br>  f must be free of side-effects</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1491">source</a>
 </li>
 <li>
@@ -1492,7 +1492,7 @@
 <div><code>(and x)</code></div>
 <div><code>(and x & next)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates exprs one at a time, from left to right. If a form<br>  returns logical false (nil or false), and returns that value and<br>  doesn't evaluate any of the other expressions, otherwise it returns<br>  the value of the last expr. (and) returns true.</p>
+  <p class="var-docstr">Evaluates exprs one at a time, from left to right. If a form<br>  returns logical false (nil or false), and returns that value and<br>  doesn't evaluate any of the other expressions, otherwise it returns<br>  the value of the last expr. (and) returns true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L628">source</a>
 </li>
 <li>
@@ -1523,7 +1523,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(array-map & keyvals)</code></div>
 </pre>
-  <p class="var-docstr">Constructs an array-map. If any keys are equal, they are handled as<br>         if by repeated uses of assoc.</p>
+  <p class="var-docstr">Constructs an array-map. If any keys are equal, they are handled as<br>         if by repeated uses of assoc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2477">source</a>
 </li>
 <li>
@@ -1532,7 +1532,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(as-> expr name & forms)</code></div>
 </pre>
-  <p class="var-docstr">Binds name to expr, evaluates the first form in the lexical context<br>  of that binding, then binds name to that result, repeating for each<br>  successive form, returning the result of the last form.</p>
+  <p class="var-docstr">Binds name to expr, evaluates the first form in the lexical context<br>  of that binding, then binds name to that result, repeating for each<br>  successive form, returning the result of the last form.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4124">source</a>
 </li>
 <li>
@@ -1542,7 +1542,7 @@
   <pre class="var-usage"><div><code>(assert x)</code></div>
 <div><code>(assert x message)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates expr and throws an exception if it does not evaluate to<br>  logical true.</p>
+  <p class="var-docstr">Evaluates expr and throws an exception if it does not evaluate to<br>  logical true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2897">source</a>
 </li>
 <li>
@@ -1552,7 +1552,7 @@
   <pre class="var-usage"><div><code>(assoc map key val)</code></div>
 <div><code>(assoc map key val & kvs)</code></div>
 </pre>
-  <p class="var-docstr">`assoc[iate]. When applied to a map, returns a new map of the<br>         same (hashed/sorted) type, that contains the mapping of key(s) to<br>         val(s). When applied to a vector, returns a new vector that<br>         contains val at index. Note - index must be <= (count vector).</p>
+  <p class="var-docstr">`assoc[iate]. When applied to a map, returns a new map of the<br>         same (hashed/sorted) type, that contains the mapping of key(s) to<br>         val(s). When applied to a vector, returns a new vector that<br>         contains val at index. Note - index must be <= (count vector).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L164">source</a>
 </li>
 <li>
@@ -1561,7 +1561,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(assoc-in m ks v)</code></div>
 </pre>
-  <p class="var-docstr">Associates a value in a nested associative structure, where ks is a<br>  sequence of keys and v is the new value and returns a new nested structure.<br>  If any levels do not exist, hash-maps will be created.</p>
+  <p class="var-docstr">Associates a value in a nested associative structure, where ks is a<br>  sequence of keys and v is the new value and returns a new nested structure.<br>  If any levels do not exist, hash-maps will be created.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3495">source</a>
 </li>
 <li>
@@ -1579,7 +1579,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(atom x & options)</code></div>
 </pre>
-  <p class="var-docstr">Creates and returns an Atom with an initial value of x and zero or<br>  more options (in any order):<br><br>  :meta metadata-map<br><br>  If metadata-map is supplied, it will become the metadata on the<br>  atom.</p>
+  <p class="var-docstr">Creates and returns an Atom with an initial value of x and zero or<br>  more options (in any order):<br><br>  :meta metadata-map<br><br>  If metadata-map is supplied, it will become the metadata on the<br>  atom.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1448">source</a>
 </li>
 <li>
@@ -1615,7 +1615,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(binding bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">binding => var-symbol init-expr<br><br>  Creates new bindings for the (already-existing) vars, with the<br>  supplied initial values, executes the exprs in an implicit do, then<br>  re-establishes the bindings that existed before.  The new bindings<br>  are made in parallel (unlike let); all init-exprs are evaluated<br>  before the vars are bound to their new values.</p>
+  <p class="var-docstr">binding => var-symbol init-expr<br><br>  Creates new bindings for the (already-existing) vars, with the<br>  supplied initial values, executes the exprs in an implicit do, then<br>  re-establishes the bindings that existed before.  The new bindings<br>  are made in parallel (unlike let); all init-exprs are evaluated<br>  before the vars are bound to their new values.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1413">source</a>
 </li>
 <li>
@@ -1745,7 +1745,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(bound? & vars)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if all of the vars provided as arguments have any bound value.<br>  Implies that deref'ing the provided vars will succeed. Returns true if no vars are provided.</p>
+  <p class="var-docstr">Returns true if all of the vars provided as arguments have any bound value.<br>  Implies that deref'ing the provided vars will succeed. Returns true if no vars are provided.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3089">source</a>
 </li>
 <li>
@@ -1754,7 +1754,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(bounded-count n coll)</code></div>
 </pre>
-  <p class="var-docstr">If coll is counted? returns its count, else will count at most the first n<br>  elements of coll using its seq</p>
+  <p class="var-docstr">If coll is counted? returns its count, else will count at most the first n<br>  elements of coll using its seq</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3960">source</a>
 </li>
 <li>
@@ -1772,7 +1772,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(callable? x)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if x implements Callable. Note that many data structures<br>  (e.g. sets and maps) implement Callable.</p>
+  <p class="var-docstr">Returns true if x implements Callable. Note that many data structures<br>  (e.g. sets and maps) implement Callable.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3553">source</a>
 </li>
 <li>
@@ -1781,7 +1781,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(case expr & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes an expression, and a set of clauses.<br><br>  Each clause can take the form of either:<br><br>  test-expr result-expr<br><br>  (test-expr ... test-expr)  result-expr<br><br>  If the expression is equal to a value of<br>  test-expr, the corresponding result-expr is returned. A single<br>  default expression can follow the clauses, and its value will be<br>  returned if no clause matches. If no default expression is provided<br>  and no clause matches, an exception is thrown.</p>
+  <p class="var-docstr">Takes an expression, and a set of clauses.<br><br>  Each clause can take the form of either:<br><br>  test-expr result-expr<br><br>  (test-expr ... test-expr)  result-expr<br><br>  If the expression is equal to a value of<br>  test-expr, the corresponding result-expr is returned. A single<br>  default expression can follow the clauses, and its value will be<br>  returned if no clause matches. If no default expression is provided<br>  and no clause matches, an exception is thrown.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3777">source</a>
 </li>
 <li>
@@ -1857,7 +1857,7 @@
 <div><code>(comp f g h)</code></div>
 <div><code>(comp f1 f2 f3 & fs)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of functions and returns a fn that is the composition<br>  of those fns.  The returned fn takes a variable number of args,<br>  applies the rightmost of fns to the args, the next<br>  fn (right-to-left) to the result, etc.</p>
+  <p class="var-docstr">Takes a set of functions and returns a fn that is the composition<br>  of those fns.  The returned fn takes a variable number of args,<br>  applies the rightmost of fns to the args, the next<br>  fn (right-to-left) to the result, etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1512">source</a>
 </li>
 <li>
@@ -1866,7 +1866,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(compare x y)</code></div>
 </pre>
-  <p class="var-docstr">Comparator. Returns a negative number, zero, or a positive number<br>  when x is logically 'less than', 'equal to', or 'greater than'<br>  y. Works for nil, and compares numbers and collections in a type-independent manner. x<br>  must implement Comparable</p>
+  <p class="var-docstr">Comparator. Returns a negative number, zero, or a positive number<br>  when x is logically 'less than', 'equal to', or 'greater than'<br>  y. Works for nil, and compares numbers and collections in a type-independent manner. x<br>  must implement Comparable</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L620">source</a>
 </li>
 <li>
@@ -1875,7 +1875,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(complement f)</code></div>
 </pre>
-  <p class="var-docstr">Takes a fn f and returns a fn that takes the same arguments as f,<br>  has the same effects, if any, and returns the opposite truth value.</p>
+  <p class="var-docstr">Takes a fn f and returns a fn that takes the same arguments as f,<br>  has the same effects, if any, and returns the opposite truth value.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1026">source</a>
 </li>
 <li>
@@ -1896,7 +1896,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(cond & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of test/expr pairs. It evaluates each test one at a<br>  time.  If a test returns logical true, cond evaluates and returns<br>  the value of the corresponding expr and doesn't evaluate any of the<br>  other tests or exprs. (cond) returns nil.</p>
+  <p class="var-docstr">Takes a set of test/expr pairs. It evaluates each test one at a<br>  time.  If a test returns logical true, cond evaluates and returns<br>  the value of the corresponding expr and doesn't evaluate any of the<br>  other tests or exprs. (cond) returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L456">source</a>
 </li>
 <li>
@@ -1905,7 +1905,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(cond-> expr & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes an expression and a set of test/form pairs. Threads expr (via ->)<br>  through each form for which the corresponding test<br>  expression is true. Note that, unlike cond branching, cond-> threading does<br>  not short circuit after the first true test expression.</p>
+  <p class="var-docstr">Takes an expression and a set of test/form pairs. Threads expr (via ->)<br>  through each form for which the corresponding test<br>  expression is true. Note that, unlike cond branching, cond-> threading does<br>  not short circuit after the first true test expression.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4080">source</a>
 </li>
 <li>
@@ -1914,7 +1914,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(cond->> expr & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes an expression and a set of test/form pairs. Threads expr (via ->>)<br>  through each form for which the corresponding test expression<br>  is true.  Note that, unlike cond branching, cond->> threading does not short circuit<br>  after the first true test expression.</p>
+  <p class="var-docstr">Takes an expression and a set of test/form pairs. Threads expr (via ->>)<br>  through each form for which the corresponding test expression<br>  is true.  Note that, unlike cond branching, cond->> threading does not short circuit<br>  after the first true test expression.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4102">source</a>
 </li>
 <li>
@@ -1923,7 +1923,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(condp pred expr & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes a binary predicate, an expression, and a set of clauses.<br>  Each clause can take the form of either:<br><br>  test-expr result-expr<br><br>  test-expr :>> result-fn<br><br>  Note :>> is an ordinary keyword.<br><br>  For each clause, (pred test-expr expr) is evaluated. If it returns<br>  logical true, the clause is a match. If a binary clause matches, the<br>  result-expr is returned, if a ternary clause matches, its result-fn,<br>  which must be a unary function, is called with the result of the<br>  predicate as its argument, the result of that call being the return<br>  value of condp. A single default expression can follow the clauses,<br>  and its value will be returned if no clause matches. If no default<br>  expression is provided and no clause matches, an<br>  exception is thrown.</p>
+  <p class="var-docstr">Takes a binary predicate, an expression, and a set of clauses.<br>  Each clause can take the form of either:<br><br>  test-expr result-expr<br><br>  test-expr :>> result-fn<br><br>  Note :>> is an ordinary keyword.<br><br>  For each clause, (pred test-expr expr) is evaluated. If it returns<br>  logical true, the clause is a match. If a binary clause matches, the<br>  result-expr is returned, if a ternary clause matches, its result-fn,<br>  which must be a unary function, is called with the result of the<br>  predicate as its argument, the result of that call being the return<br>  value of condp. A single default expression can follow the clauses,<br>  and its value will be returned if no clause matches. If no default<br>  expression is provided and no clause matches, an<br>  exception is thrown.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3651">source</a>
 </li>
 <li>
@@ -1933,7 +1933,7 @@
   <pre class="var-usage"><div><code>(conj coll x)</code></div>
 <div><code>(conj coll x & xs)</code></div>
 </pre>
-  <p class="var-docstr">conj[oin]. Returns a new collection with the xs<br>         'added'. (conj nil item) returns (item).  The 'addition' may<br>         happen at different 'places' depending on the concrete type.</p>
+  <p class="var-docstr">conj[oin]. Returns a new collection with the xs<br>         'added'. (conj nil item) returns (item).  The 'addition' may<br>         happen at different 'places' depending on the concrete type.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L70">source</a>
 </li>
 <li>
@@ -1942,7 +1942,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(cons x seq)</code></div>
 </pre>
-  <p class="var-docstr">Returns a new seq where x is the first element and seq is<br>         the rest.</p>
+  <p class="var-docstr">Returns a new seq where x is the first element and seq is<br>         the rest.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L20">source</a>
 </li>
 <li>
@@ -1960,7 +1960,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(contains? coll key)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if key is present in the given collection, otherwise<br>  returns false.  Note that for numerically indexed collections like<br>  vectors, this tests if the numeric key is within the<br>  range of indexes. 'contains?' operates constant or logarithmic time;<br>  it will not perform a linear search for a value.  See also 'some'.</p>
+  <p class="var-docstr">Returns true if key is present in the given collection, otherwise<br>  returns false.  Note that for numerically indexed collections like<br>  vectors, this tests if the numeric key is within the<br>  range of indexes. 'contains?' operates constant or logarithmic time;<br>  it will not perform a linear search for a value.  See also 'some'.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1062">source</a>
 </li>
 <li>
@@ -1969,7 +1969,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(count coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns the number of items in the collection. (count nil) returns<br>  0.  Also works on strings</p>
+  <p class="var-docstr">Returns the number of items in the collection. (count nil) returns<br>  0.  Also works on strings</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L657">source</a>
 </li>
 <li>
@@ -1987,7 +1987,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(create-ns sym)</code></div>
 </pre>
-  <p class="var-docstr">Create a new namespace named by the symbol if one doesn't already<br>  exist, returns it or the already-existing namespace of the same<br>  name.</p>
+  <p class="var-docstr">Create a new namespace named by the symbol if one doesn't already<br>  exist, returns it or the already-existing namespace of the same<br>  name.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2255">source</a>
 </li>
 <li>
@@ -2005,7 +2005,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(dec x)</code></div>
 </pre>
-  <p class="var-docstr">Returns a number one less than num. Does not auto-promote<br>  ints, will overflow. See also: dec'</p>
+  <p class="var-docstr">Returns a number one less than num. Does not auto-promote<br>  ints, will overflow. See also: dec'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L875">source</a>
 </li>
 <li>
@@ -2014,7 +2014,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(dec' x)</code></div>
 </pre>
-  <p class="var-docstr">Returns a number one less than num. Supports arbitrary precision.<br>  See also: dec</p>
+  <p class="var-docstr">Returns a number one less than num. Supports arbitrary precision.<br>  See also: dec</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L869">source</a>
 </li>
 <li>
@@ -2040,7 +2040,7 @@
   <span class="var-type ArrayMap">ArrayMap</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">Default map of data reader functions provided by Joker. May be<br>  overridden by binding *data-readers*.</p>
+  <p class="var-docstr">Default map of data reader functions provided by Joker. May be<br>  overridden by binding *data-readers*.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4194">source</a>
 </li>
 <li>
@@ -2050,7 +2050,7 @@
   <pre class="var-usage"><div><code>(defmacro name doc-string? attr-map? [params*] body)</code></div>
 <div><code>(defmacro name doc-string? attr-map? ([params*] body) + attr-map?)</code></div>
 </pre>
-  <p class="var-docstr">Like defn, but the resulting function name is declared as a<br>         macro and will be used as a macro by the compiler when it is<br>         called.</p>
+  <p class="var-docstr">Like defn, but the resulting function name is declared as a<br>         macro and will be used as a macro by the compiler when it is<br>         called.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L323">source</a>
 </li>
 <li>
@@ -2068,7 +2068,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(defmulti name docstring? attr-map? dispatch-fn & options)</code></div>
 </pre>
-  <p class="var-docstr">Creates a new multimethod with the associated dispatch function.<br>  The docstring and attr-map are optional.<br><br>  Options are key-value pairs and may be one of:<br><br>  :default<br><br>  The default dispatch value, defaults to :default<br><br>  :hierarchy (UNSUPPORTED)<br><br>  The value used for hierarchical dispatch (e.g. ::square is-a ::shape)<br><br>  Hierarchies are type-like relationships that do not depend upon type<br>  inheritance. By default Clojure's multimethods dispatch off of a<br>  global hierarchy map.  However, a hierarchy relationship can be<br>  created with the derive function used to augment the root ancestor<br>  created with make-hierarchy.<br><br>  Multimethods expect the value of the hierarchy option to be supplied as<br>  a reference type e.g. a var (i.e. via the Var-quote dispatch macro #'<br>  or the var special form).</p>
+  <p class="var-docstr">Creates a new multimethod with the associated dispatch function.<br>  The docstring and attr-map are optional.<br><br>  Options are key-value pairs and may be one of:<br><br>  :default<br><br>  The default dispatch value, defaults to :default<br><br>  :hierarchy (UNSUPPORTED)<br><br>  The value used for hierarchical dispatch (e.g. ::square is-a ::shape)<br><br>  Hierarchies are type-like relationships that do not depend upon type<br>  inheritance. By default Clojure's multimethods dispatch off of a<br>  global hierarchy map.  However, a hierarchy relationship can be<br>  created with the derive function used to augment the root ancestor<br>  created with make-hierarchy.<br><br>  Multimethods expect the value of the hierarchy option to be supplied as<br>  a reference type e.g. a var (i.e. via the Var-quote dispatch macro #'<br>  or the var special form).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4237">source</a>
 </li>
 <li>
@@ -2078,7 +2078,7 @@
   <pre class="var-usage"><div><code>(defn name doc-string? attr-map? [params*] prepost-map? body)</code></div>
 <div><code>(defn name doc-string? attr-map? ([params*] prepost-map? body) + attr-map?)</code></div>
 </pre>
-  <p class="var-docstr">Same as (def name (fn [params* ] exprs*)) or (def<br>         name (fn ([params* ] exprs*)+)) with any doc-string or attrs added<br>         to the var metadata. prepost-map defines a map with optional keys<br>         :pre and :post that contain collections of pre or post conditions.</p>
+  <p class="var-docstr">Same as (def name (fn [params* ] exprs*)) or (def<br>         name (fn ([params* ] exprs*)+)) with any doc-string or attrs added<br>         to the var metadata. prepost-map defines a map with optional keys<br>         :pre and :post that contain collections of pre or post conditions.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L242">source</a>
 </li>
 <li>
@@ -2096,7 +2096,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(defonce name expr)</code></div>
 </pre>
-  <p class="var-docstr">defs name to have the value of the expr if the named var is not bound,<br>  else expr is unevaluated</p>
+  <p class="var-docstr">defs name to have the value of the expr if the named var is not bound,<br>  else expr is unevaluated</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3178">source</a>
 </li>
 <li>
@@ -2105,7 +2105,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(delay & body)</code></div>
 </pre>
-  <p class="var-docstr">Takes a body of expressions and yields a Delay object that will<br>  invoke the body only the first time it is forced (with force or deref/@), and<br>  will cache the result and return it on all subsequent force<br>  calls. See also - realized?</p>
+  <p class="var-docstr">Takes a body of expressions and yields a Delay object that will<br>  invoke the body only the first time it is forced (with force or deref/@), and<br>  will cache the result and return it on all subsequent force<br>  calls. See also - realized?</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L561">source</a>
 </li>
 <li>
@@ -2132,7 +2132,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(deref ref)</code></div>
 </pre>
-  <p class="var-docstr">Also reader macro: @var/@atom/@delay. When applied to a var or atom,<br>  returns its current state. When applied to a delay, forces<br>  it if not already forced.</p>
+  <p class="var-docstr">Also reader macro: @var/@atom/@delay. When applied to a var or atom,<br>  returns its current state. When applied to a delay, forces<br>  it if not already forced.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1440">source</a>
 </li>
 <li>
@@ -2143,7 +2143,7 @@
 <div><code>(disj set key)</code></div>
 <div><code>(disj set key & ks)</code></div>
 </pre>
-  <p class="var-docstr">disj[oin]. Returns a new set of the same (hashed/sorted) type, that<br>  does not contain key(s).</p>
+  <p class="var-docstr">disj[oin]. Returns a new set of the same (hashed/sorted) type, that<br>  does not contain key(s).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1092">source</a>
 </li>
 <li>
@@ -2154,7 +2154,7 @@
 <div><code>(dissoc map key)</code></div>
 <div><code>(dissoc map key & ks)</code></div>
 </pre>
-  <p class="var-docstr">dissoc[iate]. Returns a new map of the same (hashed/sorted) type,<br>  that does not contain a mapping for key(s).</p>
+  <p class="var-docstr">dissoc[iate]. Returns a new map of the same (hashed/sorted) type,<br>  that does not contain a mapping for key(s).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1079">source</a>
 </li>
 <li>
@@ -2184,7 +2184,7 @@
   <pre class="var-usage"><div><code>(doall coll)</code></div>
 <div><code>(doall n coll)</code></div>
 </pre>
-  <p class="var-docstr">When lazy sequences are produced via functions that have side<br>  effects, any effects other than those needed to produce the first<br>  element in the seq do not occur until the seq is consumed. doall can<br>  be used to force any effects. Walks through the successive nexts of<br>  the seq, retains the head and returns it, thus causing the entire<br>  seq to reside in memory at one time.</p>
+  <p class="var-docstr">When lazy sequences are produced via functions that have side<br>  effects, any effects other than those needed to produce the first<br>  element in the seq do not occur until the seq is consumed. doall can<br>  be used to force any effects. Walks through the successive nexts of<br>  the seq, retains the head and returns it, thus causing the entire<br>  seq to reside in memory at one time.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1885">source</a>
 </li>
 <li>
@@ -2194,7 +2194,7 @@
   <pre class="var-usage"><div><code>(dorun coll)</code></div>
 <div><code>(dorun n coll)</code></div>
 </pre>
-  <p class="var-docstr">When lazy sequences are produced via functions that have side<br>  effects, any effects other than those needed to produce the first<br>  element in the seq do not occur until the seq is consumed. dorun can<br>  be used to force any effects. Walks through the successive nexts of<br>  the seq, does not retain the head and returns nil.</p>
+  <p class="var-docstr">When lazy sequences are produced via functions that have side<br>  effects, any effects other than those needed to produce the first<br>  element in the seq do not occur until the seq is consumed. dorun can<br>  be used to force any effects. Walks through the successive nexts of<br>  the seq, does not retain the head and returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1871">source</a>
 </li>
 <li>
@@ -2203,7 +2203,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(doseq seq-exprs & body)</code></div>
 </pre>
-  <p class="var-docstr">Repeatedly executes body (presumably for side-effects) with<br>  bindings and filtering as provided by "for".  Does not retain<br>  the head of the sequence. Returns nil.</p>
+  <p class="var-docstr">Repeatedly executes body (presumably for side-effects) with<br>  bindings and filtering as provided by "for".  Does not retain<br>  the head of the sequence. Returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1946">source</a>
 </li>
 <li>
@@ -2212,7 +2212,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(dotimes bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">bindings => name n<br><br>  Repeatedly executes body (presumably for side-effects) with name<br>  bound to integers from 0 through n-1.</p>
+  <p class="var-docstr">bindings => name n<br><br>  Repeatedly executes body (presumably for side-effects) with name<br>  bound to integers from 0 through n-1.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1982">source</a>
 </li>
 <li>
@@ -2221,7 +2221,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(doto x & forms)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates x then calls all of the methods and functions with the<br>  value of x supplied at the front of the given arguments.  The forms<br>  are evaluated in order.  Returns x.</p>
+  <p class="var-docstr">Evaluates x then calls all of the methods and functions with the<br>  value of x supplied at the front of the given arguments.  The forms<br>  are evaluated in order.  Returns x.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2180">source</a>
 </li>
 <li>
@@ -2267,7 +2267,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(drop-while pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the items in coll starting from the first<br>  item for which (pred item) returns logical false.</p>
+  <p class="var-docstr">Returns a lazy sequence of the items in coll starting from the first<br>  item for which (pred item) returns logical false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1745">source</a>
 </li>
 <li>
@@ -2285,7 +2285,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(empty? coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if coll has no items - same as (not (seq coll)).<br>  Please use the idiom (seq x) rather than (not (empty? x))</p>
+  <p class="var-docstr">Returns true if coll has no items - same as (not (seq coll)).<br>  Please use the idiom (seq x) rather than (not (empty? x))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3692">source</a>
 </li>
 <li>
@@ -2315,7 +2315,7 @@
 <div><code>(every-pred p1 p2 p3)</code></div>
 <div><code>(every-pred p1 p2 p3 & ps)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of predicates and returns a function f that returns true if all of its<br>  composing predicates return a logical true value against all of its arguments, else it returns<br>  false. Note that f is short-circuiting in that it will stop execution on the first<br>  argument that triggers a logical false result against the original predicates.</p>
+  <p class="var-docstr">Takes a set of predicates and returns a function f that returns true if all of its<br>  composing predicates return a logical true value against all of its arguments, else it returns<br>  false. Note that f is short-circuiting in that it will stop execution on the first<br>  argument that triggers a logical false result against the original predicates.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3972">source</a>
 </li>
 <li>
@@ -2324,7 +2324,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(every? pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if (pred x) is logical true for every x in coll, else<br>  false.</p>
+  <p class="var-docstr">Returns true if (pred x) is logical true for every x in coll, else<br>  false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1604">source</a>
 </li>
 <li>
@@ -2333,7 +2333,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(ex-cause ex)</code></div>
 </pre>
-  <p class="var-docstr">Returns the cause of ex if ex is an ExInfo.<br>  Otherwise returns nil.</p>
+  <p class="var-docstr">Returns the cause of ex if ex is an ExInfo.<br>  Otherwise returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2876">source</a>
 </li>
 <li>
@@ -2342,7 +2342,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(ex-data ex)</code></div>
 </pre>
-  <p class="var-docstr">Returns exception data (a map) if ex is an ExInfo.<br>  Otherwise returns nil.</p>
+  <p class="var-docstr">Returns exception data (a map) if ex is an ExInfo.<br>  Otherwise returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2868">source</a>
 </li>
 <li>
@@ -2361,7 +2361,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(ex-message ex)</code></div>
 </pre>
-  <p class="var-docstr">Returns the message attached to ex if ex is an ExInfo.<br>  Otherwise returns nil.</p>
+  <p class="var-docstr">Returns the message attached to ex if ex is an ExInfo.<br>  Otherwise returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2884">source</a>
 </li>
 <li>
@@ -2388,7 +2388,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(filter pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the items in coll for which<br>  (pred item) returns true. pred must be free of side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of the items in coll for which<br>  (pred item) returns true. pred must be free of side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1679">source</a>
 </li>
 <li>
@@ -2397,7 +2397,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(filterv pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a vector of the items in coll for which<br>  (pred item) returns true. pred must be free of side-effects.</p>
+  <p class="var-docstr">Returns a vector of the items in coll for which<br>  (pred item) returns true. pred must be free of side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3826">source</a>
 </li>
 <li>
@@ -2424,7 +2424,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(find-var sym)</code></div>
 </pre>
-  <p class="var-docstr">Returns the global var named by the namespace-qualified symbol, or<br>  nil if no var with that name.</p>
+  <p class="var-docstr">Returns the global var named by the namespace-qualified symbol, or<br>  nil if no var with that name.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1506">source</a>
 </li>
 <li>
@@ -2433,7 +2433,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(first coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns the first item in the collection. Calls seq on its<br>         argument. If coll is nil, returns nil.</p>
+  <p class="var-docstr">Returns the first item in the collection. Calls seq on its<br>         argument. If coll is nil, returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L49">source</a>
 </li>
 <li>
@@ -2442,7 +2442,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(flatten x)</code></div>
 </pre>
-  <p class="var-docstr">Takes any nested combination of sequential things (lists, vectors,<br>  etc.) and returns their contents as a single, flat sequence.<br>  (flatten nil) returns an empty sequence.</p>
+  <p class="var-docstr">Takes any nested combination of sequential things (lists, vectors,<br>  etc.) and returns their contents as a single, flat sequence.<br>  (flatten nil) returns an empty sequence.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3848">source</a>
 </li>
 <li>
@@ -2460,7 +2460,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(flush)</code></div>
 </pre>
-  <p class="var-docstr">Flushes the output stream that is the current value of<br>  *out*</p>
+  <p class="var-docstr">Flushes the output stream that is the current value of<br>  *out*</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2110">source</a>
 </li>
 <li>
@@ -2470,7 +2470,7 @@
   <pre class="var-usage"><div><code>(fn name? [params*] exprs*)</code></div>
 <div><code>(fn name? ([params*] exprs*) +)</code></div>
 </pre>
-  <p class="var-docstr">params => positional-params* , or positional-params* & next-param<br>  positional-param => binding-form<br>  next-param => binding-form<br>  name => symbol<br><br>  Defines a function</p>
+  <p class="var-docstr">params => positional-params* , or positional-params* & next-param<br>  positional-param => binding-form<br>  next-param => binding-form<br>  name => symbol<br><br>  Defines a function</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2615">source</a>
 </li>
 <li>
@@ -2499,7 +2499,7 @@
 <div><code>(fnil f x y)</code></div>
 <div><code>(fnil f x y z)</code></div>
 </pre>
-  <p class="var-docstr">Takes a function f, and returns a function that calls f, replacing<br>  a nil first argument to f with the supplied value x. Higher arity<br>  versions can replace arguments in the second and third<br>  positions (y, z). Note that the function f can take any number of<br>  arguments, not just the one(s) being nil-patched.</p>
+  <p class="var-docstr">Takes a function f, and returns a function that calls f, replacing<br>  a nil first argument to f with the supplied value x. Higher arity<br>  versions can replace arguments in the second and third<br>  positions (y, z). Note that the function f can take any number of<br>  arguments, not just the one(s) being nil-patched.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3741">source</a>
 </li>
 <li>
@@ -2508,7 +2508,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(for seq-exprs body-expr)</code></div>
 </pre>
-  <p class="var-docstr">List comprehension. Takes a vector of one or more<br>  binding-form/collection-expr pairs, each followed by zero or more<br>  modifiers, and yields a lazy sequence of evaluations of expr.<br>  Collections are iterated in a nested fashion, rightmost fastest,<br>  and nested coll-exprs can refer to bindings created in prior<br>  binding-forms.  Supported modifiers are: :let [binding-form expr ...],<br>  :while test, :when test.<br><br>  (take 100 (for [x (range 100000000) y (range 1000000) :while (< y x)]  [x y]))</p>
+  <p class="var-docstr">List comprehension. Takes a vector of one or more<br>  binding-form/collection-expr pairs, each followed by zero or more<br>  modifiers, and yields a lazy sequence of evaluations of expr.<br>  Collections are iterated in a nested fashion, rightmost fastest,<br>  and nested coll-exprs can refer to bindings created in prior<br>  binding-forms.  Supported modifiers are: :let [binding-form expr ...],<br>  :while test, :when test.<br><br>  (take 100 (for [x (range 100000000) y (range 1000000) :while (< y x)]  [x y]))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2731">source</a>
 </li>
 <li>
@@ -2535,7 +2535,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(frequencies coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a map from distinct items in coll to the number of times<br>  they appear.</p>
+  <p class="var-docstr">Returns a map from distinct items in coll to the number of times<br>  they appear.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3881">source</a>
 </li>
 <li>
@@ -2545,7 +2545,7 @@
   <pre class="var-usage"><div><code>(gensym)</code></div>
 <div><code>(gensym prefix-string)</code></div>
 </pre>
-  <p class="var-docstr">Returns a new symbol with a unique name. If a prefix string is<br>  supplied, the name is prefix# where # is some unique number. If<br>  prefix is not supplied, the prefix is 'G__'.</p>
+  <p class="var-docstr">Returns a new symbol with a unique name. If a prefix string is<br>  supplied, the name is prefix# where # is some unique number. If<br>  prefix is not supplied, the prefix is 'G__'.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L445">source</a>
 </li>
 <li>
@@ -2565,7 +2565,7 @@
   <pre class="var-usage"><div><code>(get-in m ks)</code></div>
 <div><code>(get-in m ks not-found)</code></div>
 </pre>
-  <p class="var-docstr">Returns the value in a nested associative structure,<br>  where ks is a sequence of keys. Returns nil if the key<br>  is not present, or the not-found value if supplied.</p>
+  <p class="var-docstr">Returns the value in a nested associative structure,<br>  where ks is a sequence of keys. Returns nil if the key<br>  is not present, or the not-found value if supplied.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3477">source</a>
 </li>
 <li>
@@ -2574,7 +2574,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(get-method multifn dispatch-val)</code></div>
 </pre>
-  <p class="var-docstr">Given a multimethod and a dispatch value, returns the dispatch fn<br>  that would apply to that value, or nil if none apply and no default</p>
+  <p class="var-docstr">Given a multimethod and a dispatch value, returns the dispatch fn<br>  that would apply to that value, or nil if none apply and no default</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4335">source</a>
 </li>
 <li>
@@ -2583,7 +2583,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(group-by f coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a map of the elements of coll keyed by the result of<br>  f on each element. The value at each key will be a vector of the<br>  corresponding elements, in the order they appeared in coll.</p>
+  <p class="var-docstr">Returns a map of the elements of coll keyed by the result of<br>  f on each element. The value at each key will be a vector of the<br>  corresponding elements, in the order they appeared in coll.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3857">source</a>
 </li>
 <li>
@@ -2601,7 +2601,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(hash-map & keyvals)</code></div>
 </pre>
-  <p class="var-docstr">keyval => key val<br>         Returns a new hash map with supplied mappings.  If any keys are<br>         equal, they are handled as if by repeated uses of assoc.</p>
+  <p class="var-docstr">keyval => key val<br>         Returns a new hash map with supplied mappings.  If any keys are<br>         equal, they are handled as if by repeated uses of assoc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L302">source</a>
 </li>
 <li>
@@ -2610,7 +2610,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(hash-set & keys)</code></div>
 </pre>
-  <p class="var-docstr">Returns a new hash set with supplied keys.  Any equal keys are<br>         handled as if by repeated uses of conj.</p>
+  <p class="var-docstr">Returns a new hash set with supplied keys.  Any equal keys are<br>         handled as if by repeated uses of conj.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L310">source</a>
 </li>
 <li>
@@ -2647,7 +2647,7 @@
   <pre class="var-usage"><div><code>(if-let bindings then)</code></div>
 <div><code>(if-let bindings then else & oldform)</code></div>
 </pre>
-  <p class="var-docstr">bindings => binding-form test<br><br>  If test is true, evaluates then with binding-form bound to the value of<br>  test, if not, yields else</p>
+  <p class="var-docstr">bindings => binding-form test<br><br>  If test is true, evaluates then with binding-form bound to the value of<br>  test, if not, yields else</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1257">source</a>
 </li>
 <li>
@@ -2657,7 +2657,7 @@
   <pre class="var-usage"><div><code>(if-not test then)</code></div>
 <div><code>(if-not test then else)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates test. If logical false, evaluates and returns then expr,<br>  otherwise else expr, if supplied, else nil.</p>
+  <p class="var-docstr">Evaluates test. If logical false, evaluates and returns then expr,<br>  otherwise else expr, if supplied, else nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L582">source</a>
 </li>
 <li>
@@ -2667,7 +2667,7 @@
   <pre class="var-usage"><div><code>(if-some bindings then)</code></div>
 <div><code>(if-some bindings then else & oldform)</code></div>
 </pre>
-  <p class="var-docstr">bindings => binding-form test<br><br>  If test is not nil, evaluates then with binding-form bound to the<br>  value of test, if not, yields else</p>
+  <p class="var-docstr">bindings => binding-form test<br><br>  If test is not nil, evaluates then with binding-form bound to the<br>  value of test, if not, yields else</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1299">source</a>
 </li>
 <li>
@@ -2685,7 +2685,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(inc x)</code></div>
 </pre>
-  <p class="var-docstr">Returns a number one greater than num. Does not auto-promote<br>  ints, will overflow. See also: inc'</p>
+  <p class="var-docstr">Returns a number one greater than num. Does not auto-promote<br>  ints, will overflow. See also: inc'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L698">source</a>
 </li>
 <li>
@@ -2694,7 +2694,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(inc' x)</code></div>
 </pre>
-  <p class="var-docstr">Returns a number one greater than num. Supports arbitrary precision.<br>  See also: inc</p>
+  <p class="var-docstr">Returns a number one greater than num. Supports arbitrary precision.<br>  See also: inc</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L692">source</a>
 </li>
 <li>
@@ -2712,7 +2712,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(instance? c x)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates x and tests if it is an instance of type<br>         c. Returns true or false</p>
+  <p class="var-docstr">Evaluates x and tests if it is an instance of type<br>         c. Returns true or false</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L121">source</a>
 </li>
 <li>
@@ -2761,7 +2761,7 @@
   <pre class="var-usage"><div><code>(intern ns name)</code></div>
 <div><code>(intern ns name val)</code></div>
 </pre>
-  <p class="var-docstr">Finds or creates a var named by the symbol name in the namespace<br>  ns (which can be a symbol or a namespace), setting its root binding<br>  to val if supplied. The namespace must exist. The var will adopt any<br>  metadata from the name symbol.  Returns the var.</p>
+  <p class="var-docstr">Finds or creates a var named by the symbol name in the namespace<br>  ns (which can be a symbol or a namespace), setting its root binding<br>  to val if supplied. The namespace must exist. The var will adopt any<br>  metadata from the name symbol.  Returns the var.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2340">source</a>
 </li>
 <li>
@@ -2770,7 +2770,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(interpose sep coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy seq of the elements of coll separated by sep.<br>  Returns a stateful transducer when no collection is provided.</p>
+  <p class="var-docstr">Returns a lazy seq of the elements of coll separated by sep.<br>  Returns a stateful transducer when no collection is provided.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3076">source</a>
 </li>
 <li>
@@ -2779,7 +2779,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(into to from)</code></div>
 </pre>
-  <p class="var-docstr">Returns a new coll consisting of to-coll with all of the items of<br>  from-coll conjoined.</p>
+  <p class="var-docstr">Returns a new coll consisting of to-coll with all of the items of<br>  from-coll conjoined.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3803">source</a>
 </li>
 <li>
@@ -2809,7 +2809,7 @@
 <div><code>(juxt f g h)</code></div>
 <div><code>(juxt f g h & fs)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of functions and returns a fn that is the juxtaposition<br>  of those fns.  The returned fn takes a variable number of args, and<br>  returns a vector containing the result of applying each fn to the<br>  args (left-to-right).<br>  ((juxt a b c) x) => [(a x) (b x) (c x)]</p>
+  <p class="var-docstr">Takes a set of functions and returns a fn that is the juxtaposition<br>  of those fns.  The returned fn takes a variable number of args, and<br>  returns a vector containing the result of applying each fn to the<br>  args (left-to-right).<br>  ((juxt a b c) x) => [(a x) (b x) (c x)]</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1542">source</a>
 </li>
 <li>
@@ -2818,7 +2818,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(keep f coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the non-nil results of (f item). Note,<br>  this means false return values will be included.  f must be free of<br>  side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of the non-nil results of (f item). Note,<br>  this means false return values will be included.  f must be free of<br>  side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3932">source</a>
 </li>
 <li>
@@ -2827,7 +2827,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(keep-indexed f coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the non-nil results of (f index item). Note,<br>  this means false return values will be included.  f must be free of<br>  side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of the non-nil results of (f index item). Note,<br>  this means false return values will be included.  f must be free of<br>  side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3945">source</a>
 </li>
 <li>
@@ -2855,7 +2855,7 @@
   <pre class="var-usage"><div><code>(keyword name)</code></div>
 <div><code>(keyword ns name)</code></div>
 </pre>
-  <p class="var-docstr">Returns a Keyword with the given namespace and name.  Do not use :<br>  in the keyword strings, it will be added automatically.</p>
+  <p class="var-docstr">Returns a Keyword with the given namespace and name.  Do not use :<br>  in the keyword strings, it will be added automatically.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L473">source</a>
 </li>
 <li>
@@ -2882,7 +2882,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(lazy-cat & colls)</code></div>
 </pre>
-  <p class="var-docstr">Expands to code which yields a lazy sequence of the concatenation<br>  of the supplied colls.  Each coll expr is not evaluated until it is<br>  needed.<br><br>  (lazy-cat xs ys zs) === (concat (lazy-seq xs) (lazy-seq ys) (lazy-seq zs))</p>
+  <p class="var-docstr">Expands to code which yields a lazy sequence of the concatenation<br>  of the supplied colls.  Each coll expr is not evaluated until it is<br>  needed.<br><br>  (lazy-cat xs ys zs) === (concat (lazy-seq xs) (lazy-seq ys) (lazy-seq zs))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2721">source</a>
 </li>
 <li>
@@ -2891,7 +2891,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(lazy-seq & body)</code></div>
 </pre>
-  <p class="var-docstr">Takes a body of expressions that returns an ISeq or nil, and yields<br>  a Seqable object that will invoke the body only the first time seq<br>  is called, and will cache the result and return it on all subsequent<br>  seq calls. See also - realized?</p>
+  <p class="var-docstr">Takes a body of expressions that returns an ISeq or nil, and yields<br>  a Seqable object that will invoke the body only the first time seq<br>  is called, and will cache the result and return it on all subsequent<br>  seq calls. See also - realized?</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L524">source</a>
 </li>
 <li>
@@ -2900,7 +2900,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(let [bindings*] exprs*)</code></div>
 </pre>
-  <p class="var-docstr">binding => binding-form init-expr<br><br>  Evaluates the exprs in a lexical context in which the symbols in<br>  the binding-forms are bound to their respective init-exprs or parts<br>  therein.</p>
+  <p class="var-docstr">binding => binding-form init-expr<br><br>  Evaluates the exprs in a lexical context in which the symbols in<br>  the binding-forms are bound to their respective init-exprs or parts<br>  therein.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2583">source</a>
 </li>
 <li>
@@ -2922,7 +2922,7 @@
 <div><code>(list* a b c args)</code></div>
 <div><code>(list* a b c d & more)</code></div>
 </pre>
-  <p class="var-docstr">Creates a new list containing the items prepended to the rest, the<br>  last of which will be treated as a sequence.</p>
+  <p class="var-docstr">Creates a new list containing the items prepended to the rest, the<br>  last of which will be treated as a sequence.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L492">source</a>
 </li>
 <li>
@@ -2958,7 +2958,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(load-string s)</code></div>
 </pre>
-  <p class="var-docstr">Sequentially read and evaluate the set of forms contained in the<br>  string</p>
+  <p class="var-docstr">Sequentially read and evaluate the set of forms contained in the<br>  string</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2221">source</a>
 </li>
 <li>
@@ -2976,7 +2976,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(loop [bindings*] exprs*)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates the exprs in a lexical context in which the symbols in<br>  the binding-forms are bound to their respective init-exprs or parts<br>  therein. Acts as a recur target.</p>
+  <p class="var-docstr">Evaluates the exprs in a lexical context in which the symbols in<br>  the binding-forms are bound to their respective init-exprs or parts<br>  therein. Acts as a recur target.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2680">source</a>
 </li>
 <li>
@@ -2985,7 +2985,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(macroexpand form)</code></div>
 </pre>
-  <p class="var-docstr">Repeatedly calls macroexpand-1 on form until it no longer<br>  represents a macro form, then returns it.  Note neither<br>  macroexpand-1 nor macroexpand expand macros in subforms.</p>
+  <p class="var-docstr">Repeatedly calls macroexpand-1 on form until it no longer<br>  represents a macro form, then returns it.  Note neither<br>  macroexpand-1 nor macroexpand expand macros in subforms.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2210">source</a>
 </li>
 <li>
@@ -3006,7 +3006,7 @@
 <div><code>(map f c1 c2 c3)</code></div>
 <div><code>(map f c1 c2 c3 & colls)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence consisting of the result of applying f to the<br>  set of first items of each coll, followed by applying f to the set<br>  of second items in each coll, until any one of the colls is<br>  exhausted.  Any remaining items in other colls are ignored. Function<br>  f should accept number-of-colls arguments.</p>
+  <p class="var-docstr">Returns a lazy sequence consisting of the result of applying f to the<br>  set of first items of each coll, followed by applying f to the set<br>  of second items in each coll, until any one of the colls is<br>  exhausted.  Any remaining items in other colls are ignored. Function<br>  f should accept number-of-colls arguments.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1641">source</a>
 </li>
 <li>
@@ -3015,7 +3015,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(map-indexed f coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence consisting of the result of applying f to 0<br>  and the first item of coll, followed by applying f to 1 and the second<br>  item in coll, etc, until coll is exhausted. Thus function f should<br>  accept 2 arguments, index and item.</p>
+  <p class="var-docstr">Returns a lazy sequence consisting of the result of applying f to 0<br>  and the first item of coll, followed by applying f to 1 and the second<br>  item in coll, etc, until coll is exhausted. Thus function f should<br>  accept 2 arguments, index and item.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3919">source</a>
 </li>
 <li>
@@ -3033,7 +3033,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(mapcat f & colls)</code></div>
 </pre>
-  <p class="var-docstr">Returns the result of applying concat to the result of applying map<br>  to f and colls.  Thus function f should return a collection.</p>
+  <p class="var-docstr">Returns the result of applying concat to the result of applying map<br>  to f and colls.  Thus function f should return a collection.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1672">source</a>
 </li>
 <li>
@@ -3045,7 +3045,7 @@
 <div><code>(mapv f c1 c2 c3)</code></div>
 <div><code>(mapv f c1 c2 c3 & colls)</code></div>
 </pre>
-  <p class="var-docstr">Returns a vector consisting of the result of applying f to the<br>  set of first items of each coll, followed by applying f to the set<br>  of second items in each coll, until any one of the colls is<br>  exhausted.  Any remaining items in other colls are ignored. Function<br>  f should accept number-of-colls arguments.</p>
+  <p class="var-docstr">Returns a vector consisting of the result of applying f to the<br>  set of first items of each coll, followed by applying f to the set<br>  of second items in each coll, until any one of the colls is<br>  exhausted.  Any remaining items in other colls are ignored. Function<br>  f should accept number-of-colls arguments.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3810">source</a>
 </li>
 <li>
@@ -3076,7 +3076,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(memoize f)</code></div>
 </pre>
-  <p class="var-docstr">Returns a memoized version of a referentially transparent function. The<br>  memoized version of the function keeps a cache of the mapping from arguments<br>  to results and, when calls with the same arguments are repeated often, has<br>  higher performance at the expense of higher memory use.</p>
+  <p class="var-docstr">Returns a memoized version of a referentially transparent function. The<br>  memoized version of the function keeps a cache of the mapping from arguments<br>  to results and, when calls with the same arguments are repeated often, has<br>  higher performance at the expense of higher memory use.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3636">source</a>
 </li>
 <li>
@@ -3085,7 +3085,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(merge & maps)</code></div>
 </pre>
-  <p class="var-docstr">Returns a map that consists of the rest of the maps conj-ed onto<br>  the first.  If a key occurs in more than one map, the mapping from<br>  the latter (left-to-right) will be the mapping in the result.</p>
+  <p class="var-docstr">Returns a map that consists of the rest of the maps conj-ed onto<br>  the first.  If a key occurs in more than one map, the mapping from<br>  the latter (left-to-right) will be the mapping in the result.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1807">source</a>
 </li>
 <li>
@@ -3094,7 +3094,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(merge-with f & maps)</code></div>
 </pre>
-  <p class="var-docstr">Returns a map that consists of the rest of the maps conj-ed onto<br>  the first.  If a key occurs in more than one map, the mapping(s)<br>  from the latter (left-to-right) will be combined with the mapping in<br>  the result by calling (f val-in-result val-in-latter).</p>
+  <p class="var-docstr">Returns a map that consists of the rest of the maps conj-ed onto<br>  the first.  If a key occurs in more than one map, the mapping(s)<br>  from the latter (left-to-right) will be combined with the mapping in<br>  the result by calling (f val-in-result val-in-latter).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1817">source</a>
 </li>
 <li>
@@ -3206,7 +3206,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(next coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a seq of the items after the first. Calls seq on its<br>         argument.  If there are no more items, returns nil.</p>
+  <p class="var-docstr">Returns a seq of the items after the first. Calls seq on its<br>         argument.  If there are no more items, returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L56">source</a>
 </li>
 <li>
@@ -3251,7 +3251,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(not-any? pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns false if (pred x) is logical true for any x in coll,<br>         else true.</p>
+  <p class="var-docstr">Returns false if (pred x) is logical true for any x in coll,<br>         else true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1633">source</a>
 </li>
 <li>
@@ -3269,7 +3269,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(not-every? pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns false if (pred x) is logical true for every x in<br>         coll, else true.</p>
+  <p class="var-docstr">Returns false if (pred x) is logical true for every x in<br>         coll, else true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1615">source</a>
 </li>
 <li>
@@ -3289,7 +3289,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(ns name docstring? attr-map? references*)</code></div>
 </pre>
-  <p class="var-docstr">Sets *ns* to the namespace named by name (unevaluated), creating it<br>  if needed.  references can be zero or more of:<br>  (:require ...) (:use ...) (:load ...)<br>  with the syntax of require/use/load<br>  respectively, except the arguments are unevaluated and need not be<br>  quoted. Use of ns is preferred to<br>  individual calls to in-ns/require/use:<br><br>  (ns foo.bar<br>    (:require [my.lib1 :as lib1])<br>    (:use [my.lib2]))</p>
+  <p class="var-docstr">Sets *ns* to the namespace named by name (unevaluated), creating it<br>  if needed.  references can be zero or more of:<br>  (:require ...) (:use ...) (:load ...)<br>  with the syntax of require/use/load<br>  respectively, except the arguments are unevaluated and need not be<br>  quoted. Use of ns is preferred to<br>  individual calls to in-ns/require/use:<br><br>  (ns foo.bar<br>    (:require [my.lib1 :as lib1])<br>    (:use [my.lib2]))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3129">source</a>
 </li>
 <li>
@@ -3353,7 +3353,7 @@
   <pre class="var-usage"><div><code>(ns-resolve ns sym)</code></div>
 <div><code>(ns-resolve ns env sym)</code></div>
 </pre>
-  <p class="var-docstr">Returns the var or type to which a symbol will be resolved in the<br>  namespace (unless found in the environment), else nil.  Note that<br>  if the symbol is fully qualified, the var/Type to which it resolves<br>  need not be present in the namespace.</p>
+  <p class="var-docstr">Returns the var or type to which a symbol will be resolved in the<br>  namespace (unless found in the environment), else nil.  Note that<br>  if the symbol is fully qualified, the var/Type to which it resolves<br>  need not be present in the namespace.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2458">source</a>
 </li>
 <li>
@@ -3381,7 +3381,7 @@
   <pre class="var-usage"><div><code>(nth coll index)</code></div>
 <div><code>(nth coll index not-found)</code></div>
 </pre>
-  <p class="var-docstr">Returns the value at the index. get returns nil if index out of<br>  bounds, nth throws an exception unless not-found is supplied.  nth<br>  also works, in O(n) time, for strings and sequences.</p>
+  <p class="var-docstr">Returns the value at the index. get returns nil if index out of<br>  bounds, nth throws an exception unless not-found is supplied.  nth<br>  also works, in O(n) time, for strings and sequences.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L670">source</a>
 </li>
 <li>
@@ -3446,7 +3446,7 @@
 <div><code>(or x)</code></div>
 <div><code>(or x & next)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates exprs one at a time, from left to right. If a form<br>  returns a logical true value, or returns that value and doesn't<br>  evaluate any of the other expressions, otherwise it returns the<br>  value of the last expression. (or) returns nil.</p>
+  <p class="var-docstr">Evaluates exprs one at a time, from left to right. If a form<br>  returns a logical true value, or returns that value and doesn't<br>  evaluate any of the other expressions, otherwise it returns the<br>  value of the last expression. (or) returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L640">source</a>
 </li>
 <li>
@@ -3459,7 +3459,7 @@
 <div><code>(partial f arg1 arg2 arg3)</code></div>
 <div><code>(partial f arg1 arg2 arg3 & more)</code></div>
 </pre>
-  <p class="var-docstr">Takes a function f and fewer than the normal arguments to f, and<br>  returns a fn that takes a variable number of additional args. When<br>  called, the returned function calls f with args + additional args.</p>
+  <p class="var-docstr">Takes a function f and fewer than the normal arguments to f, and<br>  returns a fn that takes a variable number of additional args. When<br>  called, the returned function calls f with args + additional args.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1579">source</a>
 </li>
 <li>
@@ -3470,7 +3470,7 @@
 <div><code>(partition n step coll)</code></div>
 <div><code>(partition n step pad coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of lists of n items each, at offsets step<br>  apart. If step is not supplied, defaults to n, i.e. the partitions<br>  do not overlap. If a pad collection is supplied, use its elements as<br>  necessary to complete last partition upto n items. In case there are<br>  not enough padding elements, return a partition with less than n items.</p>
+  <p class="var-docstr">Returns a lazy sequence of lists of n items each, at offsets step<br>  apart. If step is not supplied, defaults to n, i.e. the partitions<br>  do not overlap. If a pad collection is supplied, use its elements as<br>  necessary to complete last partition upto n items. In case there are<br>  not enough padding elements, return a partition with less than n items.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1918">source</a>
 </li>
 <li>
@@ -3480,7 +3480,7 @@
   <pre class="var-usage"><div><code>(partition-all n coll)</code></div>
 <div><code>(partition-all n step coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of lists like partition, but may include<br>  partitions with fewer than n items at the end.</p>
+  <p class="var-docstr">Returns a lazy sequence of lists like partition, but may include<br>  partitions with fewer than n items at the end.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3765">source</a>
 </li>
 <li>
@@ -3489,7 +3489,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(partition-by f coll)</code></div>
 </pre>
-  <p class="var-docstr">Applies f to each value in coll, splitting it each time f returns a<br>  new value.  Returns a lazy seq of partitions.</p>
+  <p class="var-docstr">Applies f to each value in coll, splitting it each time f returns a<br>  new value.  Returns a lazy seq of partitions.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3869">source</a>
 </li>
 <li>
@@ -3498,7 +3498,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(peek coll)</code></div>
 </pre>
-  <p class="var-docstr">For a list, same as first, for a vector, same as, but much<br>  more efficient than, last. If the collection is empty, returns nil.</p>
+  <p class="var-docstr">For a list, same as first, for a vector, same as, but much<br>  more efficient than, last. If the collection is empty, returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1048">source</a>
 </li>
 <li>
@@ -3507,7 +3507,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(pop coll)</code></div>
 </pre>
-  <p class="var-docstr">For a list, returns a new list without the first<br>  item, for a vector, returns a new vector without the last item. If<br>  the collection is empty, throws an exception.  Note - not the same<br>  as next/butlast.</p>
+  <p class="var-docstr">For a list, returns a new list without the first<br>  item, for a vector, returns a new vector without the last item. If<br>  the collection is empty, throws an exception.  Note - not the same<br>  as next/butlast.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1054">source</a>
 </li>
 <li>
@@ -3543,7 +3543,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(pr & args)</code></div>
 </pre>
-  <p class="var-docstr">Prints the object(s) to the output stream that is the current value<br>         of *out*.  Prints the object(s), separated by spaces if there is<br>         more than one.  By default, pr and prn print in a way that objects<br>         can be read by the reader</p>
+  <p class="var-docstr">Prints the object(s) to the output stream that is the current value<br>         of *out*.  Prints the object(s), separated by spaces if there is<br>         more than one.  By default, pr and prn print in a way that objects<br>         can be read by the reader</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2089">source</a>
 </li>
 <li>
@@ -3570,7 +3570,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(prefer-method multifn dispatch-val-x dispatch-val-y)</code></div>
 </pre>
-  <p class="var-docstr">Causes the multimethod to prefer matches of dispatch-val-x over dispatch-val-y<br>   when there is a conflict</p>
+  <p class="var-docstr">Causes the multimethod to prefer matches of dispatch-val-x over dispatch-val-y<br>   when there is a conflict</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4320">source</a>
 </li>
 <li>
@@ -3588,7 +3588,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(print & more)</code></div>
 </pre>
-  <p class="var-docstr">Prints the object(s) to the output stream that is the current value<br>  of *out*.  print and println produce output for human consumption.</p>
+  <p class="var-docstr">Prints the object(s) to the output stream that is the current value<br>  of *out*.  print and println produce output for human consumption.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2135">source</a>
 </li>
 <li>
@@ -3715,7 +3715,7 @@
   <pre class="var-usage"><div><code>(rand)</code></div>
 <div><code>(rand n)</code></div>
 </pre>
-  <p class="var-docstr">Returns a random floating point number between 0 (inclusive) and<br>  n (default 1) (exclusive).</p>
+  <p class="var-docstr">Returns a random floating point number between 0 (inclusive) and<br>  n (default 1) (exclusive).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2953">source</a>
 </li>
 <li>
@@ -3733,7 +3733,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(rand-nth coll)</code></div>
 </pre>
-  <p class="var-docstr">Return a random element of the (sequential) collection. Will have<br>  the same performance characteristics as nth for the given<br>  collection.</p>
+  <p class="var-docstr">Return a random element of the (sequential) collection. Will have<br>  the same performance characteristics as nth for the given<br>  collection.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3905">source</a>
 </li>
 <li>
@@ -3742,7 +3742,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(random-sample prob coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns items from coll with random probability of prob (0.0 -<br>  1.0).</p>
+  <p class="var-docstr">Returns items from coll with random probability of prob (0.0 -<br>  1.0).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4179">source</a>
 </li>
 <li>
@@ -3754,7 +3754,7 @@
 <div><code>(range start end)</code></div>
 <div><code>(range start end step)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy seq of nums from start (inclusive) to end<br>  (exclusive), by step, where start defaults to 0, step to 1, and end to<br>  infinity. When step is equal to 0, returns an infinite sequence of<br>  start. When start is equal to end, returns empty list.</p>
+  <p class="var-docstr">Returns a lazy seq of nums from start (inclusive) to end<br>  (exclusive), by step, where start defaults to 0, step to 1, and end to<br>  infinity. When step is equal to 0, returns an infinite sequence of<br>  start. When start is equal to end, returns empty list.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1788">source</a>
 </li>
 <li>
@@ -3855,7 +3855,7 @@
   <pre class="var-usage"><div><code>(reduce f coll)</code></div>
 <div><code>(reduce f val coll)</code></div>
 </pre>
-  <p class="var-docstr">f should be a function of 2 arguments. If val is not supplied,<br>  returns the result of applying f to the first 2 items in coll, then<br>  applying f to that result and the 3rd item, etc. If coll contains no<br>  items, f must accept no arguments as well, and reduce returns the<br>  result of calling f with no arguments.  If coll has only 1 item, it<br>  is returned and f is not called.  If val is supplied, returns the<br>  result of applying f to val and the first item in coll, then<br>  applying f to that result and the 2nd item, etc. If coll contains no<br>  items, returns val and f is not called.</p>
+  <p class="var-docstr">f should be a function of 2 arguments. If val is not supplied,<br>  returns the result of applying f to the first 2 items in coll, then<br>  applying f to that result and the 3rd item, etc. If coll contains no<br>  items, f must accept no arguments as well, and reduce returns the<br>  result of calling f with no arguments.  If coll has only 1 item, it<br>  is returned and f is not called.  If val is supplied, returns the<br>  result of applying f to val and the first item in coll, then<br>  applying f to that result and the 2nd item, etc. If coll contains no<br>  items, returns val and f is not called.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L704">source</a>
 </li>
 <li>
@@ -3864,7 +3864,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(reduce-kv f init coll)</code></div>
 </pre>
-  <p class="var-docstr">Reduces an associative collection. f should be a function of 3<br>  arguments. Returns the result of applying f to init, the first key<br>  and the first value in coll, then applying f to that result and the<br>  2nd key and value, etc. If coll contains no entries, returns init<br>  and f is not called. Note that reduce-kv is supported on vectors,<br>  where the keys will be the ordinals.</p>
+  <p class="var-docstr">Reduces an associative collection. f should be a function of 3<br>  arguments. Returns the result of applying f to init, the first key<br>  and the first value in coll, then applying f to that result and the<br>  2nd key and value, etc. If coll contains no entries, returns init<br>  and f is not called. Note that reduce-kv is supported on vectors,<br>  where the keys will be the ordinals.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1348">source</a>
 </li>
 <li>
@@ -3874,7 +3874,7 @@
   <pre class="var-usage"><div><code>(reductions f coll)</code></div>
 <div><code>(reductions f init coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy seq of the intermediate values of the reduction (as<br>  per reduce) of coll by f, starting with init.</p>
+  <p class="var-docstr">Returns a lazy seq of the intermediate values of the reduction (as<br>  per reduce) of coll by f, starting with init.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3890">source</a>
 </li>
 <li>
@@ -3883,7 +3883,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(refer ns-sym & filters)</code></div>
 </pre>
-  <p class="var-docstr">refers to all public vars of ns, subject to filters.<br>  filters can include at most one each of:<br><br>  :exclude list-of-symbols<br>  :only list-of-symbols<br>  :rename map-of-fromsymbol-tosymbol<br><br>  For each public interned var in the namespace named by the symbol,<br>  adds a mapping from the name of the var to the var to the current<br>  namespace.  Throws an exception if name is already mapped to<br>  something else in the current namespace. Filters can be used to<br>  select a subset, via inclusion or exclusion, or to provide a mapping<br>  to a symbol different from the var's name, in order to prevent<br>  clashes. Use :use in the ns macro in preference to calling this directly.</p>
+  <p class="var-docstr">refers to all public vars of ns, subject to filters.<br>  filters can include at most one each of:<br><br>  :exclude list-of-symbols<br>  :only list-of-symbols<br>  :rename map-of-fromsymbol-tosymbol<br><br>  For each public interned var in the namespace named by the symbol,<br>  adds a mapping from the name of the var to the var to the current<br>  namespace.  Throws an exception if name is already mapped to<br>  something else in the current namespace. Filters can be used to<br>  select a subset, via inclusion or exclusion, or to provide a mapping<br>  to a symbol different from the var's name, in order to prevent<br>  clashes. Use :use in the ns macro in preference to calling this directly.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2357">source</a>
 </li>
 <li>
@@ -3910,7 +3910,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(remove pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the items in coll for which<br>  (pred item) returns false. pred must be free of side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of the items in coll for which<br>  (pred item) returns false. pred must be free of side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1691">source</a>
 </li>
 <li>
@@ -3937,7 +3937,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(remove-ns sym)</code></div>
 </pre>
-  <p class="var-docstr">Removes the namespace named by the symbol. Use with caution.<br>  Cannot be used to remove the clojure namespace.</p>
+  <p class="var-docstr">Removes the namespace named by the symbol. Use with caution.<br>  Cannot be used to remove the clojure namespace.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2262">source</a>
 </li>
 <li>
@@ -3957,7 +3957,7 @@
   <pre class="var-usage"><div><code>(repeatedly f)</code></div>
 <div><code>(repeatedly n f)</code></div>
 </pre>
-  <p class="var-docstr">Takes a function of no args, presumably with side effects, and<br>  returns an infinite (or length n if supplied) lazy sequence of calls<br>  to it</p>
+  <p class="var-docstr">Takes a function of no args, presumably with side effects, and<br>  returns an infinite (or length n if supplied) lazy sequence of calls<br>  to it</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3068">source</a>
 </li>
 <li>
@@ -3966,7 +3966,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(replace smap coll)</code></div>
 </pre>
-  <p class="var-docstr">Given a map of replacement pairs and a vector/collection, returns a<br>  vector/seq with any elements = a key in smap replaced with the<br>  corresponding val in smap.</p>
+  <p class="var-docstr">Given a map of replacement pairs and a vector/collection, returns a<br>  vector/seq with any elements = a key in smap replaced with the<br>  corresponding val in smap.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3054">source</a>
 </li>
 <li>
@@ -3975,7 +3975,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(require & args)</code></div>
 </pre>
-  <p class="var-docstr">Loads libs, skipping any that are already loaded. Each argument is<br>  either a libspec that identifies a lib, a prefix list that identifies<br>  multiple libs whose names share a common prefix, or a flag that modifies<br>  how all the identified libs are loaded. Use :require in the ns macro<br>  in preference to calling this directly.<br><br>  Libs<br><br>  A 'lib' is a named set of resources in classpath whose contents define a<br>  library of Clojure code. Lib names are symbols and each lib is associated<br>  with a Clojure namespace and a Java package that share its name. A lib's<br>  name also locates its root directory within classpath using Java's<br>  package name to classpath-relative path mapping. All resources in a lib<br>  should be contained in the directory structure under its root directory.<br>  All definitions a lib makes should be in its associated namespace.<br><br>  'require loads a lib by loading its root resource. The root resource path<br>  is derived from the lib name in the following manner:<br>  Consider a lib named by the symbol 'x.y.z; it has the root directory<br>  <classpath>/x/y/, and its root resource is <classpath>/x/y/z.clj. The root<br>  resource should contain code to create the lib's namespace (usually by using<br>  the ns macro) and load any additional lib resources.<br><br>  Libspecs<br><br>  A libspec is a lib name or a vector containing a lib name followed by<br>  options expressed as sequential keywords and arguments.<br><br>  Recognized options:<br>  :as takes a symbol as its argument and makes that symbol an alias to the<br>    lib's namespace in the current namespace.<br>  :refer takes a list of symbols to refer from the namespace or the :all<br>    keyword to bring in all public vars.<br><br>  Prefix Lists<br><br>  It's common for Clojure code to depend on several libs whose names have<br>  the same prefix. When specifying libs, prefix lists can be used to reduce<br>  repetition. A prefix list contains the shared prefix followed by libspecs<br>  with the shared prefix removed from the lib names. After removing the<br>  prefix, the names that remain must not contain any periods.<br><br>  Flags<br><br>  A flag is a keyword.<br>  Recognized flags: :reload, :reload-all, :verbose<br>  :reload forces loading of all the identified libs even if they are<br>    already loaded<br>  :reload-all implies :reload and also forces loading of all libs that the<br>    identified libs directly or indirectly load via require or use<br>  :verbose triggers printing information about each load, alias, and refer<br><br>  Example:<br><br>  The following would load the libraries clojure.zip and clojure.set<br>  abbreviated as 's'.<br><br>  (require '(clojure zip [set :as s]))</p>
+  <p class="var-docstr">Loads libs, skipping any that are already loaded. Each argument is<br>  either a libspec that identifies a lib, a prefix list that identifies<br>  multiple libs whose names share a common prefix, or a flag that modifies<br>  how all the identified libs are loaded. Use :require in the ns macro<br>  in preference to calling this directly.<br><br>  Libs<br><br>  A 'lib' is a named set of resources in classpath whose contents define a<br>  library of Clojure code. Lib names are symbols and each lib is associated<br>  with a Clojure namespace and a Java package that share its name. A lib's<br>  name also locates its root directory within classpath using Java's<br>  package name to classpath-relative path mapping. All resources in a lib<br>  should be contained in the directory structure under its root directory.<br>  All definitions a lib makes should be in its associated namespace.<br><br>  'require loads a lib by loading its root resource. The root resource path<br>  is derived from the lib name in the following manner:<br>  Consider a lib named by the symbol 'x.y.z; it has the root directory<br>  <classpath>/x/y/, and its root resource is <classpath>/x/y/z.clj. The root<br>  resource should contain code to create the lib's namespace (usually by using<br>  the ns macro) and load any additional lib resources.<br><br>  Libspecs<br><br>  A libspec is a lib name or a vector containing a lib name followed by<br>  options expressed as sequential keywords and arguments.<br><br>  Recognized options:<br>  :as takes a symbol as its argument and makes that symbol an alias to the<br>    lib's namespace in the current namespace.<br>  :refer takes a list of symbols to refer from the namespace or the :all<br>    keyword to bring in all public vars.<br><br>  Prefix Lists<br><br>  It's common for Clojure code to depend on several libs whose names have<br>  the same prefix. When specifying libs, prefix lists can be used to reduce<br>  repetition. A prefix list contains the shared prefix followed by libspecs<br>  with the shared prefix removed from the lib names. After removing the<br>  prefix, the names that remain must not contain any periods.<br><br>  Flags<br><br>  A flag is a keyword.<br>  Recognized flags: :reload, :reload-all, :verbose<br>  :reload forces loading of all the identified libs even if they are<br>    already loaded<br>  :reload-all implies :reload and also forces loading of all libs that the<br>    identified libs directly or indirectly load via require or use<br>  :verbose triggers printing information about each load, alias, and refer<br><br>  Example:<br><br>  The following would load the libraries clojure.zip and clojure.set<br>  abbreviated as 's'.<br><br>  (require '(clojure zip [set :as s]))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3363">source</a>
 </li>
 <li>
@@ -3984,7 +3984,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(requiring-resolve sym)</code></div>
 </pre>
-  <p class="var-docstr">Resolves namespace-qualified sym per 'resolve'. If initial resolve<br>  fails, attempts to require sym's namespace and retries.</p>
+  <p class="var-docstr">Resolves namespace-qualified sym per 'resolve'. If initial resolve<br>  fails, attempts to require sym's namespace and retries.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3427">source</a>
 </li>
 <li>
@@ -3993,7 +3993,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(reset! atom newval)</code></div>
 </pre>
-  <p class="var-docstr">Sets the value of atom to newval without regard for the<br>  current value. Returns newval.</p>
+  <p class="var-docstr">Sets the value of atom to newval without regard for the<br>  current value. Returns newval.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1477">source</a>
 </li>
 <li>
@@ -4011,7 +4011,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(reset-vals! atom newval)</code></div>
 </pre>
-  <p class="var-docstr">Sets the value of atom to newval. Returns [old new], the value of the<br>  atom before and after the reset.</p>
+  <p class="var-docstr">Sets the value of atom to newval. Returns [old new], the value of the<br>  atom before and after the reset.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1484">source</a>
 </li>
 <li>
@@ -4030,7 +4030,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(rest coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a possibly empty seq of the items after the first. Calls seq on its<br>         argument.</p>
+  <p class="var-docstr">Returns a possibly empty seq of the items after the first. Calls seq on its<br>         argument.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L63">source</a>
 </li>
 <li>
@@ -4057,7 +4057,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(rseq rev)</code></div>
 </pre>
-  <p class="var-docstr">Returns, in constant time, a seq of the items in rev (which<br>  can be a vector or sorted-map), in reverse order. If rev is empty returns nil.</p>
+  <p class="var-docstr">Returns, in constant time, a seq of the items in rev (which<br>  can be a vector or sorted-map), in reverse order. If rev is empty returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1147">source</a>
 </li>
 <li>
@@ -4066,7 +4066,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(run! proc coll)</code></div>
 </pre>
-  <p class="var-docstr">Runs the supplied procedure (via reduce), for purposes of side<br>  effects, on successive items in the collection. Returns nil.</p>
+  <p class="var-docstr">Runs the supplied procedure (via reduce), for purposes of side<br>  effects, on successive items in the collection. Returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4186">source</a>
 </li>
 <li>
@@ -4093,7 +4093,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(seq coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a seq on the collection. If the collection is<br>         empty, returns nil.  (seq nil) returns nil.</p>
+  <p class="var-docstr">Returns a seq on the collection. If the collection is<br>         empty, returns nil.  (seq nil) returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L114">source</a>
 </li>
 <li>
@@ -4120,7 +4120,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(sequence coll)</code></div>
 </pre>
-  <p class="var-docstr">Coerces coll to a (possibly empty) sequence, if it is not already<br>  one. Will not force a lazy seq. (sequence nil) yields ()</p>
+  <p class="var-docstr">Coerces coll to a (possibly empty) sequence, if it is not already<br>  one. Will not force a lazy seq. (sequence nil) yields ()</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1594">source</a>
 </li>
 <li>
@@ -4201,7 +4201,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(some pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns the first logical true value of (pred x) for any x in coll,<br>  else nil.  One common idiom is to use a set as pred, for example<br>  this will return :fred if :fred is in the sequence, otherwise nil:<br>  (some #{:fred} coll)</p>
+  <p class="var-docstr">Returns the first logical true value of (pred x) for any x in coll,<br>  else nil.  One common idiom is to use a set as pred, for example<br>  this will return :fred if :fred is in the sequence, otherwise nil:<br>  (some #{:fred} coll)</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1623">source</a>
 </li>
 <li>
@@ -4210,7 +4210,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(some-> expr & forms)</code></div>
 </pre>
-  <p class="var-docstr">When expr is not nil, threads it into the first form (via ->),<br>  and when that result is not nil, through the next etc.</p>
+  <p class="var-docstr">When expr is not nil, threads it into the first form (via ->),<br>  and when that result is not nil, through the next etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4138">source</a>
 </li>
 <li>
@@ -4219,7 +4219,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(some->> expr & forms)</code></div>
 </pre>
-  <p class="var-docstr">When expr is not nil, threads it into the first form (via ->>),<br>  and when that result is not nil, through the next etc.</p>
+  <p class="var-docstr">When expr is not nil, threads it into the first form (via ->>),<br>  and when that result is not nil, through the next etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4154">source</a>
 </li>
 <li>
@@ -4231,7 +4231,7 @@
 <div><code>(some-fn p1 p2 p3)</code></div>
 <div><code>(some-fn p1 p2 p3 & ps)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of predicates and returns a function f that returns the first logical true value<br>  returned by one of its composing predicates against any of its arguments, else it returns<br>  logical false. Note that f is short-circuiting in that it will stop execution on the first<br>  argument that triggers a logical true result against the original predicates.</p>
+  <p class="var-docstr">Takes a set of predicates and returns a function f that returns the first logical true value<br>  returned by one of its composing predicates against any of its arguments, else it returns<br>  logical false. Note that f is short-circuiting in that it will stop execution on the first<br>  argument that triggers a logical true result against the original predicates.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4012">source</a>
 </li>
 <li>
@@ -4250,7 +4250,7 @@
   <pre class="var-usage"><div><code>(sort coll)</code></div>
 <div><code>(sort comp coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a sorted sequence of the items in coll. If no comparator is<br>  supplied, uses compare.</p>
+  <p class="var-docstr">Returns a sorted sequence of the items in coll. If no comparator is<br>  supplied, uses compare.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1852">source</a>
 </li>
 <li>
@@ -4260,7 +4260,7 @@
   <pre class="var-usage"><div><code>(sort-by keyfn coll)</code></div>
 <div><code>(sort-by keyfn comp coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a sorted sequence of the items in coll, where the sort<br>  order is determined by comparing (keyfn item).  If no comparator is<br>  supplied, uses compare.</p>
+  <p class="var-docstr">Returns a sorted sequence of the items in coll, where the sort<br>  order is determined by comparing (keyfn item).  If no comparator is<br>  supplied, uses compare.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1861">source</a>
 </li>
 <li>
@@ -4278,7 +4278,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(spit f content)</code></div>
 </pre>
-  <p class="var-docstr">Opposite of slurp.  Opens file f, writes content, then<br>  closes f.</p>
+  <p class="var-docstr">Opposite of slurp.  Opens file f, writes content, then<br>  closes f.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3841">source</a>
 </li>
 <li>
@@ -4305,7 +4305,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(str & xs)</code></div>
 </pre>
-  <p class="var-docstr">With no args, returns the empty string. With one arg x, returns<br>         string representation of x. (str nil) returns the empty string. With more than<br>         one arg, returns the concatenation of the str values of the args.</p>
+  <p class="var-docstr">With no args, returns the empty string. With one arg x, returns<br>         string representation of x. (str nil) returns the empty string. With more than<br>         one arg, returns the concatenation of the str values of the args.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L418">source</a>
 </li>
 <li>
@@ -4324,7 +4324,7 @@
   <pre class="var-usage"><div><code>(subs s start)</code></div>
 <div><code>(subs s start end)</code></div>
 </pre>
-  <p class="var-docstr">Returns the substring of s beginning at start inclusive, and ending<br>  at end (defaults to length of string), exclusive.</p>
+  <p class="var-docstr">Returns the substring of s beginning at start inclusive, and ending<br>  at end (defaults to length of string), exclusive.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3017">source</a>
 </li>
 <li>
@@ -4334,7 +4334,7 @@
   <pre class="var-usage"><div><code>(subvec v start)</code></div>
 <div><code>(subvec v start end)</code></div>
 </pre>
-  <p class="var-docstr">Returns a persistent vector of the items in vector from<br>  start (inclusive) to end (exclusive).  If end is not supplied,<br>  defaults to (count vector). This operation is O(1) and very fast, as<br>  the resulting vector shares structure with the original and no<br>  trimming is done.</p>
+  <p class="var-docstr">Returns a persistent vector of the items in vector from<br>  start (inclusive) to end (exclusive).  If end is not supplied,<br>  defaults to (count vector). This operation is O(1) and very fast, as<br>  the resulting vector shares structure with the original and no<br>  trimming is done.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2168">source</a>
 </li>
 <li>
@@ -4343,7 +4343,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(swap! atom f & args)</code></div>
 </pre>
-  <p class="var-docstr">Atomically swaps the value of atom to be:<br>  (apply f current-value-of-atom args).<br>  Returns the value that was swapped in.</p>
+  <p class="var-docstr">Atomically swaps the value of atom to be:<br>  (apply f current-value-of-atom args).<br>  Returns the value that was swapped in.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1460">source</a>
 </li>
 <li>
@@ -4352,7 +4352,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(swap-vals! atom f & args)</code></div>
 </pre>
-  <p class="var-docstr">Atomically swaps the value of atom to be:<br>  (apply f current-value-of-atom args). Note that f may be called<br>  multiple times, and thus should be free of side effects.<br>  Returns [old new], the value of the atom before and after the swap.</p>
+  <p class="var-docstr">Atomically swaps the value of atom to be:<br>  (apply f current-value-of-atom args). Note that f may be called<br>  multiple times, and thus should be free of side effects.<br>  Returns [old new], the value of the atom before and after the swap.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1468">source</a>
 </li>
 <li>
@@ -4380,7 +4380,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(take n coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the first n items in coll, or all items if<br>  there are fewer than n.</p>
+  <p class="var-docstr">Returns a lazy sequence of the first n items in coll, or all items if<br>  there are fewer than n.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1698">source</a>
 </li>
 <li>
@@ -4389,7 +4389,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(take-last n coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a seq of the last n items in coll.  Depending on the type<br>  of coll may be no better than linear time.  For vectors, see also subvec.</p>
+  <p class="var-docstr">Returns a seq of the last n items in coll.  Depending on the type<br>  of coll may be no better than linear time.  For vectors, see also subvec.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1735">source</a>
 </li>
 <li>
@@ -4407,7 +4407,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(take-while pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of successive items from coll while<br>  (pred item) returns true. pred must be free of side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of successive items from coll while<br>  (pred item) returns true. pred must be free of side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1708">source</a>
 </li>
 <li>
@@ -4416,7 +4416,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(test v)</code></div>
 </pre>
-  <p class="var-docstr">test [v] finds fn at key :test in var metadata and calls it,<br>  presuming failure will throw exception</p>
+  <p class="var-docstr">test [v] finds fn at key :test in var metadata and calls it,<br>  presuming failure will throw exception</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2910">source</a>
 </li>
 <li>
@@ -4425,7 +4425,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(the-ns x)</code></div>
 </pre>
-  <p class="var-docstr">If passed a namespace, returns it. Else, when passed a symbol,<br>  returns the namespace named by it, throwing an exception if not<br>  found.</p>
+  <p class="var-docstr">If passed a namespace, returns it. Else, when passed a symbol,<br>  returns the namespace named by it, throwing an exception if not<br>  found.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2273">source</a>
 </li>
 <li>
@@ -4444,7 +4444,7 @@
   <pre class="var-usage"><div><code>(trampoline f)</code></div>
 <div><code>(trampoline f & args)</code></div>
 </pre>
-  <p class="var-docstr">trampoline can be used to convert algorithms requiring mutual<br>  recursion without stack consumption. Calls f with supplied args, if<br>  any. If f returns a fn, calls that fn with no arguments, and<br>  continues to repeat, until the return value is not a fn, then<br>  returns that non-fn value. Note that if you want to return a fn as a<br>  final value, you must wrap it in some data structure and unpack it<br>  after trampoline returns.</p>
+  <p class="var-docstr">trampoline can be used to convert algorithms requiring mutual<br>  recursion without stack consumption. Calls f with supplied args, if<br>  any. If f returns a fn, calls that fn with no arguments, and<br>  continues to repeat, until the return value is not a fn, then<br>  returns that non-fn value. Note that if you want to return a fn as a<br>  final value, you must wrap it in some data structure and unpack it<br>  after trampoline returns.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3609">source</a>
 </li>
 <li>
@@ -4453,7 +4453,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(tree-seq branch? children root)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the nodes in a tree, via a depth-first walk.<br>  branch? must be a fn of one arg that returns true if passed a node<br>  that can have children (but may not).  children must be a fn of one<br>  arg that returns a sequence of the children. Will only be called on<br>  nodes for which branch? returns true. Root is the root node of the<br>  tree.</p>
+  <p class="var-docstr">Returns a lazy sequence of the nodes in a tree, via a depth-first walk.<br>  branch? must be a fn of one arg that returns true if passed a node<br>  that can have children (but may not).  children must be a fn of one<br>  arg that returns a sequence of the children. Will only be called on<br>  nodes for which branch? returns true. Root is the root node of the<br>  tree.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2971">source</a>
 </li>
 <li>
@@ -4493,7 +4493,7 @@
 <div><code>(update m k f x y z)</code></div>
 <div><code>(update m k f x y z & more)</code></div>
 </pre>
-  <p class="var-docstr">'Updates' a value in an associative structure, where k is a<br>  key and f is a function that will take the old value<br>  and any supplied args and return the new value, and returns a new<br>  structure.  If the key does not exist, nil is passed as the old value.</p>
+  <p class="var-docstr">'Updates' a value in an associative structure, where k is a<br>  key and f is a function that will take the old value<br>  and any supplied args and return the new value, and returns a new<br>  structure.  If the key does not exist, nil is passed as the old value.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3519">source</a>
 </li>
 <li>
@@ -4502,7 +4502,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(update-in m ks f & args)</code></div>
 </pre>
-  <p class="var-docstr">'Updates' a value in a nested associative structure, where ks is a<br>  sequence of keys and f is a function that will take the old value<br>  and any supplied args and return the new value, and returns a new<br>  nested structure.  If any levels do not exist, hash-maps will be<br>  created.</p>
+  <p class="var-docstr">'Updates' a value in a nested associative structure, where ks is a<br>  sequence of keys and f is a function that will take the old value<br>  and any supplied args and return the new value, and returns a new<br>  nested structure.  If any levels do not exist, hash-maps will be<br>  created.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3506">source</a>
 </li>
 <li>
@@ -4511,7 +4511,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(use & args)</code></div>
 </pre>
-  <p class="var-docstr">Like 'require, but also refers to each lib's namespace using<br>  joker.core/refer. Use :use in the ns macro in preference to calling<br>  this directly.<br><br>  'use accepts additional options in libspecs: :exclude, :only, :rename.<br>  The arguments and semantics for :exclude, :only, and :rename are the same<br>  as those documented for joker.core/refer.</p>
+  <p class="var-docstr">Like 'require, but also refers to each lib's namespace using<br>  joker.core/refer. Use :use in the ns macro in preference to calling<br>  this directly.<br><br>  'use accepts additional options in libspecs: :exclude, :only, :rename.<br>  The arguments and semantics for :exclude, :only, and :rename are the same<br>  as those documented for joker.core/refer.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3438">source</a>
 </li>
 <li>
@@ -4565,7 +4565,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(vary-meta obj f & args)</code></div>
 </pre>
-  <p class="var-docstr">Returns an object of the same type and value as obj, with<br>  (apply f (meta obj) args) as its metadata.</p>
+  <p class="var-docstr">Returns an object of the same type and value as obj, with<br>  (apply f (meta obj) args) as its metadata.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L517">source</a>
 </li>
 <li>
@@ -4610,7 +4610,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(when-first bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">bindings => x xs<br><br>  Roughly the same as (when (seq xs) (let [x (first xs)] body)) but xs is evaluated only once</p>
+  <p class="var-docstr">bindings => x xs<br><br>  Roughly the same as (when (seq xs) (let [x (first xs)] body)) but xs is evaluated only once</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2707">source</a>
 </li>
 <li>
@@ -4619,7 +4619,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(when-let bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">bindings => binding-form test<br><br>  When test is true, evaluates body with binding-form bound to the value of test</p>
+  <p class="var-docstr">bindings => binding-form test<br><br>  When test is true, evaluates body with binding-form bound to the value of test</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1284">source</a>
 </li>
 <li>
@@ -4637,7 +4637,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(when-some bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">bindings => binding-form test<br><br>  When test is not nil, evaluates body with binding-form bound to the<br>  value of test</p>
+  <p class="var-docstr">bindings => binding-form test<br><br>  When test is not nil, evaluates body with binding-form bound to the<br>  value of test</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1319">source</a>
 </li>
 <li>
@@ -4646,7 +4646,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(while test & body)</code></div>
 </pre>
-  <p class="var-docstr">Repeatedly executes body while test expression is true. Presumes<br>  some side-effect will cause test to become false/nil. Returns nil</p>
+  <p class="var-docstr">Repeatedly executes body while test expression is true. Presumes<br>  some side-effect will cause test to become false/nil. Returns nil</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3626">source</a>
 </li>
 <li>
@@ -4655,7 +4655,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-bindings binding-map & body)</code></div>
 </pre>
-  <p class="var-docstr">Takes a map of Var/value pairs. Sets the vars to the corresponding values.<br>  Then executes body. Resets the vars back to the original<br>  values after body was evaluated. Returns the value of body.</p>
+  <p class="var-docstr">Takes a map of Var/value pairs. Sets the vars to the corresponding values.<br>  Then executes body. Resets the vars back to the original<br>  values after body was evaluated. Returns the value of body.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1405">source</a>
 </li>
 <li>
@@ -4664,7 +4664,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-bindings* binding-map f & args)</code></div>
 </pre>
-  <p class="var-docstr">Takes a map of Var/value pairs. Sets the vars to the corresponding values.<br>  Then calls f with the supplied arguments. Resets the vars back to the original<br>  values after f returned. Returns whatever f returns.</p>
+  <p class="var-docstr">Takes a map of Var/value pairs. Sets the vars to the corresponding values.<br>  Then calls f with the supplied arguments. Resets the vars back to the original<br>  values after f returned. Returns whatever f returns.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1387">source</a>
 </li>
 <li>
@@ -4673,7 +4673,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-in-str s & body)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates body in a context in which *in* is bound to a fresh<br>  Buffer initialized with the string s.</p>
+  <p class="var-docstr">Evaluates body in a context in which *in* is bound to a fresh<br>  Buffer initialized with the string s.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2795">source</a>
 </li>
 <li>
@@ -4682,7 +4682,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-meta obj m)</code></div>
 </pre>
-  <p class="var-docstr">Returns an object of the same type and value as obj, with<br>         map m as its metadata.</p>
+  <p class="var-docstr">Returns an object of the same type and value as obj, with<br>         map m as its metadata.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L188">source</a>
 </li>
 <li>
@@ -4691,7 +4691,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-out-str & body)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates exprs in a context in which *out* is bound to a fresh<br>  Buffer.  Returns the string created by any nested printing<br>  calls.</p>
+  <p class="var-docstr">Evaluates exprs in a context in which *out* is bound to a fresh<br>  Buffer.  Returns the string created by any nested printing<br>  calls.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2785">source</a>
 </li>
 <li>

--- a/docs/joker.core.html
+++ b/docs/joker.core.html
@@ -1173,7 +1173,7 @@
 <div><code>(* x y)</code></div>
 <div><code>(* x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns the product of nums. (*) returns 1. Does not auto-promote<br>  ints, will overflow. See also: *'</p>
+  <p class="var-docstr">Returns the product of nums. (*) returns 1. Does not auto-promote<br>  ints, will overflow. See also: *'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L762">source</a>
 </li>
 <li>
@@ -1185,7 +1185,7 @@
 <div><code>(*' x y)</code></div>
 <div><code>(*' x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns the product of nums. (*) returns 1. Supports arbitrary precision.<br>  See also: *</p>
+  <p class="var-docstr">Returns the product of nums. (*) returns 1. Supports arbitrary precision.<br>  See also: *</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L752">source</a>
 </li>
 <li>
@@ -1225,7 +1225,7 @@
   <span class="var-type Nil">Nil</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">A sequence of the supplied command line arguments, or nil if<br>  none were supplied</p>
+  <p class="var-docstr">A sequence of the supplied command line arguments, or nil if<br>  none were supplied</p>
   
 </li>
 <li>
@@ -1241,7 +1241,7 @@
   <span class="var-type IOWriter">IOWriter</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">A File object representing standard error for print operations.<br><br>  Defaults to stderr.</p>
+  <p class="var-docstr">A File object representing standard error for print operations.<br><br>  Defaults to stderr.</p>
   
 </li>
 <li>
@@ -1249,7 +1249,7 @@
   <span class="var-type String">String</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">The path of the file being evaluated, as a String.<br><br>  When there is no file, e.g. in the REPL, the value is not defined.</p>
+  <p class="var-docstr">The path of the file being evaluated, as a String.<br><br>  When there is no file, e.g. in the REPL, the value is not defined.</p>
   
 </li>
 <li>
@@ -1257,7 +1257,7 @@
   <span class="var-type Bool">Bool</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">When set to true, output will be flushed whenever a newline is printed.<br><br>    Defaults to true.</p>
+  <p class="var-docstr">When set to true, output will be flushed whenever a newline is printed.<br><br>    Defaults to true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2118">source</a>
 </li>
 <li>
@@ -1265,7 +1265,7 @@
   <span class="var-type BufferedReader">BufferedReader</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">A File object representing standard input for read operations.<br><br>  Defaults to stdin.</p>
+  <p class="var-docstr">A File object representing standard input for read operations.<br><br>  Defaults to stdin.</p>
   
 </li>
 <li>
@@ -1305,7 +1305,7 @@
   <span class="var-type IOWriter">IOWriter</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">A File object representing standard output for print operations.<br><br>  Defaults to stdout.</p>
+  <p class="var-docstr">A File object representing standard output for print operations.<br><br>  Defaults to stdout.</p>
   
 </li>
 <li>
@@ -1313,7 +1313,7 @@
   <span class="var-type Bool">Bool</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">When set to logical false, strings and characters will be printed with<br>  non-alphanumeric characters converted to the appropriate escape sequences.<br><br>  Defaults to true</p>
+  <p class="var-docstr">When set to logical false, strings and characters will be printed with<br>  non-alphanumeric characters converted to the appropriate escape sequences.<br><br>  Defaults to true</p>
   
 </li>
 <li>
@@ -1325,7 +1325,7 @@
 <div><code>(+ x y)</code></div>
 <div><code>(+ x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns the sum of nums. (+) returns 0. Does not auto-promote<br>  ints, will overflow. See also: +'</p>
+  <p class="var-docstr">Returns the sum of nums. (+) returns 0. Does not auto-promote<br>  ints, will overflow. See also: +'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L742">source</a>
 </li>
 <li>
@@ -1337,7 +1337,7 @@
 <div><code>(+' x y)</code></div>
 <div><code>(+' x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns the sum of nums. (+) returns 0. Supports arbitrary precision.<br>  See also: +</p>
+  <p class="var-docstr">Returns the sum of nums. (+) returns 0. Supports arbitrary precision.<br>  See also: +</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L732">source</a>
 </li>
 <li>
@@ -1348,7 +1348,7 @@
 <div><code>(- x y)</code></div>
 <div><code>(- x y & more)</code></div>
 </pre>
-  <p class="var-docstr">If no ys are supplied, returns the negation of x, else subtracts<br>  the ys from x and returns the result. Does not auto-promote<br>  ints, will overflow. See also: -'</p>
+  <p class="var-docstr">If no ys are supplied, returns the negation of x, else subtracts<br>  the ys from x and returns the result. Does not auto-promote<br>  ints, will overflow. See also: -'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L791">source</a>
 </li>
 <li>
@@ -1359,7 +1359,7 @@
 <div><code>(-' x y)</code></div>
 <div><code>(-' x y & more)</code></div>
 </pre>
-  <p class="var-docstr">If no ys are supplied, returns the negation of x, else subtracts<br>  the ys from x and returns the result. Supports arbitrary precision.<br>  See also: -</p>
+  <p class="var-docstr">If no ys are supplied, returns the negation of x, else subtracts<br>  the ys from x and returns the result. Supports arbitrary precision.<br>  See also: -</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L781">source</a>
 </li>
 <li>
@@ -1368,7 +1368,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(-> x & forms)</code></div>
 </pre>
-  <p class="var-docstr">Threads the expr through the forms. Inserts x as the<br>  second item in the first form, making a list of it if it is not a<br>  list already. If there are more forms, inserts the first form as the<br>  second item in second form, etc.</p>
+  <p class="var-docstr">Threads the expr through the forms. Inserts x as the<br>  second item in the first form, making a list of it if it is not a<br>  list already. If there are more forms, inserts the first form as the<br>  second item in second form, etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1211">source</a>
 </li>
 <li>
@@ -1377,7 +1377,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(->> x & forms)</code></div>
 </pre>
-  <p class="var-docstr">Threads the expr through the forms. Inserts x as the<br>  last item in the first form, making a list of it if it is not a<br>  list already. If there are more forms, inserts the first form as the<br>  last item in second form, etc.</p>
+  <p class="var-docstr">Threads the expr through the forms. Inserts x as the<br>  last item in the first form, making a list of it if it is not a<br>  list already. If there are more forms, inserts the first form as the<br>  last item in second form, etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1229">source</a>
 </li>
 <li>
@@ -1388,7 +1388,7 @@
 <div><code>(/ x y)</code></div>
 <div><code>(/ x y & more)</code></div>
 </pre>
-  <p class="var-docstr">If no denominators are supplied, returns 1/numerator,<br>  else returns numerator divided by all of the denominators.</p>
+  <p class="var-docstr">If no denominators are supplied, returns 1/numerator,<br>  else returns numerator divided by all of the denominators.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L772">source</a>
 </li>
 <li>
@@ -1399,7 +1399,7 @@
 <div><code>(< x y)</code></div>
 <div><code>(< x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums are in monotonically increasing order,<br>  otherwise false.</p>
+  <p class="var-docstr">Returns non-nil if nums are in monotonically increasing order,<br>  otherwise false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L679">source</a>
 </li>
 <li>
@@ -1410,7 +1410,7 @@
 <div><code>(<= x y)</code></div>
 <div><code>(<= x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums are in monotonically non-decreasing order,<br>  otherwise false.</p>
+  <p class="var-docstr">Returns non-nil if nums are in monotonically non-decreasing order,<br>  otherwise false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L801">source</a>
 </li>
 <li>
@@ -1421,7 +1421,7 @@
 <div><code>(= x y)</code></div>
 <div><code>(= x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Equality. Returns true if x equals y, false if not. Works for nil, and compares<br>  numbers and collections in a type-independent manner.  Immutable data<br>  structures define = as a value, not an identity,<br>  comparison.</p>
+  <p class="var-docstr">Equality. Returns true if x equals y, false if not. Works for nil, and compares<br>  numbers and collections in a type-independent manner.  Immutable data<br>  structures define = as a value, not an identity,<br>  comparison.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L596">source</a>
 </li>
 <li>
@@ -1432,7 +1432,7 @@
 <div><code>(== x y)</code></div>
 <div><code>(== x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums all have the equivalent<br>  value (type-independent), otherwise false</p>
+  <p class="var-docstr">Returns non-nil if nums all have the equivalent<br>  value (type-independent), otherwise false</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L840">source</a>
 </li>
 <li>
@@ -1443,7 +1443,7 @@
 <div><code>(> x y)</code></div>
 <div><code>(> x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums are in monotonically decreasing order,<br>  otherwise false.</p>
+  <p class="var-docstr">Returns non-nil if nums are in monotonically decreasing order,<br>  otherwise false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L814">source</a>
 </li>
 <li>
@@ -1454,7 +1454,7 @@
 <div><code>(>= x y)</code></div>
 <div><code>(>= x y & more)</code></div>
 </pre>
-  <p class="var-docstr">Returns non-nil if nums are in monotonically non-increasing order,<br>  otherwise false.</p>
+  <p class="var-docstr">Returns non-nil if nums are in monotonically non-increasing order,<br>  otherwise false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L827">source</a>
 </li>
 <li>
@@ -1463,7 +1463,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(alias alias namespace-sym)</code></div>
 </pre>
-  <p class="var-docstr">Add an alias in the current namespace to another<br>  namespace. Arguments are two symbols: the alias to be used, and<br>  the symbolic name of the target namespace. Use :as in the ns macro in preference<br>  to calling this directly.</p>
+  <p class="var-docstr">Add an alias in the current namespace to another<br>  namespace. Arguments are two symbols: the alias to be used, and<br>  the symbolic name of the target namespace. Use :as in the ns macro in preference<br>  to calling this directly.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2409">source</a>
 </li>
 <li>
@@ -1481,7 +1481,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(alter-meta! ref f & args)</code></div>
 </pre>
-  <p class="var-docstr">Atomically sets the metadata for a namespace/var/atom to be:<br><br>  (apply f its-current-meta args)<br><br>  f must be free of side-effects</p>
+  <p class="var-docstr">Atomically sets the metadata for a namespace/var/atom to be:<br><br>  (apply f its-current-meta args)<br><br>  f must be free of side-effects</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1491">source</a>
 </li>
 <li>
@@ -1492,7 +1492,7 @@
 <div><code>(and x)</code></div>
 <div><code>(and x & next)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates exprs one at a time, from left to right. If a form<br>  returns logical false (nil or false), and returns that value and<br>  doesn't evaluate any of the other expressions, otherwise it returns<br>  the value of the last expr. (and) returns true.</p>
+  <p class="var-docstr">Evaluates exprs one at a time, from left to right. If a form<br>  returns logical false (nil or false), and returns that value and<br>  doesn't evaluate any of the other expressions, otherwise it returns<br>  the value of the last expr. (and) returns true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L628">source</a>
 </li>
 <li>
@@ -1523,7 +1523,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(array-map & keyvals)</code></div>
 </pre>
-  <p class="var-docstr">Constructs an array-map. If any keys are equal, they are handled as<br>         if by repeated uses of assoc.</p>
+  <p class="var-docstr">Constructs an array-map. If any keys are equal, they are handled as<br>         if by repeated uses of assoc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2477">source</a>
 </li>
 <li>
@@ -1532,7 +1532,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(as-> expr name & forms)</code></div>
 </pre>
-  <p class="var-docstr">Binds name to expr, evaluates the first form in the lexical context<br>  of that binding, then binds name to that result, repeating for each<br>  successive form, returning the result of the last form.</p>
+  <p class="var-docstr">Binds name to expr, evaluates the first form in the lexical context<br>  of that binding, then binds name to that result, repeating for each<br>  successive form, returning the result of the last form.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4124">source</a>
 </li>
 <li>
@@ -1542,7 +1542,7 @@
   <pre class="var-usage"><div><code>(assert x)</code></div>
 <div><code>(assert x message)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates expr and throws an exception if it does not evaluate to<br>  logical true.</p>
+  <p class="var-docstr">Evaluates expr and throws an exception if it does not evaluate to<br>  logical true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2897">source</a>
 </li>
 <li>
@@ -1552,7 +1552,7 @@
   <pre class="var-usage"><div><code>(assoc map key val)</code></div>
 <div><code>(assoc map key val & kvs)</code></div>
 </pre>
-  <p class="var-docstr">`assoc[iate]. When applied to a map, returns a new map of the<br>         same (hashed/sorted) type, that contains the mapping of key(s) to<br>         val(s). When applied to a vector, returns a new vector that<br>         contains val at index. Note - index must be <= (count vector).</p>
+  <p class="var-docstr">`assoc[iate]. When applied to a map, returns a new map of the<br>         same (hashed/sorted) type, that contains the mapping of key(s) to<br>         val(s). When applied to a vector, returns a new vector that<br>         contains val at index. Note - index must be <= (count vector).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L164">source</a>
 </li>
 <li>
@@ -1561,7 +1561,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(assoc-in m ks v)</code></div>
 </pre>
-  <p class="var-docstr">Associates a value in a nested associative structure, where ks is a<br>  sequence of keys and v is the new value and returns a new nested structure.<br>  If any levels do not exist, hash-maps will be created.</p>
+  <p class="var-docstr">Associates a value in a nested associative structure, where ks is a<br>  sequence of keys and v is the new value and returns a new nested structure.<br>  If any levels do not exist, hash-maps will be created.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3495">source</a>
 </li>
 <li>
@@ -1579,7 +1579,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(atom x & options)</code></div>
 </pre>
-  <p class="var-docstr">Creates and returns an Atom with an initial value of x and zero or<br>  more options (in any order):<br><br>  :meta metadata-map<br><br>  If metadata-map is supplied, it will become the metadata on the<br>  atom.</p>
+  <p class="var-docstr">Creates and returns an Atom with an initial value of x and zero or<br>  more options (in any order):<br><br>  :meta metadata-map<br><br>  If metadata-map is supplied, it will become the metadata on the<br>  atom.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1448">source</a>
 </li>
 <li>
@@ -1615,7 +1615,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(binding bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">binding => var-symbol init-expr<br><br>  Creates new bindings for the (already-existing) vars, with the<br>  supplied initial values, executes the exprs in an implicit do, then<br>  re-establishes the bindings that existed before.  The new bindings<br>  are made in parallel (unlike let); all init-exprs are evaluated<br>  before the vars are bound to their new values.</p>
+  <p class="var-docstr">binding => var-symbol init-expr<br><br>  Creates new bindings for the (already-existing) vars, with the<br>  supplied initial values, executes the exprs in an implicit do, then<br>  re-establishes the bindings that existed before.  The new bindings<br>  are made in parallel (unlike let); all init-exprs are evaluated<br>  before the vars are bound to their new values.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1413">source</a>
 </li>
 <li>
@@ -1745,7 +1745,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(bound? & vars)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if all of the vars provided as arguments have any bound value.<br>  Implies that deref'ing the provided vars will succeed. Returns true if no vars are provided.</p>
+  <p class="var-docstr">Returns true if all of the vars provided as arguments have any bound value.<br>  Implies that deref'ing the provided vars will succeed. Returns true if no vars are provided.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3089">source</a>
 </li>
 <li>
@@ -1754,7 +1754,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(bounded-count n coll)</code></div>
 </pre>
-  <p class="var-docstr">If coll is counted? returns its count, else will count at most the first n<br>  elements of coll using its seq</p>
+  <p class="var-docstr">If coll is counted? returns its count, else will count at most the first n<br>  elements of coll using its seq</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3960">source</a>
 </li>
 <li>
@@ -1772,7 +1772,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(callable? x)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if x implements Callable. Note that many data structures<br>  (e.g. sets and maps) implement Callable.</p>
+  <p class="var-docstr">Returns true if x implements Callable. Note that many data structures<br>  (e.g. sets and maps) implement Callable.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3553">source</a>
 </li>
 <li>
@@ -1781,7 +1781,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(case expr & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes an expression, and a set of clauses.<br><br>  Each clause can take the form of either:<br><br>  test-expr result-expr<br><br>  (test-expr ... test-expr)  result-expr<br><br>  If the expression is equal to a value of<br>  test-expr, the corresponding result-expr is returned. A single<br>  default expression can follow the clauses, and its value will be<br>  returned if no clause matches. If no default expression is provided<br>  and no clause matches, an exception is thrown.</p>
+  <p class="var-docstr">Takes an expression, and a set of clauses.<br><br>  Each clause can take the form of either:<br><br>  test-expr result-expr<br><br>  (test-expr ... test-expr)  result-expr<br><br>  If the expression is equal to a value of<br>  test-expr, the corresponding result-expr is returned. A single<br>  default expression can follow the clauses, and its value will be<br>  returned if no clause matches. If no default expression is provided<br>  and no clause matches, an exception is thrown.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3777">source</a>
 </li>
 <li>
@@ -1857,7 +1857,7 @@
 <div><code>(comp f g h)</code></div>
 <div><code>(comp f1 f2 f3 & fs)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of functions and returns a fn that is the composition<br>  of those fns.  The returned fn takes a variable number of args,<br>  applies the rightmost of fns to the args, the next<br>  fn (right-to-left) to the result, etc.</p>
+  <p class="var-docstr">Takes a set of functions and returns a fn that is the composition<br>  of those fns.  The returned fn takes a variable number of args,<br>  applies the rightmost of fns to the args, the next<br>  fn (right-to-left) to the result, etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1512">source</a>
 </li>
 <li>
@@ -1866,7 +1866,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(compare x y)</code></div>
 </pre>
-  <p class="var-docstr">Comparator. Returns a negative number, zero, or a positive number<br>  when x is logically 'less than', 'equal to', or 'greater than'<br>  y. Works for nil, and compares numbers and collections in a type-independent manner. x<br>  must implement Comparable</p>
+  <p class="var-docstr">Comparator. Returns a negative number, zero, or a positive number<br>  when x is logically 'less than', 'equal to', or 'greater than'<br>  y. Works for nil, and compares numbers and collections in a type-independent manner. x<br>  must implement Comparable</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L620">source</a>
 </li>
 <li>
@@ -1875,7 +1875,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(complement f)</code></div>
 </pre>
-  <p class="var-docstr">Takes a fn f and returns a fn that takes the same arguments as f,<br>  has the same effects, if any, and returns the opposite truth value.</p>
+  <p class="var-docstr">Takes a fn f and returns a fn that takes the same arguments as f,<br>  has the same effects, if any, and returns the opposite truth value.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1026">source</a>
 </li>
 <li>
@@ -1896,7 +1896,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(cond & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of test/expr pairs. It evaluates each test one at a<br>  time.  If a test returns logical true, cond evaluates and returns<br>  the value of the corresponding expr and doesn't evaluate any of the<br>  other tests or exprs. (cond) returns nil.</p>
+  <p class="var-docstr">Takes a set of test/expr pairs. It evaluates each test one at a<br>  time.  If a test returns logical true, cond evaluates and returns<br>  the value of the corresponding expr and doesn't evaluate any of the<br>  other tests or exprs. (cond) returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L456">source</a>
 </li>
 <li>
@@ -1905,7 +1905,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(cond-> expr & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes an expression and a set of test/form pairs. Threads expr (via ->)<br>  through each form for which the corresponding test<br>  expression is true. Note that, unlike cond branching, cond-> threading does<br>  not short circuit after the first true test expression.</p>
+  <p class="var-docstr">Takes an expression and a set of test/form pairs. Threads expr (via ->)<br>  through each form for which the corresponding test<br>  expression is true. Note that, unlike cond branching, cond-> threading does<br>  not short circuit after the first true test expression.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4080">source</a>
 </li>
 <li>
@@ -1914,7 +1914,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(cond->> expr & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes an expression and a set of test/form pairs. Threads expr (via ->>)<br>  through each form for which the corresponding test expression<br>  is true.  Note that, unlike cond branching, cond->> threading does not short circuit<br>  after the first true test expression.</p>
+  <p class="var-docstr">Takes an expression and a set of test/form pairs. Threads expr (via ->>)<br>  through each form for which the corresponding test expression<br>  is true.  Note that, unlike cond branching, cond->> threading does not short circuit<br>  after the first true test expression.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4102">source</a>
 </li>
 <li>
@@ -1923,7 +1923,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(condp pred expr & clauses)</code></div>
 </pre>
-  <p class="var-docstr">Takes a binary predicate, an expression, and a set of clauses.<br>  Each clause can take the form of either:<br><br>  test-expr result-expr<br><br>  test-expr :>> result-fn<br><br>  Note :>> is an ordinary keyword.<br><br>  For each clause, (pred test-expr expr) is evaluated. If it returns<br>  logical true, the clause is a match. If a binary clause matches, the<br>  result-expr is returned, if a ternary clause matches, its result-fn,<br>  which must be a unary function, is called with the result of the<br>  predicate as its argument, the result of that call being the return<br>  value of condp. A single default expression can follow the clauses,<br>  and its value will be returned if no clause matches. If no default<br>  expression is provided and no clause matches, an<br>  exception is thrown.</p>
+  <p class="var-docstr">Takes a binary predicate, an expression, and a set of clauses.<br>  Each clause can take the form of either:<br><br>  test-expr result-expr<br><br>  test-expr :>> result-fn<br><br>  Note :>> is an ordinary keyword.<br><br>  For each clause, (pred test-expr expr) is evaluated. If it returns<br>  logical true, the clause is a match. If a binary clause matches, the<br>  result-expr is returned, if a ternary clause matches, its result-fn,<br>  which must be a unary function, is called with the result of the<br>  predicate as its argument, the result of that call being the return<br>  value of condp. A single default expression can follow the clauses,<br>  and its value will be returned if no clause matches. If no default<br>  expression is provided and no clause matches, an<br>  exception is thrown.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3651">source</a>
 </li>
 <li>
@@ -1933,7 +1933,7 @@
   <pre class="var-usage"><div><code>(conj coll x)</code></div>
 <div><code>(conj coll x & xs)</code></div>
 </pre>
-  <p class="var-docstr">conj[oin]. Returns a new collection with the xs<br>         'added'. (conj nil item) returns (item).  The 'addition' may<br>         happen at different 'places' depending on the concrete type.</p>
+  <p class="var-docstr">conj[oin]. Returns a new collection with the xs<br>         'added'. (conj nil item) returns (item).  The 'addition' may<br>         happen at different 'places' depending on the concrete type.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L70">source</a>
 </li>
 <li>
@@ -1942,7 +1942,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(cons x seq)</code></div>
 </pre>
-  <p class="var-docstr">Returns a new seq where x is the first element and seq is<br>         the rest.</p>
+  <p class="var-docstr">Returns a new seq where x is the first element and seq is<br>         the rest.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L20">source</a>
 </li>
 <li>
@@ -1960,7 +1960,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(contains? coll key)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if key is present in the given collection, otherwise<br>  returns false.  Note that for numerically indexed collections like<br>  vectors, this tests if the numeric key is within the<br>  range of indexes. 'contains?' operates constant or logarithmic time;<br>  it will not perform a linear search for a value.  See also 'some'.</p>
+  <p class="var-docstr">Returns true if key is present in the given collection, otherwise<br>  returns false.  Note that for numerically indexed collections like<br>  vectors, this tests if the numeric key is within the<br>  range of indexes. 'contains?' operates constant or logarithmic time;<br>  it will not perform a linear search for a value.  See also 'some'.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1062">source</a>
 </li>
 <li>
@@ -1969,7 +1969,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(count coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns the number of items in the collection. (count nil) returns<br>  0.  Also works on strings</p>
+  <p class="var-docstr">Returns the number of items in the collection. (count nil) returns<br>  0.  Also works on strings</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L657">source</a>
 </li>
 <li>
@@ -1987,7 +1987,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(create-ns sym)</code></div>
 </pre>
-  <p class="var-docstr">Create a new namespace named by the symbol if one doesn't already<br>  exist, returns it or the already-existing namespace of the same<br>  name.</p>
+  <p class="var-docstr">Create a new namespace named by the symbol if one doesn't already<br>  exist, returns it or the already-existing namespace of the same<br>  name.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2255">source</a>
 </li>
 <li>
@@ -2005,7 +2005,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(dec x)</code></div>
 </pre>
-  <p class="var-docstr">Returns a number one less than num. Does not auto-promote<br>  ints, will overflow. See also: dec'</p>
+  <p class="var-docstr">Returns a number one less than num. Does not auto-promote<br>  ints, will overflow. See also: dec'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L875">source</a>
 </li>
 <li>
@@ -2014,7 +2014,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(dec' x)</code></div>
 </pre>
-  <p class="var-docstr">Returns a number one less than num. Supports arbitrary precision.<br>  See also: dec</p>
+  <p class="var-docstr">Returns a number one less than num. Supports arbitrary precision.<br>  See also: dec</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L869">source</a>
 </li>
 <li>
@@ -2040,7 +2040,7 @@
   <span class="var-type ArrayMap">ArrayMap</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
-  <p class="var-docstr">Default map of data reader functions provided by Joker. May be<br>  overridden by binding *data-readers*.</p>
+  <p class="var-docstr">Default map of data reader functions provided by Joker. May be<br>  overridden by binding *data-readers*.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4194">source</a>
 </li>
 <li>
@@ -2050,7 +2050,7 @@
   <pre class="var-usage"><div><code>(defmacro name doc-string? attr-map? [params*] body)</code></div>
 <div><code>(defmacro name doc-string? attr-map? ([params*] body) + attr-map?)</code></div>
 </pre>
-  <p class="var-docstr">Like defn, but the resulting function name is declared as a<br>         macro and will be used as a macro by the compiler when it is<br>         called.</p>
+  <p class="var-docstr">Like defn, but the resulting function name is declared as a<br>         macro and will be used as a macro by the compiler when it is<br>         called.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L323">source</a>
 </li>
 <li>
@@ -2068,7 +2068,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(defmulti name docstring? attr-map? dispatch-fn & options)</code></div>
 </pre>
-  <p class="var-docstr">Creates a new multimethod with the associated dispatch function.<br>  The docstring and attr-map are optional.<br><br>  Options are key-value pairs and may be one of:<br><br>  :default<br><br>  The default dispatch value, defaults to :default<br><br>  :hierarchy (UNSUPPORTED)<br><br>  The value used for hierarchical dispatch (e.g. ::square is-a ::shape)<br><br>  Hierarchies are type-like relationships that do not depend upon type<br>  inheritance. By default Clojure's multimethods dispatch off of a<br>  global hierarchy map.  However, a hierarchy relationship can be<br>  created with the derive function used to augment the root ancestor<br>  created with make-hierarchy.<br><br>  Multimethods expect the value of the hierarchy option to be supplied as<br>  a reference type e.g. a var (i.e. via the Var-quote dispatch macro #'<br>  or the var special form).</p>
+  <p class="var-docstr">Creates a new multimethod with the associated dispatch function.<br>  The docstring and attr-map are optional.<br><br>  Options are key-value pairs and may be one of:<br><br>  :default<br><br>  The default dispatch value, defaults to :default<br><br>  :hierarchy (UNSUPPORTED)<br><br>  The value used for hierarchical dispatch (e.g. ::square is-a ::shape)<br><br>  Hierarchies are type-like relationships that do not depend upon type<br>  inheritance. By default Clojure's multimethods dispatch off of a<br>  global hierarchy map.  However, a hierarchy relationship can be<br>  created with the derive function used to augment the root ancestor<br>  created with make-hierarchy.<br><br>  Multimethods expect the value of the hierarchy option to be supplied as<br>  a reference type e.g. a var (i.e. via the Var-quote dispatch macro #'<br>  or the var special form).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4237">source</a>
 </li>
 <li>
@@ -2078,7 +2078,7 @@
   <pre class="var-usage"><div><code>(defn name doc-string? attr-map? [params*] prepost-map? body)</code></div>
 <div><code>(defn name doc-string? attr-map? ([params*] prepost-map? body) + attr-map?)</code></div>
 </pre>
-  <p class="var-docstr">Same as (def name (fn [params* ] exprs*)) or (def<br>         name (fn ([params* ] exprs*)+)) with any doc-string or attrs added<br>         to the var metadata. prepost-map defines a map with optional keys<br>         :pre and :post that contain collections of pre or post conditions.</p>
+  <p class="var-docstr">Same as (def name (fn [params* ] exprs*)) or (def<br>         name (fn ([params* ] exprs*)+)) with any doc-string or attrs added<br>         to the var metadata. prepost-map defines a map with optional keys<br>         :pre and :post that contain collections of pre or post conditions.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L242">source</a>
 </li>
 <li>
@@ -2096,7 +2096,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(defonce name expr)</code></div>
 </pre>
-  <p class="var-docstr">defs name to have the value of the expr if the named var is not bound,<br>  else expr is unevaluated</p>
+  <p class="var-docstr">defs name to have the value of the expr if the named var is not bound,<br>  else expr is unevaluated</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3178">source</a>
 </li>
 <li>
@@ -2105,7 +2105,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(delay & body)</code></div>
 </pre>
-  <p class="var-docstr">Takes a body of expressions and yields a Delay object that will<br>  invoke the body only the first time it is forced (with force or deref/@), and<br>  will cache the result and return it on all subsequent force<br>  calls. See also - realized?</p>
+  <p class="var-docstr">Takes a body of expressions and yields a Delay object that will<br>  invoke the body only the first time it is forced (with force or deref/@), and<br>  will cache the result and return it on all subsequent force<br>  calls. See also - realized?</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L561">source</a>
 </li>
 <li>
@@ -2132,7 +2132,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(deref ref)</code></div>
 </pre>
-  <p class="var-docstr">Also reader macro: @var/@atom/@delay. When applied to a var or atom,<br>  returns its current state. When applied to a delay, forces<br>  it if not already forced.</p>
+  <p class="var-docstr">Also reader macro: @var/@atom/@delay. When applied to a var or atom,<br>  returns its current state. When applied to a delay, forces<br>  it if not already forced.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1440">source</a>
 </li>
 <li>
@@ -2143,7 +2143,7 @@
 <div><code>(disj set key)</code></div>
 <div><code>(disj set key & ks)</code></div>
 </pre>
-  <p class="var-docstr">disj[oin]. Returns a new set of the same (hashed/sorted) type, that<br>  does not contain key(s).</p>
+  <p class="var-docstr">disj[oin]. Returns a new set of the same (hashed/sorted) type, that<br>  does not contain key(s).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1092">source</a>
 </li>
 <li>
@@ -2154,7 +2154,7 @@
 <div><code>(dissoc map key)</code></div>
 <div><code>(dissoc map key & ks)</code></div>
 </pre>
-  <p class="var-docstr">dissoc[iate]. Returns a new map of the same (hashed/sorted) type,<br>  that does not contain a mapping for key(s).</p>
+  <p class="var-docstr">dissoc[iate]. Returns a new map of the same (hashed/sorted) type,<br>  that does not contain a mapping for key(s).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1079">source</a>
 </li>
 <li>
@@ -2184,7 +2184,7 @@
   <pre class="var-usage"><div><code>(doall coll)</code></div>
 <div><code>(doall n coll)</code></div>
 </pre>
-  <p class="var-docstr">When lazy sequences are produced via functions that have side<br>  effects, any effects other than those needed to produce the first<br>  element in the seq do not occur until the seq is consumed. doall can<br>  be used to force any effects. Walks through the successive nexts of<br>  the seq, retains the head and returns it, thus causing the entire<br>  seq to reside in memory at one time.</p>
+  <p class="var-docstr">When lazy sequences are produced via functions that have side<br>  effects, any effects other than those needed to produce the first<br>  element in the seq do not occur until the seq is consumed. doall can<br>  be used to force any effects. Walks through the successive nexts of<br>  the seq, retains the head and returns it, thus causing the entire<br>  seq to reside in memory at one time.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1885">source</a>
 </li>
 <li>
@@ -2194,7 +2194,7 @@
   <pre class="var-usage"><div><code>(dorun coll)</code></div>
 <div><code>(dorun n coll)</code></div>
 </pre>
-  <p class="var-docstr">When lazy sequences are produced via functions that have side<br>  effects, any effects other than those needed to produce the first<br>  element in the seq do not occur until the seq is consumed. dorun can<br>  be used to force any effects. Walks through the successive nexts of<br>  the seq, does not retain the head and returns nil.</p>
+  <p class="var-docstr">When lazy sequences are produced via functions that have side<br>  effects, any effects other than those needed to produce the first<br>  element in the seq do not occur until the seq is consumed. dorun can<br>  be used to force any effects. Walks through the successive nexts of<br>  the seq, does not retain the head and returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1871">source</a>
 </li>
 <li>
@@ -2203,7 +2203,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(doseq seq-exprs & body)</code></div>
 </pre>
-  <p class="var-docstr">Repeatedly executes body (presumably for side-effects) with<br>  bindings and filtering as provided by "for".  Does not retain<br>  the head of the sequence. Returns nil.</p>
+  <p class="var-docstr">Repeatedly executes body (presumably for side-effects) with<br>  bindings and filtering as provided by "for".  Does not retain<br>  the head of the sequence. Returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1946">source</a>
 </li>
 <li>
@@ -2212,7 +2212,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(dotimes bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">bindings => name n<br><br>  Repeatedly executes body (presumably for side-effects) with name<br>  bound to integers from 0 through n-1.</p>
+  <p class="var-docstr">bindings => name n<br><br>  Repeatedly executes body (presumably for side-effects) with name<br>  bound to integers from 0 through n-1.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1982">source</a>
 </li>
 <li>
@@ -2221,7 +2221,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(doto x & forms)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates x then calls all of the methods and functions with the<br>  value of x supplied at the front of the given arguments.  The forms<br>  are evaluated in order.  Returns x.</p>
+  <p class="var-docstr">Evaluates x then calls all of the methods and functions with the<br>  value of x supplied at the front of the given arguments.  The forms<br>  are evaluated in order.  Returns x.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2180">source</a>
 </li>
 <li>
@@ -2267,7 +2267,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(drop-while pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the items in coll starting from the first<br>  item for which (pred item) returns logical false.</p>
+  <p class="var-docstr">Returns a lazy sequence of the items in coll starting from the first<br>  item for which (pred item) returns logical false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1745">source</a>
 </li>
 <li>
@@ -2285,7 +2285,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(empty? coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if coll has no items - same as (not (seq coll)).<br>  Please use the idiom (seq x) rather than (not (empty? x))</p>
+  <p class="var-docstr">Returns true if coll has no items - same as (not (seq coll)).<br>  Please use the idiom (seq x) rather than (not (empty? x))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3692">source</a>
 </li>
 <li>
@@ -2315,7 +2315,7 @@
 <div><code>(every-pred p1 p2 p3)</code></div>
 <div><code>(every-pred p1 p2 p3 & ps)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of predicates and returns a function f that returns true if all of its<br>  composing predicates return a logical true value against all of its arguments, else it returns<br>  false. Note that f is short-circuiting in that it will stop execution on the first<br>  argument that triggers a logical false result against the original predicates.</p>
+  <p class="var-docstr">Takes a set of predicates and returns a function f that returns true if all of its<br>  composing predicates return a logical true value against all of its arguments, else it returns<br>  false. Note that f is short-circuiting in that it will stop execution on the first<br>  argument that triggers a logical false result against the original predicates.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3972">source</a>
 </li>
 <li>
@@ -2324,7 +2324,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(every? pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns true if (pred x) is logical true for every x in coll, else<br>  false.</p>
+  <p class="var-docstr">Returns true if (pred x) is logical true for every x in coll, else<br>  false.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1604">source</a>
 </li>
 <li>
@@ -2333,7 +2333,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(ex-cause ex)</code></div>
 </pre>
-  <p class="var-docstr">Returns the cause of ex if ex is an ExInfo.<br>  Otherwise returns nil.</p>
+  <p class="var-docstr">Returns the cause of ex if ex is an ExInfo.<br>  Otherwise returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2876">source</a>
 </li>
 <li>
@@ -2342,7 +2342,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(ex-data ex)</code></div>
 </pre>
-  <p class="var-docstr">Returns exception data (a map) if ex is an ExInfo.<br>  Otherwise returns nil.</p>
+  <p class="var-docstr">Returns exception data (a map) if ex is an ExInfo.<br>  Otherwise returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2868">source</a>
 </li>
 <li>
@@ -2361,7 +2361,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(ex-message ex)</code></div>
 </pre>
-  <p class="var-docstr">Returns the message attached to ex if ex is an ExInfo.<br>  Otherwise returns nil.</p>
+  <p class="var-docstr">Returns the message attached to ex if ex is an ExInfo.<br>  Otherwise returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2884">source</a>
 </li>
 <li>
@@ -2388,7 +2388,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(filter pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the items in coll for which<br>  (pred item) returns true. pred must be free of side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of the items in coll for which<br>  (pred item) returns true. pred must be free of side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1679">source</a>
 </li>
 <li>
@@ -2397,7 +2397,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(filterv pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a vector of the items in coll for which<br>  (pred item) returns true. pred must be free of side-effects.</p>
+  <p class="var-docstr">Returns a vector of the items in coll for which<br>  (pred item) returns true. pred must be free of side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3826">source</a>
 </li>
 <li>
@@ -2424,7 +2424,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(find-var sym)</code></div>
 </pre>
-  <p class="var-docstr">Returns the global var named by the namespace-qualified symbol, or<br>  nil if no var with that name.</p>
+  <p class="var-docstr">Returns the global var named by the namespace-qualified symbol, or<br>  nil if no var with that name.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1506">source</a>
 </li>
 <li>
@@ -2433,7 +2433,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(first coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns the first item in the collection. Calls seq on its<br>         argument. If coll is nil, returns nil.</p>
+  <p class="var-docstr">Returns the first item in the collection. Calls seq on its<br>         argument. If coll is nil, returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L49">source</a>
 </li>
 <li>
@@ -2442,7 +2442,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(flatten x)</code></div>
 </pre>
-  <p class="var-docstr">Takes any nested combination of sequential things (lists, vectors,<br>  etc.) and returns their contents as a single, flat sequence.<br>  (flatten nil) returns an empty sequence.</p>
+  <p class="var-docstr">Takes any nested combination of sequential things (lists, vectors,<br>  etc.) and returns their contents as a single, flat sequence.<br>  (flatten nil) returns an empty sequence.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3848">source</a>
 </li>
 <li>
@@ -2460,7 +2460,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(flush)</code></div>
 </pre>
-  <p class="var-docstr">Flushes the output stream that is the current value of<br>  *out*</p>
+  <p class="var-docstr">Flushes the output stream that is the current value of<br>  *out*</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2110">source</a>
 </li>
 <li>
@@ -2470,7 +2470,7 @@
   <pre class="var-usage"><div><code>(fn name? [params*] exprs*)</code></div>
 <div><code>(fn name? ([params*] exprs*) +)</code></div>
 </pre>
-  <p class="var-docstr">params => positional-params* , or positional-params* & next-param<br>  positional-param => binding-form<br>  next-param => binding-form<br>  name => symbol<br><br>  Defines a function</p>
+  <p class="var-docstr">params => positional-params* , or positional-params* & next-param<br>  positional-param => binding-form<br>  next-param => binding-form<br>  name => symbol<br><br>  Defines a function</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2615">source</a>
 </li>
 <li>
@@ -2499,7 +2499,7 @@
 <div><code>(fnil f x y)</code></div>
 <div><code>(fnil f x y z)</code></div>
 </pre>
-  <p class="var-docstr">Takes a function f, and returns a function that calls f, replacing<br>  a nil first argument to f with the supplied value x. Higher arity<br>  versions can replace arguments in the second and third<br>  positions (y, z). Note that the function f can take any number of<br>  arguments, not just the one(s) being nil-patched.</p>
+  <p class="var-docstr">Takes a function f, and returns a function that calls f, replacing<br>  a nil first argument to f with the supplied value x. Higher arity<br>  versions can replace arguments in the second and third<br>  positions (y, z). Note that the function f can take any number of<br>  arguments, not just the one(s) being nil-patched.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3741">source</a>
 </li>
 <li>
@@ -2508,7 +2508,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(for seq-exprs body-expr)</code></div>
 </pre>
-  <p class="var-docstr">List comprehension. Takes a vector of one or more<br>  binding-form/collection-expr pairs, each followed by zero or more<br>  modifiers, and yields a lazy sequence of evaluations of expr.<br>  Collections are iterated in a nested fashion, rightmost fastest,<br>  and nested coll-exprs can refer to bindings created in prior<br>  binding-forms.  Supported modifiers are: :let [binding-form expr ...],<br>  :while test, :when test.<br><br>  (take 100 (for [x (range 100000000) y (range 1000000) :while (< y x)]  [x y]))</p>
+  <p class="var-docstr">List comprehension. Takes a vector of one or more<br>  binding-form/collection-expr pairs, each followed by zero or more<br>  modifiers, and yields a lazy sequence of evaluations of expr.<br>  Collections are iterated in a nested fashion, rightmost fastest,<br>  and nested coll-exprs can refer to bindings created in prior<br>  binding-forms.  Supported modifiers are: :let [binding-form expr ...],<br>  :while test, :when test.<br><br>  (take 100 (for [x (range 100000000) y (range 1000000) :while (< y x)]  [x y]))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2731">source</a>
 </li>
 <li>
@@ -2535,7 +2535,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(frequencies coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a map from distinct items in coll to the number of times<br>  they appear.</p>
+  <p class="var-docstr">Returns a map from distinct items in coll to the number of times<br>  they appear.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3881">source</a>
 </li>
 <li>
@@ -2545,7 +2545,7 @@
   <pre class="var-usage"><div><code>(gensym)</code></div>
 <div><code>(gensym prefix-string)</code></div>
 </pre>
-  <p class="var-docstr">Returns a new symbol with a unique name. If a prefix string is<br>  supplied, the name is prefix# where # is some unique number. If<br>  prefix is not supplied, the prefix is 'G__'.</p>
+  <p class="var-docstr">Returns a new symbol with a unique name. If a prefix string is<br>  supplied, the name is prefix# where # is some unique number. If<br>  prefix is not supplied, the prefix is 'G__'.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L445">source</a>
 </li>
 <li>
@@ -2565,7 +2565,7 @@
   <pre class="var-usage"><div><code>(get-in m ks)</code></div>
 <div><code>(get-in m ks not-found)</code></div>
 </pre>
-  <p class="var-docstr">Returns the value in a nested associative structure,<br>  where ks is a sequence of keys. Returns nil if the key<br>  is not present, or the not-found value if supplied.</p>
+  <p class="var-docstr">Returns the value in a nested associative structure,<br>  where ks is a sequence of keys. Returns nil if the key<br>  is not present, or the not-found value if supplied.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3477">source</a>
 </li>
 <li>
@@ -2574,7 +2574,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(get-method multifn dispatch-val)</code></div>
 </pre>
-  <p class="var-docstr">Given a multimethod and a dispatch value, returns the dispatch fn<br>  that would apply to that value, or nil if none apply and no default</p>
+  <p class="var-docstr">Given a multimethod and a dispatch value, returns the dispatch fn<br>  that would apply to that value, or nil if none apply and no default</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4335">source</a>
 </li>
 <li>
@@ -2583,7 +2583,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(group-by f coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a map of the elements of coll keyed by the result of<br>  f on each element. The value at each key will be a vector of the<br>  corresponding elements, in the order they appeared in coll.</p>
+  <p class="var-docstr">Returns a map of the elements of coll keyed by the result of<br>  f on each element. The value at each key will be a vector of the<br>  corresponding elements, in the order they appeared in coll.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3857">source</a>
 </li>
 <li>
@@ -2601,7 +2601,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(hash-map & keyvals)</code></div>
 </pre>
-  <p class="var-docstr">keyval => key val<br>         Returns a new hash map with supplied mappings.  If any keys are<br>         equal, they are handled as if by repeated uses of assoc.</p>
+  <p class="var-docstr">keyval => key val<br>         Returns a new hash map with supplied mappings.  If any keys are<br>         equal, they are handled as if by repeated uses of assoc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L302">source</a>
 </li>
 <li>
@@ -2610,7 +2610,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(hash-set & keys)</code></div>
 </pre>
-  <p class="var-docstr">Returns a new hash set with supplied keys.  Any equal keys are<br>         handled as if by repeated uses of conj.</p>
+  <p class="var-docstr">Returns a new hash set with supplied keys.  Any equal keys are<br>         handled as if by repeated uses of conj.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L310">source</a>
 </li>
 <li>
@@ -2647,7 +2647,7 @@
   <pre class="var-usage"><div><code>(if-let bindings then)</code></div>
 <div><code>(if-let bindings then else & oldform)</code></div>
 </pre>
-  <p class="var-docstr">bindings => binding-form test<br><br>  If test is true, evaluates then with binding-form bound to the value of<br>  test, if not, yields else</p>
+  <p class="var-docstr">bindings => binding-form test<br><br>  If test is true, evaluates then with binding-form bound to the value of<br>  test, if not, yields else</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1257">source</a>
 </li>
 <li>
@@ -2657,7 +2657,7 @@
   <pre class="var-usage"><div><code>(if-not test then)</code></div>
 <div><code>(if-not test then else)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates test. If logical false, evaluates and returns then expr,<br>  otherwise else expr, if supplied, else nil.</p>
+  <p class="var-docstr">Evaluates test. If logical false, evaluates and returns then expr,<br>  otherwise else expr, if supplied, else nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L582">source</a>
 </li>
 <li>
@@ -2667,7 +2667,7 @@
   <pre class="var-usage"><div><code>(if-some bindings then)</code></div>
 <div><code>(if-some bindings then else & oldform)</code></div>
 </pre>
-  <p class="var-docstr">bindings => binding-form test<br><br>  If test is not nil, evaluates then with binding-form bound to the<br>  value of test, if not, yields else</p>
+  <p class="var-docstr">bindings => binding-form test<br><br>  If test is not nil, evaluates then with binding-form bound to the<br>  value of test, if not, yields else</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1299">source</a>
 </li>
 <li>
@@ -2685,7 +2685,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(inc x)</code></div>
 </pre>
-  <p class="var-docstr">Returns a number one greater than num. Does not auto-promote<br>  ints, will overflow. See also: inc'</p>
+  <p class="var-docstr">Returns a number one greater than num. Does not auto-promote<br>  ints, will overflow. See also: inc'</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L698">source</a>
 </li>
 <li>
@@ -2694,7 +2694,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(inc' x)</code></div>
 </pre>
-  <p class="var-docstr">Returns a number one greater than num. Supports arbitrary precision.<br>  See also: inc</p>
+  <p class="var-docstr">Returns a number one greater than num. Supports arbitrary precision.<br>  See also: inc</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L692">source</a>
 </li>
 <li>
@@ -2712,7 +2712,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(instance? c x)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates x and tests if it is an instance of type<br>         c. Returns true or false</p>
+  <p class="var-docstr">Evaluates x and tests if it is an instance of type<br>         c. Returns true or false</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L121">source</a>
 </li>
 <li>
@@ -2761,7 +2761,7 @@
   <pre class="var-usage"><div><code>(intern ns name)</code></div>
 <div><code>(intern ns name val)</code></div>
 </pre>
-  <p class="var-docstr">Finds or creates a var named by the symbol name in the namespace<br>  ns (which can be a symbol or a namespace), setting its root binding<br>  to val if supplied. The namespace must exist. The var will adopt any<br>  metadata from the name symbol.  Returns the var.</p>
+  <p class="var-docstr">Finds or creates a var named by the symbol name in the namespace<br>  ns (which can be a symbol or a namespace), setting its root binding<br>  to val if supplied. The namespace must exist. The var will adopt any<br>  metadata from the name symbol.  Returns the var.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2340">source</a>
 </li>
 <li>
@@ -2770,7 +2770,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(interpose sep coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy seq of the elements of coll separated by sep.<br>  Returns a stateful transducer when no collection is provided.</p>
+  <p class="var-docstr">Returns a lazy seq of the elements of coll separated by sep.<br>  Returns a stateful transducer when no collection is provided.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3076">source</a>
 </li>
 <li>
@@ -2779,7 +2779,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(into to from)</code></div>
 </pre>
-  <p class="var-docstr">Returns a new coll consisting of to-coll with all of the items of<br>  from-coll conjoined.</p>
+  <p class="var-docstr">Returns a new coll consisting of to-coll with all of the items of<br>  from-coll conjoined.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3803">source</a>
 </li>
 <li>
@@ -2809,7 +2809,7 @@
 <div><code>(juxt f g h)</code></div>
 <div><code>(juxt f g h & fs)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of functions and returns a fn that is the juxtaposition<br>  of those fns.  The returned fn takes a variable number of args, and<br>  returns a vector containing the result of applying each fn to the<br>  args (left-to-right).<br>  ((juxt a b c) x) => [(a x) (b x) (c x)]</p>
+  <p class="var-docstr">Takes a set of functions and returns a fn that is the juxtaposition<br>  of those fns.  The returned fn takes a variable number of args, and<br>  returns a vector containing the result of applying each fn to the<br>  args (left-to-right).<br>  ((juxt a b c) x) => [(a x) (b x) (c x)]</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1542">source</a>
 </li>
 <li>
@@ -2818,7 +2818,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(keep f coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the non-nil results of (f item). Note,<br>  this means false return values will be included.  f must be free of<br>  side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of the non-nil results of (f item). Note,<br>  this means false return values will be included.  f must be free of<br>  side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3932">source</a>
 </li>
 <li>
@@ -2827,7 +2827,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(keep-indexed f coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the non-nil results of (f index item). Note,<br>  this means false return values will be included.  f must be free of<br>  side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of the non-nil results of (f index item). Note,<br>  this means false return values will be included.  f must be free of<br>  side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3945">source</a>
 </li>
 <li>
@@ -2855,7 +2855,7 @@
   <pre class="var-usage"><div><code>(keyword name)</code></div>
 <div><code>(keyword ns name)</code></div>
 </pre>
-  <p class="var-docstr">Returns a Keyword with the given namespace and name.  Do not use :<br>  in the keyword strings, it will be added automatically.</p>
+  <p class="var-docstr">Returns a Keyword with the given namespace and name.  Do not use :<br>  in the keyword strings, it will be added automatically.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L473">source</a>
 </li>
 <li>
@@ -2882,7 +2882,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(lazy-cat & colls)</code></div>
 </pre>
-  <p class="var-docstr">Expands to code which yields a lazy sequence of the concatenation<br>  of the supplied colls.  Each coll expr is not evaluated until it is<br>  needed.<br><br>  (lazy-cat xs ys zs) === (concat (lazy-seq xs) (lazy-seq ys) (lazy-seq zs))</p>
+  <p class="var-docstr">Expands to code which yields a lazy sequence of the concatenation<br>  of the supplied colls.  Each coll expr is not evaluated until it is<br>  needed.<br><br>  (lazy-cat xs ys zs) === (concat (lazy-seq xs) (lazy-seq ys) (lazy-seq zs))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2721">source</a>
 </li>
 <li>
@@ -2891,7 +2891,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(lazy-seq & body)</code></div>
 </pre>
-  <p class="var-docstr">Takes a body of expressions that returns an ISeq or nil, and yields<br>  a Seqable object that will invoke the body only the first time seq<br>  is called, and will cache the result and return it on all subsequent<br>  seq calls. See also - realized?</p>
+  <p class="var-docstr">Takes a body of expressions that returns an ISeq or nil, and yields<br>  a Seqable object that will invoke the body only the first time seq<br>  is called, and will cache the result and return it on all subsequent<br>  seq calls. See also - realized?</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L524">source</a>
 </li>
 <li>
@@ -2900,7 +2900,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(let [bindings*] exprs*)</code></div>
 </pre>
-  <p class="var-docstr">binding => binding-form init-expr<br><br>  Evaluates the exprs in a lexical context in which the symbols in<br>  the binding-forms are bound to their respective init-exprs or parts<br>  therein.</p>
+  <p class="var-docstr">binding => binding-form init-expr<br><br>  Evaluates the exprs in a lexical context in which the symbols in<br>  the binding-forms are bound to their respective init-exprs or parts<br>  therein.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2583">source</a>
 </li>
 <li>
@@ -2922,7 +2922,7 @@
 <div><code>(list* a b c args)</code></div>
 <div><code>(list* a b c d & more)</code></div>
 </pre>
-  <p class="var-docstr">Creates a new list containing the items prepended to the rest, the<br>  last of which will be treated as a sequence.</p>
+  <p class="var-docstr">Creates a new list containing the items prepended to the rest, the<br>  last of which will be treated as a sequence.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L492">source</a>
 </li>
 <li>
@@ -2958,7 +2958,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(load-string s)</code></div>
 </pre>
-  <p class="var-docstr">Sequentially read and evaluate the set of forms contained in the<br>  string</p>
+  <p class="var-docstr">Sequentially read and evaluate the set of forms contained in the<br>  string</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2221">source</a>
 </li>
 <li>
@@ -2976,7 +2976,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(loop [bindings*] exprs*)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates the exprs in a lexical context in which the symbols in<br>  the binding-forms are bound to their respective init-exprs or parts<br>  therein. Acts as a recur target.</p>
+  <p class="var-docstr">Evaluates the exprs in a lexical context in which the symbols in<br>  the binding-forms are bound to their respective init-exprs or parts<br>  therein. Acts as a recur target.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2680">source</a>
 </li>
 <li>
@@ -2985,7 +2985,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(macroexpand form)</code></div>
 </pre>
-  <p class="var-docstr">Repeatedly calls macroexpand-1 on form until it no longer<br>  represents a macro form, then returns it.  Note neither<br>  macroexpand-1 nor macroexpand expand macros in subforms.</p>
+  <p class="var-docstr">Repeatedly calls macroexpand-1 on form until it no longer<br>  represents a macro form, then returns it.  Note neither<br>  macroexpand-1 nor macroexpand expand macros in subforms.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2210">source</a>
 </li>
 <li>
@@ -3006,7 +3006,7 @@
 <div><code>(map f c1 c2 c3)</code></div>
 <div><code>(map f c1 c2 c3 & colls)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence consisting of the result of applying f to the<br>  set of first items of each coll, followed by applying f to the set<br>  of second items in each coll, until any one of the colls is<br>  exhausted.  Any remaining items in other colls are ignored. Function<br>  f should accept number-of-colls arguments.</p>
+  <p class="var-docstr">Returns a lazy sequence consisting of the result of applying f to the<br>  set of first items of each coll, followed by applying f to the set<br>  of second items in each coll, until any one of the colls is<br>  exhausted.  Any remaining items in other colls are ignored. Function<br>  f should accept number-of-colls arguments.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1641">source</a>
 </li>
 <li>
@@ -3015,7 +3015,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(map-indexed f coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence consisting of the result of applying f to 0<br>  and the first item of coll, followed by applying f to 1 and the second<br>  item in coll, etc, until coll is exhausted. Thus function f should<br>  accept 2 arguments, index and item.</p>
+  <p class="var-docstr">Returns a lazy sequence consisting of the result of applying f to 0<br>  and the first item of coll, followed by applying f to 1 and the second<br>  item in coll, etc, until coll is exhausted. Thus function f should<br>  accept 2 arguments, index and item.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3919">source</a>
 </li>
 <li>
@@ -3033,7 +3033,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(mapcat f & colls)</code></div>
 </pre>
-  <p class="var-docstr">Returns the result of applying concat to the result of applying map<br>  to f and colls.  Thus function f should return a collection.</p>
+  <p class="var-docstr">Returns the result of applying concat to the result of applying map<br>  to f and colls.  Thus function f should return a collection.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1672">source</a>
 </li>
 <li>
@@ -3045,7 +3045,7 @@
 <div><code>(mapv f c1 c2 c3)</code></div>
 <div><code>(mapv f c1 c2 c3 & colls)</code></div>
 </pre>
-  <p class="var-docstr">Returns a vector consisting of the result of applying f to the<br>  set of first items of each coll, followed by applying f to the set<br>  of second items in each coll, until any one of the colls is<br>  exhausted.  Any remaining items in other colls are ignored. Function<br>  f should accept number-of-colls arguments.</p>
+  <p class="var-docstr">Returns a vector consisting of the result of applying f to the<br>  set of first items of each coll, followed by applying f to the set<br>  of second items in each coll, until any one of the colls is<br>  exhausted.  Any remaining items in other colls are ignored. Function<br>  f should accept number-of-colls arguments.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3810">source</a>
 </li>
 <li>
@@ -3076,7 +3076,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(memoize f)</code></div>
 </pre>
-  <p class="var-docstr">Returns a memoized version of a referentially transparent function. The<br>  memoized version of the function keeps a cache of the mapping from arguments<br>  to results and, when calls with the same arguments are repeated often, has<br>  higher performance at the expense of higher memory use.</p>
+  <p class="var-docstr">Returns a memoized version of a referentially transparent function. The<br>  memoized version of the function keeps a cache of the mapping from arguments<br>  to results and, when calls with the same arguments are repeated often, has<br>  higher performance at the expense of higher memory use.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3636">source</a>
 </li>
 <li>
@@ -3085,7 +3085,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(merge & maps)</code></div>
 </pre>
-  <p class="var-docstr">Returns a map that consists of the rest of the maps conj-ed onto<br>  the first.  If a key occurs in more than one map, the mapping from<br>  the latter (left-to-right) will be the mapping in the result.</p>
+  <p class="var-docstr">Returns a map that consists of the rest of the maps conj-ed onto<br>  the first.  If a key occurs in more than one map, the mapping from<br>  the latter (left-to-right) will be the mapping in the result.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1807">source</a>
 </li>
 <li>
@@ -3094,7 +3094,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(merge-with f & maps)</code></div>
 </pre>
-  <p class="var-docstr">Returns a map that consists of the rest of the maps conj-ed onto<br>  the first.  If a key occurs in more than one map, the mapping(s)<br>  from the latter (left-to-right) will be combined with the mapping in<br>  the result by calling (f val-in-result val-in-latter).</p>
+  <p class="var-docstr">Returns a map that consists of the rest of the maps conj-ed onto<br>  the first.  If a key occurs in more than one map, the mapping(s)<br>  from the latter (left-to-right) will be combined with the mapping in<br>  the result by calling (f val-in-result val-in-latter).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1817">source</a>
 </li>
 <li>
@@ -3206,7 +3206,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(next coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a seq of the items after the first. Calls seq on its<br>         argument.  If there are no more items, returns nil.</p>
+  <p class="var-docstr">Returns a seq of the items after the first. Calls seq on its<br>         argument.  If there are no more items, returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L56">source</a>
 </li>
 <li>
@@ -3251,7 +3251,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(not-any? pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns false if (pred x) is logical true for any x in coll,<br>         else true.</p>
+  <p class="var-docstr">Returns false if (pred x) is logical true for any x in coll,<br>         else true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1633">source</a>
 </li>
 <li>
@@ -3269,7 +3269,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(not-every? pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns false if (pred x) is logical true for every x in<br>         coll, else true.</p>
+  <p class="var-docstr">Returns false if (pred x) is logical true for every x in<br>         coll, else true.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1615">source</a>
 </li>
 <li>
@@ -3289,7 +3289,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(ns name docstring? attr-map? references*)</code></div>
 </pre>
-  <p class="var-docstr">Sets *ns* to the namespace named by name (unevaluated), creating it<br>  if needed.  references can be zero or more of:<br>  (:require ...) (:use ...) (:load ...)<br>  with the syntax of require/use/load<br>  respectively, except the arguments are unevaluated and need not be<br>  quoted. Use of ns is preferred to<br>  individual calls to in-ns/require/use:<br><br>  (ns foo.bar<br>    (:require [my.lib1 :as lib1])<br>    (:use [my.lib2]))</p>
+  <p class="var-docstr">Sets *ns* to the namespace named by name (unevaluated), creating it<br>  if needed.  references can be zero or more of:<br>  (:require ...) (:use ...) (:load ...)<br>  with the syntax of require/use/load<br>  respectively, except the arguments are unevaluated and need not be<br>  quoted. Use of ns is preferred to<br>  individual calls to in-ns/require/use:<br><br>  (ns foo.bar<br>    (:require [my.lib1 :as lib1])<br>    (:use [my.lib2]))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3129">source</a>
 </li>
 <li>
@@ -3353,7 +3353,7 @@
   <pre class="var-usage"><div><code>(ns-resolve ns sym)</code></div>
 <div><code>(ns-resolve ns env sym)</code></div>
 </pre>
-  <p class="var-docstr">Returns the var or type to which a symbol will be resolved in the<br>  namespace (unless found in the environment), else nil.  Note that<br>  if the symbol is fully qualified, the var/Type to which it resolves<br>  need not be present in the namespace.</p>
+  <p class="var-docstr">Returns the var or type to which a symbol will be resolved in the<br>  namespace (unless found in the environment), else nil.  Note that<br>  if the symbol is fully qualified, the var/Type to which it resolves<br>  need not be present in the namespace.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2458">source</a>
 </li>
 <li>
@@ -3381,7 +3381,7 @@
   <pre class="var-usage"><div><code>(nth coll index)</code></div>
 <div><code>(nth coll index not-found)</code></div>
 </pre>
-  <p class="var-docstr">Returns the value at the index. get returns nil if index out of<br>  bounds, nth throws an exception unless not-found is supplied.  nth<br>  also works, in O(n) time, for strings and sequences.</p>
+  <p class="var-docstr">Returns the value at the index. get returns nil if index out of<br>  bounds, nth throws an exception unless not-found is supplied.  nth<br>  also works, in O(n) time, for strings and sequences.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L670">source</a>
 </li>
 <li>
@@ -3446,7 +3446,7 @@
 <div><code>(or x)</code></div>
 <div><code>(or x & next)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates exprs one at a time, from left to right. If a form<br>  returns a logical true value, or returns that value and doesn't<br>  evaluate any of the other expressions, otherwise it returns the<br>  value of the last expression. (or) returns nil.</p>
+  <p class="var-docstr">Evaluates exprs one at a time, from left to right. If a form<br>  returns a logical true value, or returns that value and doesn't<br>  evaluate any of the other expressions, otherwise it returns the<br>  value of the last expression. (or) returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L640">source</a>
 </li>
 <li>
@@ -3459,7 +3459,7 @@
 <div><code>(partial f arg1 arg2 arg3)</code></div>
 <div><code>(partial f arg1 arg2 arg3 & more)</code></div>
 </pre>
-  <p class="var-docstr">Takes a function f and fewer than the normal arguments to f, and<br>  returns a fn that takes a variable number of additional args. When<br>  called, the returned function calls f with args + additional args.</p>
+  <p class="var-docstr">Takes a function f and fewer than the normal arguments to f, and<br>  returns a fn that takes a variable number of additional args. When<br>  called, the returned function calls f with args + additional args.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1579">source</a>
 </li>
 <li>
@@ -3470,7 +3470,7 @@
 <div><code>(partition n step coll)</code></div>
 <div><code>(partition n step pad coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of lists of n items each, at offsets step<br>  apart. If step is not supplied, defaults to n, i.e. the partitions<br>  do not overlap. If a pad collection is supplied, use its elements as<br>  necessary to complete last partition upto n items. In case there are<br>  not enough padding elements, return a partition with less than n items.</p>
+  <p class="var-docstr">Returns a lazy sequence of lists of n items each, at offsets step<br>  apart. If step is not supplied, defaults to n, i.e. the partitions<br>  do not overlap. If a pad collection is supplied, use its elements as<br>  necessary to complete last partition upto n items. In case there are<br>  not enough padding elements, return a partition with less than n items.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1918">source</a>
 </li>
 <li>
@@ -3480,7 +3480,7 @@
   <pre class="var-usage"><div><code>(partition-all n coll)</code></div>
 <div><code>(partition-all n step coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of lists like partition, but may include<br>  partitions with fewer than n items at the end.</p>
+  <p class="var-docstr">Returns a lazy sequence of lists like partition, but may include<br>  partitions with fewer than n items at the end.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3765">source</a>
 </li>
 <li>
@@ -3489,7 +3489,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(partition-by f coll)</code></div>
 </pre>
-  <p class="var-docstr">Applies f to each value in coll, splitting it each time f returns a<br>  new value.  Returns a lazy seq of partitions.</p>
+  <p class="var-docstr">Applies f to each value in coll, splitting it each time f returns a<br>  new value.  Returns a lazy seq of partitions.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3869">source</a>
 </li>
 <li>
@@ -3498,7 +3498,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(peek coll)</code></div>
 </pre>
-  <p class="var-docstr">For a list, same as first, for a vector, same as, but much<br>  more efficient than, last. If the collection is empty, returns nil.</p>
+  <p class="var-docstr">For a list, same as first, for a vector, same as, but much<br>  more efficient than, last. If the collection is empty, returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1048">source</a>
 </li>
 <li>
@@ -3507,7 +3507,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(pop coll)</code></div>
 </pre>
-  <p class="var-docstr">For a list, returns a new list without the first<br>  item, for a vector, returns a new vector without the last item. If<br>  the collection is empty, throws an exception.  Note - not the same<br>  as next/butlast.</p>
+  <p class="var-docstr">For a list, returns a new list without the first<br>  item, for a vector, returns a new vector without the last item. If<br>  the collection is empty, throws an exception.  Note - not the same<br>  as next/butlast.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1054">source</a>
 </li>
 <li>
@@ -3543,7 +3543,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(pr & args)</code></div>
 </pre>
-  <p class="var-docstr">Prints the object(s) to the output stream that is the current value<br>         of *out*.  Prints the object(s), separated by spaces if there is<br>         more than one.  By default, pr and prn print in a way that objects<br>         can be read by the reader</p>
+  <p class="var-docstr">Prints the object(s) to the output stream that is the current value<br>         of *out*.  Prints the object(s), separated by spaces if there is<br>         more than one.  By default, pr and prn print in a way that objects<br>         can be read by the reader</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2089">source</a>
 </li>
 <li>
@@ -3570,7 +3570,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(prefer-method multifn dispatch-val-x dispatch-val-y)</code></div>
 </pre>
-  <p class="var-docstr">Causes the multimethod to prefer matches of dispatch-val-x over dispatch-val-y<br>   when there is a conflict</p>
+  <p class="var-docstr">Causes the multimethod to prefer matches of dispatch-val-x over dispatch-val-y<br>   when there is a conflict</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4320">source</a>
 </li>
 <li>
@@ -3588,7 +3588,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(print & more)</code></div>
 </pre>
-  <p class="var-docstr">Prints the object(s) to the output stream that is the current value<br>  of *out*.  print and println produce output for human consumption.</p>
+  <p class="var-docstr">Prints the object(s) to the output stream that is the current value<br>  of *out*.  print and println produce output for human consumption.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2135">source</a>
 </li>
 <li>
@@ -3715,7 +3715,7 @@
   <pre class="var-usage"><div><code>(rand)</code></div>
 <div><code>(rand n)</code></div>
 </pre>
-  <p class="var-docstr">Returns a random floating point number between 0 (inclusive) and<br>  n (default 1) (exclusive).</p>
+  <p class="var-docstr">Returns a random floating point number between 0 (inclusive) and<br>  n (default 1) (exclusive).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2953">source</a>
 </li>
 <li>
@@ -3733,7 +3733,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(rand-nth coll)</code></div>
 </pre>
-  <p class="var-docstr">Return a random element of the (sequential) collection. Will have<br>  the same performance characteristics as nth for the given<br>  collection.</p>
+  <p class="var-docstr">Return a random element of the (sequential) collection. Will have<br>  the same performance characteristics as nth for the given<br>  collection.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3905">source</a>
 </li>
 <li>
@@ -3742,7 +3742,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(random-sample prob coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns items from coll with random probability of prob (0.0 -<br>  1.0).</p>
+  <p class="var-docstr">Returns items from coll with random probability of prob (0.0 -<br>  1.0).</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4179">source</a>
 </li>
 <li>
@@ -3754,7 +3754,7 @@
 <div><code>(range start end)</code></div>
 <div><code>(range start end step)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy seq of nums from start (inclusive) to end<br>  (exclusive), by step, where start defaults to 0, step to 1, and end to<br>  infinity. When step is equal to 0, returns an infinite sequence of<br>  start. When start is equal to end, returns empty list.</p>
+  <p class="var-docstr">Returns a lazy seq of nums from start (inclusive) to end<br>  (exclusive), by step, where start defaults to 0, step to 1, and end to<br>  infinity. When step is equal to 0, returns an infinite sequence of<br>  start. When start is equal to end, returns empty list.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1788">source</a>
 </li>
 <li>
@@ -3855,7 +3855,7 @@
   <pre class="var-usage"><div><code>(reduce f coll)</code></div>
 <div><code>(reduce f val coll)</code></div>
 </pre>
-  <p class="var-docstr">f should be a function of 2 arguments. If val is not supplied,<br>  returns the result of applying f to the first 2 items in coll, then<br>  applying f to that result and the 3rd item, etc. If coll contains no<br>  items, f must accept no arguments as well, and reduce returns the<br>  result of calling f with no arguments.  If coll has only 1 item, it<br>  is returned and f is not called.  If val is supplied, returns the<br>  result of applying f to val and the first item in coll, then<br>  applying f to that result and the 2nd item, etc. If coll contains no<br>  items, returns val and f is not called.</p>
+  <p class="var-docstr">f should be a function of 2 arguments. If val is not supplied,<br>  returns the result of applying f to the first 2 items in coll, then<br>  applying f to that result and the 3rd item, etc. If coll contains no<br>  items, f must accept no arguments as well, and reduce returns the<br>  result of calling f with no arguments.  If coll has only 1 item, it<br>  is returned and f is not called.  If val is supplied, returns the<br>  result of applying f to val and the first item in coll, then<br>  applying f to that result and the 2nd item, etc. If coll contains no<br>  items, returns val and f is not called.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L704">source</a>
 </li>
 <li>
@@ -3864,7 +3864,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(reduce-kv f init coll)</code></div>
 </pre>
-  <p class="var-docstr">Reduces an associative collection. f should be a function of 3<br>  arguments. Returns the result of applying f to init, the first key<br>  and the first value in coll, then applying f to that result and the<br>  2nd key and value, etc. If coll contains no entries, returns init<br>  and f is not called. Note that reduce-kv is supported on vectors,<br>  where the keys will be the ordinals.</p>
+  <p class="var-docstr">Reduces an associative collection. f should be a function of 3<br>  arguments. Returns the result of applying f to init, the first key<br>  and the first value in coll, then applying f to that result and the<br>  2nd key and value, etc. If coll contains no entries, returns init<br>  and f is not called. Note that reduce-kv is supported on vectors,<br>  where the keys will be the ordinals.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1348">source</a>
 </li>
 <li>
@@ -3874,7 +3874,7 @@
   <pre class="var-usage"><div><code>(reductions f coll)</code></div>
 <div><code>(reductions f init coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy seq of the intermediate values of the reduction (as<br>  per reduce) of coll by f, starting with init.</p>
+  <p class="var-docstr">Returns a lazy seq of the intermediate values of the reduction (as<br>  per reduce) of coll by f, starting with init.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3890">source</a>
 </li>
 <li>
@@ -3883,7 +3883,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(refer ns-sym & filters)</code></div>
 </pre>
-  <p class="var-docstr">refers to all public vars of ns, subject to filters.<br>  filters can include at most one each of:<br><br>  :exclude list-of-symbols<br>  :only list-of-symbols<br>  :rename map-of-fromsymbol-tosymbol<br><br>  For each public interned var in the namespace named by the symbol,<br>  adds a mapping from the name of the var to the var to the current<br>  namespace.  Throws an exception if name is already mapped to<br>  something else in the current namespace. Filters can be used to<br>  select a subset, via inclusion or exclusion, or to provide a mapping<br>  to a symbol different from the var's name, in order to prevent<br>  clashes. Use :use in the ns macro in preference to calling this directly.</p>
+  <p class="var-docstr">refers to all public vars of ns, subject to filters.<br>  filters can include at most one each of:<br><br>  :exclude list-of-symbols<br>  :only list-of-symbols<br>  :rename map-of-fromsymbol-tosymbol<br><br>  For each public interned var in the namespace named by the symbol,<br>  adds a mapping from the name of the var to the var to the current<br>  namespace.  Throws an exception if name is already mapped to<br>  something else in the current namespace. Filters can be used to<br>  select a subset, via inclusion or exclusion, or to provide a mapping<br>  to a symbol different from the var's name, in order to prevent<br>  clashes. Use :use in the ns macro in preference to calling this directly.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2357">source</a>
 </li>
 <li>
@@ -3910,7 +3910,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(remove pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the items in coll for which<br>  (pred item) returns false. pred must be free of side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of the items in coll for which<br>  (pred item) returns false. pred must be free of side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1691">source</a>
 </li>
 <li>
@@ -3937,7 +3937,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(remove-ns sym)</code></div>
 </pre>
-  <p class="var-docstr">Removes the namespace named by the symbol. Use with caution.<br>  Cannot be used to remove the clojure namespace.</p>
+  <p class="var-docstr">Removes the namespace named by the symbol. Use with caution.<br>  Cannot be used to remove the clojure namespace.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2262">source</a>
 </li>
 <li>
@@ -3957,7 +3957,7 @@
   <pre class="var-usage"><div><code>(repeatedly f)</code></div>
 <div><code>(repeatedly n f)</code></div>
 </pre>
-  <p class="var-docstr">Takes a function of no args, presumably with side effects, and<br>  returns an infinite (or length n if supplied) lazy sequence of calls<br>  to it</p>
+  <p class="var-docstr">Takes a function of no args, presumably with side effects, and<br>  returns an infinite (or length n if supplied) lazy sequence of calls<br>  to it</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3068">source</a>
 </li>
 <li>
@@ -3966,7 +3966,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(replace smap coll)</code></div>
 </pre>
-  <p class="var-docstr">Given a map of replacement pairs and a vector/collection, returns a<br>  vector/seq with any elements = a key in smap replaced with the<br>  corresponding val in smap.</p>
+  <p class="var-docstr">Given a map of replacement pairs and a vector/collection, returns a<br>  vector/seq with any elements = a key in smap replaced with the<br>  corresponding val in smap.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3054">source</a>
 </li>
 <li>
@@ -3975,7 +3975,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(require & args)</code></div>
 </pre>
-  <p class="var-docstr">Loads libs, skipping any that are already loaded. Each argument is<br>  either a libspec that identifies a lib, a prefix list that identifies<br>  multiple libs whose names share a common prefix, or a flag that modifies<br>  how all the identified libs are loaded. Use :require in the ns macro<br>  in preference to calling this directly.<br><br>  Libs<br><br>  A 'lib' is a named set of resources in classpath whose contents define a<br>  library of Clojure code. Lib names are symbols and each lib is associated<br>  with a Clojure namespace and a Java package that share its name. A lib's<br>  name also locates its root directory within classpath using Java's<br>  package name to classpath-relative path mapping. All resources in a lib<br>  should be contained in the directory structure under its root directory.<br>  All definitions a lib makes should be in its associated namespace.<br><br>  'require loads a lib by loading its root resource. The root resource path<br>  is derived from the lib name in the following manner:<br>  Consider a lib named by the symbol 'x.y.z; it has the root directory<br>  <classpath>/x/y/, and its root resource is <classpath>/x/y/z.clj. The root<br>  resource should contain code to create the lib's namespace (usually by using<br>  the ns macro) and load any additional lib resources.<br><br>  Libspecs<br><br>  A libspec is a lib name or a vector containing a lib name followed by<br>  options expressed as sequential keywords and arguments.<br><br>  Recognized options:<br>  :as takes a symbol as its argument and makes that symbol an alias to the<br>    lib's namespace in the current namespace.<br>  :refer takes a list of symbols to refer from the namespace or the :all<br>    keyword to bring in all public vars.<br><br>  Prefix Lists<br><br>  It's common for Clojure code to depend on several libs whose names have<br>  the same prefix. When specifying libs, prefix lists can be used to reduce<br>  repetition. A prefix list contains the shared prefix followed by libspecs<br>  with the shared prefix removed from the lib names. After removing the<br>  prefix, the names that remain must not contain any periods.<br><br>  Flags<br><br>  A flag is a keyword.<br>  Recognized flags: :reload, :reload-all, :verbose<br>  :reload forces loading of all the identified libs even if they are<br>    already loaded<br>  :reload-all implies :reload and also forces loading of all libs that the<br>    identified libs directly or indirectly load via require or use<br>  :verbose triggers printing information about each load, alias, and refer<br><br>  Example:<br><br>  The following would load the libraries clojure.zip and clojure.set<br>  abbreviated as 's'.<br><br>  (require '(clojure zip [set :as s]))</p>
+  <p class="var-docstr">Loads libs, skipping any that are already loaded. Each argument is<br>  either a libspec that identifies a lib, a prefix list that identifies<br>  multiple libs whose names share a common prefix, or a flag that modifies<br>  how all the identified libs are loaded. Use :require in the ns macro<br>  in preference to calling this directly.<br><br>  Libs<br><br>  A 'lib' is a named set of resources in classpath whose contents define a<br>  library of Clojure code. Lib names are symbols and each lib is associated<br>  with a Clojure namespace and a Java package that share its name. A lib's<br>  name also locates its root directory within classpath using Java's<br>  package name to classpath-relative path mapping. All resources in a lib<br>  should be contained in the directory structure under its root directory.<br>  All definitions a lib makes should be in its associated namespace.<br><br>  'require loads a lib by loading its root resource. The root resource path<br>  is derived from the lib name in the following manner:<br>  Consider a lib named by the symbol 'x.y.z; it has the root directory<br>  <classpath>/x/y/, and its root resource is <classpath>/x/y/z.clj. The root<br>  resource should contain code to create the lib's namespace (usually by using<br>  the ns macro) and load any additional lib resources.<br><br>  Libspecs<br><br>  A libspec is a lib name or a vector containing a lib name followed by<br>  options expressed as sequential keywords and arguments.<br><br>  Recognized options:<br>  :as takes a symbol as its argument and makes that symbol an alias to the<br>    lib's namespace in the current namespace.<br>  :refer takes a list of symbols to refer from the namespace or the :all<br>    keyword to bring in all public vars.<br><br>  Prefix Lists<br><br>  It's common for Clojure code to depend on several libs whose names have<br>  the same prefix. When specifying libs, prefix lists can be used to reduce<br>  repetition. A prefix list contains the shared prefix followed by libspecs<br>  with the shared prefix removed from the lib names. After removing the<br>  prefix, the names that remain must not contain any periods.<br><br>  Flags<br><br>  A flag is a keyword.<br>  Recognized flags: :reload, :reload-all, :verbose<br>  :reload forces loading of all the identified libs even if they are<br>    already loaded<br>  :reload-all implies :reload and also forces loading of all libs that the<br>    identified libs directly or indirectly load via require or use<br>  :verbose triggers printing information about each load, alias, and refer<br><br>  Example:<br><br>  The following would load the libraries clojure.zip and clojure.set<br>  abbreviated as 's'.<br><br>  (require '(clojure zip [set :as s]))</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3363">source</a>
 </li>
 <li>
@@ -3984,7 +3984,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(requiring-resolve sym)</code></div>
 </pre>
-  <p class="var-docstr">Resolves namespace-qualified sym per 'resolve'. If initial resolve<br>  fails, attempts to require sym's namespace and retries.</p>
+  <p class="var-docstr">Resolves namespace-qualified sym per 'resolve'. If initial resolve<br>  fails, attempts to require sym's namespace and retries.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3427">source</a>
 </li>
 <li>
@@ -3993,7 +3993,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(reset! atom newval)</code></div>
 </pre>
-  <p class="var-docstr">Sets the value of atom to newval without regard for the<br>  current value. Returns newval.</p>
+  <p class="var-docstr">Sets the value of atom to newval without regard for the<br>  current value. Returns newval.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1477">source</a>
 </li>
 <li>
@@ -4011,7 +4011,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(reset-vals! atom newval)</code></div>
 </pre>
-  <p class="var-docstr">Sets the value of atom to newval. Returns [old new], the value of the<br>  atom before and after the reset.</p>
+  <p class="var-docstr">Sets the value of atom to newval. Returns [old new], the value of the<br>  atom before and after the reset.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1484">source</a>
 </li>
 <li>
@@ -4030,7 +4030,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(rest coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a possibly empty seq of the items after the first. Calls seq on its<br>         argument.</p>
+  <p class="var-docstr">Returns a possibly empty seq of the items after the first. Calls seq on its<br>         argument.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L63">source</a>
 </li>
 <li>
@@ -4057,7 +4057,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(rseq rev)</code></div>
 </pre>
-  <p class="var-docstr">Returns, in constant time, a seq of the items in rev (which<br>  can be a vector or sorted-map), in reverse order. If rev is empty returns nil.</p>
+  <p class="var-docstr">Returns, in constant time, a seq of the items in rev (which<br>  can be a vector or sorted-map), in reverse order. If rev is empty returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1147">source</a>
 </li>
 <li>
@@ -4066,7 +4066,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(run! proc coll)</code></div>
 </pre>
-  <p class="var-docstr">Runs the supplied procedure (via reduce), for purposes of side<br>  effects, on successive items in the collection. Returns nil.</p>
+  <p class="var-docstr">Runs the supplied procedure (via reduce), for purposes of side<br>  effects, on successive items in the collection. Returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4186">source</a>
 </li>
 <li>
@@ -4093,7 +4093,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(seq coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a seq on the collection. If the collection is<br>         empty, returns nil.  (seq nil) returns nil.</p>
+  <p class="var-docstr">Returns a seq on the collection. If the collection is<br>         empty, returns nil.  (seq nil) returns nil.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L114">source</a>
 </li>
 <li>
@@ -4120,7 +4120,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(sequence coll)</code></div>
 </pre>
-  <p class="var-docstr">Coerces coll to a (possibly empty) sequence, if it is not already<br>  one. Will not force a lazy seq. (sequence nil) yields ()</p>
+  <p class="var-docstr">Coerces coll to a (possibly empty) sequence, if it is not already<br>  one. Will not force a lazy seq. (sequence nil) yields ()</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1594">source</a>
 </li>
 <li>
@@ -4201,7 +4201,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(some pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns the first logical true value of (pred x) for any x in coll,<br>  else nil.  One common idiom is to use a set as pred, for example<br>  this will return :fred if :fred is in the sequence, otherwise nil:<br>  (some #{:fred} coll)</p>
+  <p class="var-docstr">Returns the first logical true value of (pred x) for any x in coll,<br>  else nil.  One common idiom is to use a set as pred, for example<br>  this will return :fred if :fred is in the sequence, otherwise nil:<br>  (some #{:fred} coll)</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1623">source</a>
 </li>
 <li>
@@ -4210,7 +4210,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(some-> expr & forms)</code></div>
 </pre>
-  <p class="var-docstr">When expr is not nil, threads it into the first form (via ->),<br>  and when that result is not nil, through the next etc.</p>
+  <p class="var-docstr">When expr is not nil, threads it into the first form (via ->),<br>  and when that result is not nil, through the next etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4138">source</a>
 </li>
 <li>
@@ -4219,7 +4219,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(some->> expr & forms)</code></div>
 </pre>
-  <p class="var-docstr">When expr is not nil, threads it into the first form (via ->>),<br>  and when that result is not nil, through the next etc.</p>
+  <p class="var-docstr">When expr is not nil, threads it into the first form (via ->>),<br>  and when that result is not nil, through the next etc.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4154">source</a>
 </li>
 <li>
@@ -4231,7 +4231,7 @@
 <div><code>(some-fn p1 p2 p3)</code></div>
 <div><code>(some-fn p1 p2 p3 & ps)</code></div>
 </pre>
-  <p class="var-docstr">Takes a set of predicates and returns a function f that returns the first logical true value<br>  returned by one of its composing predicates against any of its arguments, else it returns<br>  logical false. Note that f is short-circuiting in that it will stop execution on the first<br>  argument that triggers a logical true result against the original predicates.</p>
+  <p class="var-docstr">Takes a set of predicates and returns a function f that returns the first logical true value<br>  returned by one of its composing predicates against any of its arguments, else it returns<br>  logical false. Note that f is short-circuiting in that it will stop execution on the first<br>  argument that triggers a logical true result against the original predicates.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L4012">source</a>
 </li>
 <li>
@@ -4250,7 +4250,7 @@
   <pre class="var-usage"><div><code>(sort coll)</code></div>
 <div><code>(sort comp coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a sorted sequence of the items in coll. If no comparator is<br>  supplied, uses compare.</p>
+  <p class="var-docstr">Returns a sorted sequence of the items in coll. If no comparator is<br>  supplied, uses compare.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1852">source</a>
 </li>
 <li>
@@ -4260,7 +4260,7 @@
   <pre class="var-usage"><div><code>(sort-by keyfn coll)</code></div>
 <div><code>(sort-by keyfn comp coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a sorted sequence of the items in coll, where the sort<br>  order is determined by comparing (keyfn item).  If no comparator is<br>  supplied, uses compare.</p>
+  <p class="var-docstr">Returns a sorted sequence of the items in coll, where the sort<br>  order is determined by comparing (keyfn item).  If no comparator is<br>  supplied, uses compare.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1861">source</a>
 </li>
 <li>
@@ -4278,7 +4278,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(spit f content)</code></div>
 </pre>
-  <p class="var-docstr">Opposite of slurp.  Opens file f, writes content, then<br>  closes f.</p>
+  <p class="var-docstr">Opposite of slurp.  Opens file f, writes content, then<br>  closes f.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3841">source</a>
 </li>
 <li>
@@ -4305,7 +4305,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(str & xs)</code></div>
 </pre>
-  <p class="var-docstr">With no args, returns the empty string. With one arg x, returns<br>         string representation of x. (str nil) returns the empty string. With more than<br>         one arg, returns the concatenation of the str values of the args.</p>
+  <p class="var-docstr">With no args, returns the empty string. With one arg x, returns<br>         string representation of x. (str nil) returns the empty string. With more than<br>         one arg, returns the concatenation of the str values of the args.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L418">source</a>
 </li>
 <li>
@@ -4324,7 +4324,7 @@
   <pre class="var-usage"><div><code>(subs s start)</code></div>
 <div><code>(subs s start end)</code></div>
 </pre>
-  <p class="var-docstr">Returns the substring of s beginning at start inclusive, and ending<br>  at end (defaults to length of string), exclusive.</p>
+  <p class="var-docstr">Returns the substring of s beginning at start inclusive, and ending<br>  at end (defaults to length of string), exclusive.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3017">source</a>
 </li>
 <li>
@@ -4334,7 +4334,7 @@
   <pre class="var-usage"><div><code>(subvec v start)</code></div>
 <div><code>(subvec v start end)</code></div>
 </pre>
-  <p class="var-docstr">Returns a persistent vector of the items in vector from<br>  start (inclusive) to end (exclusive).  If end is not supplied,<br>  defaults to (count vector). This operation is O(1) and very fast, as<br>  the resulting vector shares structure with the original and no<br>  trimming is done.</p>
+  <p class="var-docstr">Returns a persistent vector of the items in vector from<br>  start (inclusive) to end (exclusive).  If end is not supplied,<br>  defaults to (count vector). This operation is O(1) and very fast, as<br>  the resulting vector shares structure with the original and no<br>  trimming is done.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2168">source</a>
 </li>
 <li>
@@ -4343,7 +4343,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(swap! atom f & args)</code></div>
 </pre>
-  <p class="var-docstr">Atomically swaps the value of atom to be:<br>  (apply f current-value-of-atom args).<br>  Returns the value that was swapped in.</p>
+  <p class="var-docstr">Atomically swaps the value of atom to be:<br>  (apply f current-value-of-atom args).<br>  Returns the value that was swapped in.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1460">source</a>
 </li>
 <li>
@@ -4352,7 +4352,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(swap-vals! atom f & args)</code></div>
 </pre>
-  <p class="var-docstr">Atomically swaps the value of atom to be:<br>  (apply f current-value-of-atom args). Note that f may be called<br>  multiple times, and thus should be free of side effects.<br>  Returns [old new], the value of the atom before and after the swap.</p>
+  <p class="var-docstr">Atomically swaps the value of atom to be:<br>  (apply f current-value-of-atom args). Note that f may be called<br>  multiple times, and thus should be free of side effects.<br>  Returns [old new], the value of the atom before and after the swap.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1468">source</a>
 </li>
 <li>
@@ -4380,7 +4380,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(take n coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the first n items in coll, or all items if<br>  there are fewer than n.</p>
+  <p class="var-docstr">Returns a lazy sequence of the first n items in coll, or all items if<br>  there are fewer than n.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1698">source</a>
 </li>
 <li>
@@ -4389,7 +4389,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(take-last n coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a seq of the last n items in coll.  Depending on the type<br>  of coll may be no better than linear time.  For vectors, see also subvec.</p>
+  <p class="var-docstr">Returns a seq of the last n items in coll.  Depending on the type<br>  of coll may be no better than linear time.  For vectors, see also subvec.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1735">source</a>
 </li>
 <li>
@@ -4407,7 +4407,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(take-while pred coll)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of successive items from coll while<br>  (pred item) returns true. pred must be free of side-effects.</p>
+  <p class="var-docstr">Returns a lazy sequence of successive items from coll while<br>  (pred item) returns true. pred must be free of side-effects.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1708">source</a>
 </li>
 <li>
@@ -4416,7 +4416,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(test v)</code></div>
 </pre>
-  <p class="var-docstr">test [v] finds fn at key :test in var metadata and calls it,<br>  presuming failure will throw exception</p>
+  <p class="var-docstr">test [v] finds fn at key :test in var metadata and calls it,<br>  presuming failure will throw exception</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2910">source</a>
 </li>
 <li>
@@ -4425,7 +4425,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(the-ns x)</code></div>
 </pre>
-  <p class="var-docstr">If passed a namespace, returns it. Else, when passed a symbol,<br>  returns the namespace named by it, throwing an exception if not<br>  found.</p>
+  <p class="var-docstr">If passed a namespace, returns it. Else, when passed a symbol,<br>  returns the namespace named by it, throwing an exception if not<br>  found.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2273">source</a>
 </li>
 <li>
@@ -4444,7 +4444,7 @@
   <pre class="var-usage"><div><code>(trampoline f)</code></div>
 <div><code>(trampoline f & args)</code></div>
 </pre>
-  <p class="var-docstr">trampoline can be used to convert algorithms requiring mutual<br>  recursion without stack consumption. Calls f with supplied args, if<br>  any. If f returns a fn, calls that fn with no arguments, and<br>  continues to repeat, until the return value is not a fn, then<br>  returns that non-fn value. Note that if you want to return a fn as a<br>  final value, you must wrap it in some data structure and unpack it<br>  after trampoline returns.</p>
+  <p class="var-docstr">trampoline can be used to convert algorithms requiring mutual<br>  recursion without stack consumption. Calls f with supplied args, if<br>  any. If f returns a fn, calls that fn with no arguments, and<br>  continues to repeat, until the return value is not a fn, then<br>  returns that non-fn value. Note that if you want to return a fn as a<br>  final value, you must wrap it in some data structure and unpack it<br>  after trampoline returns.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3609">source</a>
 </li>
 <li>
@@ -4453,7 +4453,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(tree-seq branch? children root)</code></div>
 </pre>
-  <p class="var-docstr">Returns a lazy sequence of the nodes in a tree, via a depth-first walk.<br>  branch? must be a fn of one arg that returns true if passed a node<br>  that can have children (but may not).  children must be a fn of one<br>  arg that returns a sequence of the children. Will only be called on<br>  nodes for which branch? returns true. Root is the root node of the<br>  tree.</p>
+  <p class="var-docstr">Returns a lazy sequence of the nodes in a tree, via a depth-first walk.<br>  branch? must be a fn of one arg that returns true if passed a node<br>  that can have children (but may not).  children must be a fn of one<br>  arg that returns a sequence of the children. Will only be called on<br>  nodes for which branch? returns true. Root is the root node of the<br>  tree.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2971">source</a>
 </li>
 <li>
@@ -4493,7 +4493,7 @@
 <div><code>(update m k f x y z)</code></div>
 <div><code>(update m k f x y z & more)</code></div>
 </pre>
-  <p class="var-docstr">'Updates' a value in an associative structure, where k is a<br>  key and f is a function that will take the old value<br>  and any supplied args and return the new value, and returns a new<br>  structure.  If the key does not exist, nil is passed as the old value.</p>
+  <p class="var-docstr">'Updates' a value in an associative structure, where k is a<br>  key and f is a function that will take the old value<br>  and any supplied args and return the new value, and returns a new<br>  structure.  If the key does not exist, nil is passed as the old value.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3519">source</a>
 </li>
 <li>
@@ -4502,7 +4502,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(update-in m ks f & args)</code></div>
 </pre>
-  <p class="var-docstr">'Updates' a value in a nested associative structure, where ks is a<br>  sequence of keys and f is a function that will take the old value<br>  and any supplied args and return the new value, and returns a new<br>  nested structure.  If any levels do not exist, hash-maps will be<br>  created.</p>
+  <p class="var-docstr">'Updates' a value in a nested associative structure, where ks is a<br>  sequence of keys and f is a function that will take the old value<br>  and any supplied args and return the new value, and returns a new<br>  nested structure.  If any levels do not exist, hash-maps will be<br>  created.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3506">source</a>
 </li>
 <li>
@@ -4511,7 +4511,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(use & args)</code></div>
 </pre>
-  <p class="var-docstr">Like 'require, but also refers to each lib's namespace using<br>  joker.core/refer. Use :use in the ns macro in preference to calling<br>  this directly.<br><br>  'use accepts additional options in libspecs: :exclude, :only, :rename.<br>  The arguments and semantics for :exclude, :only, and :rename are the same<br>  as those documented for joker.core/refer.</p>
+  <p class="var-docstr">Like 'require, but also refers to each lib's namespace using<br>  joker.core/refer. Use :use in the ns macro in preference to calling<br>  this directly.<br><br>  'use accepts additional options in libspecs: :exclude, :only, :rename.<br>  The arguments and semantics for :exclude, :only, and :rename are the same<br>  as those documented for joker.core/refer.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3438">source</a>
 </li>
 <li>
@@ -4565,7 +4565,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(vary-meta obj f & args)</code></div>
 </pre>
-  <p class="var-docstr">Returns an object of the same type and value as obj, with<br>  (apply f (meta obj) args) as its metadata.</p>
+  <p class="var-docstr">Returns an object of the same type and value as obj, with<br>  (apply f (meta obj) args) as its metadata.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L517">source</a>
 </li>
 <li>
@@ -4610,7 +4610,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(when-first bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">bindings => x xs<br><br>  Roughly the same as (when (seq xs) (let [x (first xs)] body)) but xs is evaluated only once</p>
+  <p class="var-docstr">bindings => x xs<br><br>  Roughly the same as (when (seq xs) (let [x (first xs)] body)) but xs is evaluated only once</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2707">source</a>
 </li>
 <li>
@@ -4619,7 +4619,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(when-let bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">bindings => binding-form test<br><br>  When test is true, evaluates body with binding-form bound to the value of test</p>
+  <p class="var-docstr">bindings => binding-form test<br><br>  When test is true, evaluates body with binding-form bound to the value of test</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1284">source</a>
 </li>
 <li>
@@ -4637,7 +4637,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(when-some bindings & body)</code></div>
 </pre>
-  <p class="var-docstr">bindings => binding-form test<br><br>  When test is not nil, evaluates body with binding-form bound to the<br>  value of test</p>
+  <p class="var-docstr">bindings => binding-form test<br><br>  When test is not nil, evaluates body with binding-form bound to the<br>  value of test</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1319">source</a>
 </li>
 <li>
@@ -4646,7 +4646,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(while test & body)</code></div>
 </pre>
-  <p class="var-docstr">Repeatedly executes body while test expression is true. Presumes<br>  some side-effect will cause test to become false/nil. Returns nil</p>
+  <p class="var-docstr">Repeatedly executes body while test expression is true. Presumes<br>  some side-effect will cause test to become false/nil. Returns nil</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L3626">source</a>
 </li>
 <li>
@@ -4655,7 +4655,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-bindings binding-map & body)</code></div>
 </pre>
-  <p class="var-docstr">Takes a map of Var/value pairs. Sets the vars to the corresponding values.<br>  Then executes body. Resets the vars back to the original<br>  values after body was evaluated. Returns the value of body.</p>
+  <p class="var-docstr">Takes a map of Var/value pairs. Sets the vars to the corresponding values.<br>  Then executes body. Resets the vars back to the original<br>  values after body was evaluated. Returns the value of body.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1405">source</a>
 </li>
 <li>
@@ -4664,7 +4664,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-bindings* binding-map f & args)</code></div>
 </pre>
-  <p class="var-docstr">Takes a map of Var/value pairs. Sets the vars to the corresponding values.<br>  Then calls f with the supplied arguments. Resets the vars back to the original<br>  values after f returned. Returns whatever f returns.</p>
+  <p class="var-docstr">Takes a map of Var/value pairs. Sets the vars to the corresponding values.<br>  Then calls f with the supplied arguments. Resets the vars back to the original<br>  values after f returned. Returns whatever f returns.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L1387">source</a>
 </li>
 <li>
@@ -4673,7 +4673,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-in-str s & body)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates body in a context in which *in* is bound to a fresh<br>  Buffer initialized with the string s.</p>
+  <p class="var-docstr">Evaluates body in a context in which *in* is bound to a fresh<br>  Buffer initialized with the string s.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2795">source</a>
 </li>
 <li>
@@ -4682,7 +4682,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-meta obj m)</code></div>
 </pre>
-  <p class="var-docstr">Returns an object of the same type and value as obj, with<br>         map m as its metadata.</p>
+  <p class="var-docstr">Returns an object of the same type and value as obj, with<br>         map m as its metadata.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L188">source</a>
 </li>
 <li>
@@ -4691,7 +4691,7 @@
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(with-out-str & body)</code></div>
 </pre>
-  <p class="var-docstr">Evaluates exprs in a context in which *out* is bound to a fresh<br>  Buffer.  Returns the string created by any nested printing<br>  calls.</p>
+  <p class="var-docstr">Evaluates exprs in a context in which *out* is bound to a fresh<br>  Buffer.  Returns the string created by any nested printing<br>  calls.</p>
   <a href="https://github.com/candid82/joker/blob/master/core/data/core.joke#L2785">source</a>
 </li>
 <li>


### PR DESCRIPTION
I'm not 100% sure this is the right approach. It'll prevent editing of (most) Joker source files via NotePad on Windows (since NotePad doesn't handle Unix-style line terminators correctly). I'm not sure whether there'll be other issues.

But it avoids requiring tools like `run-eval-tests.joke` to "manually" strip out carriage returns in expected outputs (they don't seem to show up in generated output, at least not in Git Bash) before comparing them.

Since I don't currently have a non-Git-Bash, barebones Joker development environment on a Windows machine, it's hard to predict what effect this might have on such environments; but they're currently probably rather broken anyway due to lack of a `run.bat` and other equivalents for shell scripts.

While doing this work (which was rather painful, due to Git Bash not behaving as documented with respect to changing `.gitattributes` on the GitHub site and elsewhere), `docs/joker.core.html` kept getting changed. Arguably `generate-docs.joke` has a bug wherein it outputs embedded `\r` (CR) characters in multiline docstrings (which are read in by Joker when files are in DOS format), resulting in sequences like `foo\r<br>...`; this approach avoids, but does not fix, that bug.

If moving to Unix line endings for most/all files is unacceptable, I'll try the other approach of having the various test scripts replacing `\r\n` with `\n` in expected (`slurp`'ed) outputs.