### PR TITLE
Make re-seq and re-find return nil when appropriate

### DIFF
--- a/core/procs.go
+++ b/core/procs.go
@@ -345,21 +345,35 @@ var procRegex Proc = func(args []Object) Object {
 	return Regex{R: r}
 }
 
+func reGroups(s string, indexes []int) Object {
+	if indexes == nil {
+		return NIL
+	} else if len(indexes) == 2 {
+		if indexes[0] == -1 {
+			return NIL
+		} else {
+			return String{S: s[indexes[0]:indexes[1]]}
+		}
+	} else {
+		v := EmptyVector()
+		for i := 0; i < len(indexes); i += 2 {
+			if indexes[i] == -1 {
+				v = v.Conjoin(NIL)
+			} else {
+				v = v.Conjoin(String{S: s[indexes[i]:indexes[i+1]]})
+			}
+		}
+		return v
+	}
+}
+
 var procReSeq Proc = func(args []Object) Object {
 	re := EnsureRegex(args, 0)
 	s := EnsureString(args, 1)
-	matches := re.R.FindAllStringSubmatch(s.S, -1)
+	matches := re.R.FindAllStringSubmatchIndex(s.S, -1)
 	res := make([]Object, len(matches))
 	for i, match := range matches {
-		if len(match) == 1 {
-			res[i] = String{S: match[0]}
-		} else {
-			v := EmptyVector()
-			for _, str := range match {
-				v = v.Conjoin(String{S: str})
-			}
-			res[i] = v
-		}
+		res[i] = reGroups(s.S, match)
 	}
 	return &ArraySeq{arr: res}
 }
@@ -367,18 +381,8 @@ var procReSeq Proc = func(args []Object) Object {
 var procReFind Proc = func(args []Object) Object {
 	re := EnsureRegex(args, 0)
 	s := EnsureString(args, 1)
-	match := re.R.FindStringSubmatch(s.S)
-	if len(match) == 0 {
-		return NIL
-	}
-	if len(match) == 1 {
-		return String{S: match[0]}
-	}
-	v := EmptyVector()
-	for _, str := range match {
-		v = v.Conjoin(String{S: str})
-	}
-	return v
+	match := re.R.FindStringSubmatchIndex(s.S)
+	return reGroups(s.S, match)
 }
 
 var procRand Proc = func(args []Object) Object {

--- a/core/procs.go
+++ b/core/procs.go
@@ -371,6 +371,9 @@ var procReSeq Proc = func(args []Object) Object {
 	re := EnsureRegex(args, 0)
 	s := EnsureString(args, 1)
 	matches := re.R.FindAllStringSubmatchIndex(s.S, -1)
+	if matches == nil {
+		return NIL
+	}
 	res := make([]Object, len(matches))
 	for i, match := range matches {
 		res[i] = reGroups(s.S, match)


### PR DESCRIPTION
Thanks for joker, I've found it extremely useful!

I was writing a script that has some regex parsing in it and noticed that `re-seq` and `re-find` behave a little differently than in clojure (aside from re-seq not being lazy, which isn't a big deal). This PR includes a couple of changes to bring these functions more in line with their clojure cousins:

1. `re-seq` returns `nil` instead of an empty sequence when there are no matches:

```clj
#_=> (re-seq #"nothing-should-match" "test-string")
nil
;; Currently this returns ()
```

2. Regex matching functions return `nil` instead of `""` when a group does not match. This is consistent with how [java.util.regex.Matcher.group()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#group(int)) works:

>  If the match was successful but the group specified failed to match any part of the input sequence, then null is returned. Note that some groups, for example (a*), match the empty string. This method will return the empty string when such a group successfully matches the empty string in the input. 

```clj
#_=> (re-find #"test(ing)?" "test")
["test" nil]
;; Currently this returns ["test" ""]]

;; But note the difference between (ing)? -- no match; and (a*) -- empty match
#_=> (re-find #"test(ing)?(a*)" "test")
["test" nil ""]
;; Currently this returns ["test" "" ""]
```