### PR TITLE
[main] Add ability to set classpath with an environment variable.

### DIFF
--- a/main.go
+++ b/main.go
@@ -557,6 +557,16 @@ var runningProfile interface {
 	Stop()
 }
 
+func getEnv(key string) string {
+	for _, e := range os.Environ() {
+		pair := strings.Split(e, "=")
+		if pair[0] == key {
+			return pair[1]
+		}
+	}
+	return ""
+}
+
 func main() {
 	InitInternalLibs()
 	ProcessCoreData()
@@ -578,6 +588,9 @@ func main() {
 	}
 
 	parseArgs(os.Args)
+	if classPath == "" {
+		classPath = getEnv("JOKER_CLASSPATH")
+	}
 	GLOBAL_ENV.SetEnvArgs(remainingArgs)
 	GLOBAL_ENV.SetClassPath(classPath)
 


### PR DESCRIPTION
For some of the work I'm doing, I have scripts that simply specify the joker command to run. They rely on external libraries for which I would like to specify a class path externally using an enviornment variable.

This PR allows you to specify the class path using "JOKER_CLASSPATH=dir1:dir2" syntax just like you would with the "-c" option on the command line.

It would definitely be a help to my use of joker if this was in master.

Much thanks for all of your work!