### PR TITLE
Pass actual Stdin object to os.exec commands

### DIFF
--- a/eval-tests.sh
+++ b/eval-tests.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
+# Let test suite know to try.
+[[ -t 0 ]] && export TTY_TESTS=1
+
 ./joker tests/run-eval-tests.joke "$@"

--- a/tests/eval/os.joke
+++ b/tests/eval/os.joke
@@ -1,0 +1,8 @@
+(ns joker.test-joker.os
+  (:require [joker.os :as os]
+            [joker.test :refer [deftest is]]))
+
+(deftest exec-pipe
+  (if (= (get (os/env) "TTY_TESTS") "1")
+    (is (= 0 (:exit (os/exec "stty" {:args ["echo"] :stdin :pipe}))))
+    (println "Skipping tty tests (STDIN is not a tty)")))

--- a/tests/eval/stdin-pipe/input.joke
+++ b/tests/eval/stdin-pipe/input.joke
@@ -1,0 +1,5 @@
+(ns stdin-pipe-test
+  (:require [joker.os :as os]))
+
+(let [result (os/exec "cat" {:stdin :pipe})]
+  (print "|" (:out result)))

--- a/tests/eval/stdin-pipe/stdin.txt
+++ b/tests/eval/stdin-pipe/stdin.txt
@@ -1,0 +1,1 @@
+stdin pipe test

--- a/tests/eval/stdin-pipe/stdout.txt
+++ b/tests/eval/stdin-pipe/stdout.txt
@@ -1,0 +1,1 @@
+| stdin pipe test

--- a/tests/run-eval-tests.joke
+++ b/tests/run-eval-tests.joke
@@ -37,7 +37,8 @@
       (println (str "Running test in subdirectory " test-dir)))
     (let [dir (str "tests/eval/" test-dir "/")
           filename "input.joke"
-          res (joker.os/sh-from dir exe filename) ; Someday add: :in "input.txt" (no :in support yet)
+          stdin (slurp-or (str dir "stdin.txt") :pipe)
+          res (joker.os/exec exe {:dir dir :args [filename] :stdin stdin})
           out (:out res)
           err (:err res)
           rc (:exit res)


### PR DESCRIPTION
I was trying to do something like

```clojure
(defn get-pass [prompt]
  (try
    (stty "-echo")
    (get-input prompt)
    (finally
      (stty "echo")
      (println))))
```

and couldn't because the `:stdin :pipe` wasn't really a terminal.

I added tests for string and :pipe and then made the change to pass the object directly and added some tests for that, though it will only work when there really is a tty.

If you agree with the concept I have some design questions for you:
- do you see any reason to keep the previous :pipe behavior? I believe this works the same, but it could be a different keyword if there was any distinction.
- i added 3 different tests for the tty behavior, all of which are a little weird.  do you prefer one over the others (or have another suggestion)?

I appreciate your feedback.  Joker is really fantastic!  ❤️  Thanks!