### PR TITLE
Fix builds for 32-bit hosts

### DIFF
--- a/core/array_map.go
+++ b/core/array_map.go
@@ -21,7 +21,7 @@ type (
 )
 
 var (
-	HASHMAP_THRESHOLD int = 16
+	HASHMAP_THRESHOLD int64 = 16
 )
 
 func EmptyArrayMap() *ArrayMap {
@@ -169,7 +169,7 @@ func (m *ArrayMap) Assoc(key Object, value Object) Associative {
 		res.arr[i+1] = value
 		return res
 	}
-	if len(m.arr) >= HASHMAP_THRESHOLD {
+	if int64(len(m.arr)) >= HASHMAP_THRESHOLD {
 		return NewHashMap(m.arr...).Assoc(key, value)
 	}
 	res := m.Clone()

--- a/core/eval.go
+++ b/core/eval.go
@@ -204,7 +204,7 @@ func (expr *VectorExpr) Eval(env *LocalEnv) Object {
 }
 
 func (expr *MapExpr) Eval(env *LocalEnv) Object {
-	if len(expr.keys) > HASHMAP_THRESHOLD/2 {
+	if int64(len(expr.keys)) > HASHMAP_THRESHOLD/2 {
 		res := EmptyHashMap
 		for i := range expr.keys {
 			key := Eval(expr.keys[i], env)

--- a/core/read.go
+++ b/core/read.go
@@ -604,7 +604,7 @@ func readMapWithNamespace(reader *Reader, nsname string) Object {
 	if len(objs)%2 != 0 {
 		panic(MakeReadError(reader, "Map literal must contain an even number of forms"))
 	}
-	if len(objs) > HASHMAP_THRESHOLD {
+	if int64(len(objs)) >= HASHMAP_THRESHOLD {
 		hashMap := NewHashMap()
 		for i := 0; i < len(objs); i += 2 {
 			key := resolveKey(objs[i], nsname)

--- a/main.go
+++ b/main.go
@@ -437,7 +437,7 @@ func parseArgs(args []string) {
 		case "--hashmap-threshold":
 			if i < length-1 && notOption(args[i+1]) {
 				i += 1 // shift
-				thresh, err := strconv.Atoi(args[i])
+				thresh, err := strconv.ParseInt(args[i], 10, 64)
 				if err != nil {
 					fmt.Fprintln(Stderr, "Error: ", err)
 					return


### PR DESCRIPTION
Fixes https://github.com/candid82/joker/issues/200 with only slight modifications to the proposed changes (to ensure the command-line value is parsed as an `int64` in the first place).

Tested via:

```
$ GOOS=linux GOARCH=386 go build
$ file joker
joker: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, not stripped
$ ./joker
Welcome to joker v0.12.2. Use EOF (Ctrl-D) or SIGINT (Ctrl-C) to exit.
user=> ^D
$ ./all-tests.sh
[...]
Ran 59 tests containing 511 assertions.
0 failures, 0 errors.
All three tests passed.
$
```