### PR TITLE
Add joker.time/parse and add-date

### DIFF
--- a/std/time.joke
+++ b/std/time.joke
@@ -41,6 +41,12 @@
   :go "t.Add(time.Duration(d))"}
   [^Time t ^Int d])
 
+(defn ^Time parse
+  "Parses a time string."
+  {:added "1.0"
+   :go "!_res, err := time.Parse(layout, value); PanicOnErr(err)"}
+  [^String layout ^String value])
+
 (defn ^Int parse-duration
   "Parses a duration string. A duration string is a possibly signed sequence of decimal numbers,
   each with optional fraction and a unit suffix, such as 300ms, -1.5h or 2h45m. Valid time units are

--- a/std/time.joke
+++ b/std/time.joke
@@ -41,6 +41,12 @@
   :go "t.Add(time.Duration(d))"}
   [^Time t ^Int d])
 
+(defn ^Time add-date
+  "Returns the time t + (years, months, days)."
+  {:added "1.0"
+   :go "t.AddDate(years, months, days)"}
+  [^Time t ^Int years ^Int months ^Int days])
+
 (defn ^Time parse
   "Parses a time string."
   {:added "1.0"

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -46,6 +46,23 @@ var add_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
+var add_date_ Proc = func(_args []Object) Object {
+	_c := len(_args)
+	switch {
+	case _c == 4:
+		t := ExtractTime(_args, 0)
+		years := ExtractInt(_args, 1)
+		months := ExtractInt(_args, 2)
+		days := ExtractInt(_args, 3)
+		_res := t.AddDate(years, months, days)
+		return MakeTime(_res)
+
+	default:
+		PanicArity(_c)
+	}
+	return NIL
+}
+
 var format_ Proc = func(_args []Object) Object {
 	_c := len(_args)
 	switch {
@@ -392,6 +409,11 @@ func init() {
 		MakeMeta(
 			NewListFrom(NewVectorFrom(MakeSymbol("t"), MakeSymbol("d"))),
 			`Returns the time t+d.`, "1.0"))
+
+	timeNamespace.InternVar("add-date", add_date_,
+		MakeMeta(
+			NewListFrom(NewVectorFrom(MakeSymbol("t"), MakeSymbol("years"), MakeSymbol("months"), MakeSymbol("days"))),
+			`Returns the time t + (years, months, days).`, "1.0"))
 
 	timeNamespace.InternVar("format", format_,
 		MakeMeta(

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -117,6 +117,22 @@ var now_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
+var parse_ Proc = func(_args []Object) Object {
+	_c := len(_args)
+	switch {
+	case _c == 2:
+		layout := ExtractString(_args, 0)
+		value := ExtractString(_args, 1)
+		_res, err := time.Parse(layout, value)
+		PanicOnErr(err)
+		return MakeTime(_res)
+
+	default:
+		PanicArity(_c)
+	}
+	return NIL
+}
+
 var parse_duration_ Proc = func(_args []Object) Object {
 	_c := len(_args)
 	switch {
@@ -406,6 +422,11 @@ func init() {
 		MakeMeta(
 			NewListFrom(NewVectorFrom()),
 			`Returns the current local time.`, "1.0"))
+
+	timeNamespace.InternVar("parse", parse_,
+		MakeMeta(
+			NewListFrom(NewVectorFrom(MakeSymbol("layout"), MakeSymbol("value"))),
+			`Parses a time string.`, "1.0"))
 
 	timeNamespace.InternVar("parse-duration", parse_duration_,
 		MakeMeta(


### PR DESCRIPTION
A couple extra functions in the joker.time namespace. I didn't get this far, but it would open up the possibility of adding an `#inst` data reader in the future.