### PR TITLE
Support Go1.12 Beta 2

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,9 +5,9 @@ build() {
 
     go generate ./...
 
-    go vet -all ./
+    go vet -all ./...
 
-    [ -n "$SHADOW" ] && go vet -all "$SHADOW" ./ && echo "Shadowed-variables check complete."
+    [ -n "$SHADOW" ] && go vet -all "$SHADOW" ./... && echo "Shadowed-variables check complete."
 
     go build
 }

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,13 @@ build() {
 
     go vet -all ./...
 
-    [ -n "$SHADOW" ] && go vet -all "$SHADOW" ./... && echo "Shadowed-variables check complete."
+    if [ -n "$SHADOW" ]; then
+        go vet -all "$SHADOW" ./... && echo "Shadowed-variables check complete."
+    else
+        echo "Not performing shadowed-variables check; consider installing shadow tool via:"
+        echo "  go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow"
+        echo "and rebuilding."
+    fi
 
     go build
 }
@@ -15,6 +21,8 @@ build() {
 if which shadow >/dev/null 2>/dev/null; then
     # Install via: go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
     SHADOW="-vettool=$(which shadow)"
+elif $(go tool vet nonexistent.go 2>&1 | grep -q -v unsupported); then
+    SHADOW="-shadow=true"
 fi
 
 set -e  # Exit on error.

--- a/run.sh
+++ b/run.sh
@@ -5,10 +5,17 @@ build() {
 
     go generate ./...
 
-    go tool vet -all -shadow=true ./
+    go vet -all ./
+
+    [ -n "$SHADOW" ] && go vet -all "$SHADOW" ./ && echo "Shadowed-variables check complete."
 
     go build
 }
+
+if which shadow >/dev/null 2>/dev/null; then
+    # Install via: go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+    SHADOW="-vettool=$(which shadow)"
+fi
 
 set -e  # Exit on error.
 


### PR DESCRIPTION
This should work for both Go 1.12 and Go 1.11.

Also note that `set -e` has been replaced with `trap` per best practices, mentioned here:

https://stackoverflow.com/a/4384381/8869495

(The script wasn't always stopping upon `go vet` failure, probably because `set -e` or `trap` is needed as well in the `build` function.)