### PR TITLE
Populate *command-line-args* When Documenting It

### DIFF
--- a/core/environment.go
+++ b/core/environment.go
@@ -49,7 +49,11 @@ func (env *Env) SetEnvArgs(newArgs []string) {
 	for _, arg := range newArgs {
 		args = args.Conjoin(MakeString(arg))
 	}
-	env.args.Value = args.Seq()
+	if args.Count() > 0 {
+		env.args.Value = args.Seq()
+	} else {
+		env.args.Value = NIL
+	}
 }
 
 func (env *Env) SetClassPath(cp string) {

--- a/core/environment.go
+++ b/core/environment.go
@@ -49,11 +49,7 @@ func (env *Env) SetEnvArgs(newArgs []string) {
 	for _, arg := range newArgs {
 		args = args.Conjoin(MakeString(arg))
 	}
-	if args.Count() > 0 {
-		env.args.Value = args.Seq()
-	} else {
-		env.args.Value = NIL
-	}
+	env.args.Value = args.Seq()
 }
 
 func (env *Env) SetClassPath(cp string) {

--- a/docs/joker.core.html
+++ b/docs/joker.core.html
@@ -1222,7 +1222,7 @@
 </li>
 <li>
   <h3 id="*command-line-args*">*command-line-args*</h3>
-  <span class="var-type Nil">Nil</span>
+  <span class="var-type VectorSeq">VectorSeq</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"></pre>
   <p class="var-docstr">A sequence of the supplied command line arguments, or nil if<br>  none were supplied</p>

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ Rebuilding Joker, as the libraries have changed; then regenerating docs.
 EOF
     build
 
-    (cd docs; ../joker generate-docs.joke)
+    (cd docs; ../joker generate-docs.joke --dummy-arg-so-command-line-args-is-documented-as-type-VectorSeq)
 fi
 
 ./joker "$@"


### PR DESCRIPTION
An empty VectorSeq is more consistent than nil, especially since the
docs are generated by a Joker script, normally run with no arguments,
that uses the type of *command-line-args* to describe its type in the
docs.