### PR TITLE
Fix stdin pipe so output reliably captured

### DIFF
--- a/std/os/os_native.go
+++ b/std/os/os_native.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
-	"time"
 
 	. "github.com/candid82/joker/core"
 )
@@ -80,19 +79,16 @@ func sh(dir string, stdin io.Reader, name string, args []string) Object {
 		PanicOnErr(err)
 		stdinWriter = writer
 	}
+
 	bufOut := new(bytes.Buffer)
 	bufErr := new(bytes.Buffer)
 
 	go io.Copy(bufOut, stdoutReader)
 	go io.Copy(bufErr, stderrReader)
 
-	time.Sleep(1 * time.Second)
-
 	if err = cmd.Start(); err != nil {
 		panic(RT.NewError(err.Error()))
 	}
-
-	time.Sleep(1 * time.Second)
 
 	if stdin != nil && stdinWriter != nil {
 		go func() {

--- a/std/os/os_native.go
+++ b/std/os/os_native.go
@@ -2,6 +2,7 @@ package os
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -65,6 +66,9 @@ func execute(name string, opts Map) Object {
 }
 
 func sh(dir string, stdin io.Reader, name string, args []string) Object {
+	b, e := ioutil.ReadAll(stdin)
+	PanicOnErr(e)
+	fmt.Fprintf(Stderr, "stdin had %d bytes\n", len(b))
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	stdoutReader, err := cmd.StdoutPipe()

--- a/std/os/os_native.go
+++ b/std/os/os_native.go
@@ -2,7 +2,6 @@ package os
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -66,9 +65,6 @@ func execute(name string, opts Map) Object {
 }
 
 func sh(dir string, stdin io.Reader, name string, args []string) Object {
-	b, e := ioutil.ReadAll(stdin)
-	PanicOnErr(e)
-	fmt.Fprintf(Stderr, "stdin had %d bytes\n", len(b))
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	stdoutReader, err := cmd.StdoutPipe()

--- a/std/os/os_native.go
+++ b/std/os/os_native.go
@@ -67,29 +67,14 @@ func execute(name string, opts Map) Object {
 func sh(dir string, stdin io.Reader, name string, args []string) Object {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
+	cmd.Stdin = stdin
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	var stdinWriter io.WriteCloser
-	if stdin == Stdin {
-		cmd.Stdin = Stdin
-	} else {
-		writer, err := cmd.StdinPipe()
-		PanicOnErr(err)
-		stdinWriter = writer
-	}
-
 	err := cmd.Start()
 	PanicOnErr(err)
-
-	if stdin != nil && stdinWriter != nil {
-		go func() {
-			io.Copy(stdinWriter, stdin)
-			stdinWriter.Close()
-		}()
-	}
 
 	err = cmd.Wait()
 

--- a/std/os/os_native.go
+++ b/std/os/os_native.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	. "github.com/candid82/joker/core"
 )
@@ -79,15 +80,20 @@ func sh(dir string, stdin io.Reader, name string, args []string) Object {
 		PanicOnErr(err)
 		stdinWriter = writer
 	}
-	if err = cmd.Start(); err != nil {
-		panic(RT.NewError(err.Error()))
-	}
-
 	bufOut := new(bytes.Buffer)
 	bufErr := new(bytes.Buffer)
 
 	go io.Copy(bufOut, stdoutReader)
 	go io.Copy(bufErr, stderrReader)
+
+	time.Sleep(1 * time.Second)
+
+	if err = cmd.Start(); err != nil {
+		panic(RT.NewError(err.Error()))
+	}
+
+	time.Sleep(1 * time.Second)
+
 	if stdin != nil && stdinWriter != nil {
 		go func() {
 			io.Copy(stdinWriter, stdin)


### PR DESCRIPTION
Fix https://github.com/candid82/joker/issues/237 by simply using the built-in `cmd.Stdout` and `cmd.Stderr` fields to hold buffers that will be written to (asynchronously) such that `cmd.Wait()` knows to wait for such writing to complete before tearing things down.