### PR TITLE
Use $GOHOSTOS and $GOHOSTARCH for build-time generation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,13 +15,16 @@ if [ "$1" == "-v" ]; then
   ./joker -e '(print "\nLibraries available in this build:\n  ") (loaded-libs) (println)'
 fi
 
-SUM256="$(GOOS="$GOHOSTOS" GOARCH="$GOHOSTARCH" go run tools/sum256dir/main.go std)"
-(cd std; ../joker generate-std.joke 2> /dev/null)
-NEW_SUM256="$(GOOS="$GOHOSTOS" GOARCH="$GOHOSTARCH" go run tools/sum256dir/main.go std)"
+# Check for changes in std, and run just-built Joker, only when building for host os/architecture.
+if [ "$GOOS" = "$GOHOSTOS" -a "$GOARCH" = "$GOHOSTARCH" ]; then
+    SUM256="$(GOOS="$GOHOSTOS" GOARCH="$GOHOSTARCH" go run tools/sum256dir/main.go std)"
+    (cd std; ../joker generate-std.joke 2> /dev/null)
+    NEW_SUM256="$(GOOS="$GOHOSTOS" GOARCH="$GOHOSTARCH" go run tools/sum256dir/main.go std)"
 
-if [ "$SUM256" != "$NEW_SUM256" ]; then
-  echo 'std has changed, rebuilding...'
-  build
-fi
+    if [ "$SUM256" != "$NEW_SUM256" ]; then
+        echo 'std has changed, rebuilding...'
+        build
+    fi
 
 ./joker "$@"
+fi

--- a/run.sh
+++ b/run.sh
@@ -2,12 +2,13 @@
 
 build() {
   go clean
-  go generate ./...
+  GOOS="$GOHOSTOS" GOARCH="$GOHOSTARCH" go generate ./...
   go vet ./...
   go build
 }
 
 set -e  # Exit on error.
+set -x  # Show commands as they execute.
 
 build
 
@@ -15,9 +16,9 @@ if [ "$1" == "-v" ]; then
   ./joker -e '(print "\nLibraries available in this build:\n  ") (loaded-libs) (println)'
 fi
 
-SUM256="$(go run tools/sum256dir/main.go std)"
+SUM256="$(GOOS="$GOHOSTOS" GOARCH="$GOHOSTARCH" go run tools/sum256dir/main.go std)"
 (cd std; ../joker generate-std.joke 2> /dev/null)
-NEW_SUM256="$(go run tools/sum256dir/main.go std)"
+NEW_SUM256="$(GOOS="$GOHOSTOS" GOARCH="$GOHOSTARCH" go run tools/sum256dir/main.go std)"
 
 if [ "$SUM256" != "$NEW_SUM256" ]; then
   echo 'std has changed, rebuilding...'

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,6 @@ build() {
 }
 
 set -e  # Exit on error.
-set -x  # Show commands as they execute.
 
 build
 


### PR DESCRIPTION
Fixes https://github.com/candid82/joker/issues/250.

Note that I'm not sure this is a perfect fix, insofar as there's also a $GOARM env var that has no $GOHOSTARM equivalent that I can see (on my systems, which are all non-ARM). That might mean one cannot build on a particular ARM system while targeting a different ARM system.

If someone who has an ARM system up and running can confirm that $GOHOSTARM is defined in their environment, perhaps just adding GOARM="$GOHOSTARM" to the environments for host builds would fix that issue.