### PR TITLE
Create shadow.sh script

### DIFF
--- a/shadow.sh
+++ b/shadow.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Check for shadowed variables.
+
+if which shadow >/dev/null 2>/dev/null; then
+    # Install via: go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+    SHADOW="-vettool=$(which shadow)"
+elif $(go tool vet nonexistent.go 2>&1 | grep -q -v unsupported); then
+    SHADOW="-shadow=true"
+fi
+
+if [ -n "$SHADOW" ]; then
+    go vet "$SHADOW" ./...
+else
+    echo >&2 "Not performing shadowed-variables check; consider installing shadow tool via:"
+    echo >&2 "  go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow"
+    echo >&2 "and rerunning this script."
+    exit 99
+fi


### PR DESCRIPTION
This provides the shadowed-variable checking that `run.sh` used to do, but no longer does, keeping that script simple.

This new script supports Go 1.12 as well as previous releases; 1.12 support requires installation of the `shadow` tool to work (see the diagnostic produced for more info).

If this script is found sufficiently worthy, I suppose it could be invoked by `run.sh` in the `build()` function. In the meantime, it's available for developers changing Joker code.