### PR TITLE
exit 1 when eval errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -662,7 +662,9 @@ func main() {
 			ExitJoker(9)
 		}
 		reader := NewReader(strings.NewReader(eval), "<expr>")
-		ProcessReader(reader, "", phase)
+		if err := ProcessReader(reader, "", phase); err != nil {
+			ExitJoker(1)
+		}
 		return
 	}
 
@@ -687,7 +689,9 @@ func main() {
 	}
 
 	if filename != "" {
-		processFile(filename, phase)
+		if err := processFile(filename, phase); err != nil {
+			ExitJoker(1)
+		}
 		return
 	}
 


### PR DESCRIPTION
The tests in #186 failed, but circleci reports that they passed, because joker exits 0 in all cases when evaluating code. I'm not sure 1 is the correct exit code (since there are a lot of exit codes in main.go), but I don't think it should be 0.

Specifically, the [eval tests](https://circleci.com/gh/candid82/joker/599) failed since I forgot to push the `gen_data.go` file in that PR.