### PR TITLE
Try initializing namespaces lazily

### DIFF
--- a/core/environment.go
+++ b/core/environment.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,9 +11,10 @@ import (
 )
 
 var (
-	Stdin  io.Reader = os.Stdin
-	Stdout io.Writer = os.Stdout
-	Stderr io.Writer = os.Stderr
+	Stdin   io.Reader = os.Stdin
+	Stdout  io.Writer = os.Stdout
+	Stderr  io.Writer = os.Stderr
+	Verbose           = false
 )
 
 type (
@@ -137,6 +139,13 @@ func (env *Env) NamespaceFor(ns *Namespace, s Symbol) *Namespace {
 			res = env.Namespaces[s.ns]
 		}
 	}
+	if res != nil && res.Lazy != nil {
+		res.Lazy()
+		if Verbose {
+			fmt.Fprintf(Stderr, "NamespaceFor: Lazily initialized %s\n", *res.Name.name)
+		}
+		res.Lazy = nil
+	}
 	return res
 }
 
@@ -157,7 +166,15 @@ func (env *Env) FindNamespace(s Symbol) *Namespace {
 	if s.ns != nil {
 		return nil
 	}
-	return env.Namespaces[s.name]
+	ns := env.Namespaces[s.name]
+	if ns != nil && ns.Lazy != nil {
+		ns.Lazy()
+		if Verbose {
+			fmt.Fprintf(Stderr, "FindNameSpace: Lazily initialized %s\n", *ns.Name.name)
+		}
+		ns.Lazy = nil
+	}
+	return ns
 }
 
 func (env *Env) RemoveNamespace(s Symbol) *Namespace {

--- a/core/ns.go
+++ b/core/ns.go
@@ -11,6 +11,7 @@ type (
 	Namespace struct {
 		MetaHolder
 		Name     Symbol
+		Lazy     func()
 		mappings map[*string]*Var
 		aliases  map[*string]*Namespace
 		isUsed   bool

--- a/main.go
+++ b/main.go
@@ -402,6 +402,8 @@ func parseArgs(args []string) {
 			debugOut = Stderr
 		case "--debug=stdout":
 			debugOut = Stdout
+		case "--verbose":
+			Verbose = true
 		case "--help", "-h":
 			helpFlag = true
 			return // don't bother parsing anything else

--- a/std/base64/a_base64.go
+++ b/std/base64/a_base64.go
@@ -38,7 +38,7 @@ var encode_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	base64Namespace.ResetMeta(MakeMeta(nil, "Implements base64 encoding as specified by RFC 4648.", "1.0"))
 
@@ -53,4 +53,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("s"))),
 			`Returns the base64 encoding of s.`, "1.0"))
 
+}
+
+func init() {
+	base64Namespace.Lazy = Init
 }

--- a/std/crypto/a_crypto.go
+++ b/std/crypto/a_crypto.go
@@ -150,7 +150,7 @@ var sha512_256_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	cryptoNamespace.ResetMeta(MakeMeta(nil, "Implements common cryptographic and hash functions.", "1.0"))
 
@@ -201,4 +201,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("data"))),
 			`Returns the SHA512/256 checksum of the data.`, "1.0"))
 
+}
+
+func init() {
+	cryptoNamespace.Lazy = Init
 }

--- a/std/csv/a_csv.go
+++ b/std/csv/a_csv.go
@@ -72,7 +72,7 @@ var write_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	csvNamespace.ResetMeta(MakeMeta(nil, "Reads and writes comma-separated values (CSV) files as defined in RFC 4180.", "1.0"))
 
@@ -129,4 +129,8 @@ func init() {
 
   :use-crlf - if true, uses \r\n as the line terminator. Default value is false.`, "1.0"))
 
+}
+
+func init() {
+	csvNamespace.Lazy = Init
 }

--- a/std/filepath/a_filepath.go
+++ b/std/filepath/a_filepath.go
@@ -259,7 +259,7 @@ var volume_name_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	filepathNamespace.ResetMeta(MakeMeta(nil, "Implements utility routines for manipulating filename paths.", "1.0"))
 
@@ -403,4 +403,8 @@ If the result of this process is an empty string, returns the string ".".`, "1.0
 			`Returns leading volume name. Given "C:\foo\bar" it returns "C:" on Windows. Given "\\host\share\foo"
   returns "\\host\share". On other platforms it returns "".`, "1.0"))
 
+}
+
+func init() {
+	filepathNamespace.Lazy = Init
 }

--- a/std/hex/a_hex.go
+++ b/std/hex/a_hex.go
@@ -41,7 +41,7 @@ var encode_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	hexNamespace.ResetMeta(MakeMeta(nil, "Implements hexadecimal encoding and decoding.", "1.0"))
 
@@ -56,4 +56,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("s"))),
 			`Returns the hexadecimal encoding of s.`, "1.0"))
 
+}
+
+func init() {
+	hexNamespace.Lazy = Init
 }

--- a/std/html/a_html.go
+++ b/std/html/a_html.go
@@ -39,7 +39,7 @@ var unescape_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	htmlNamespace.ResetMeta(MakeMeta(nil, "Provides functions for escaping and unescaping HTML text.", "1.0"))
 
@@ -54,4 +54,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("s"))),
 			`Unescapes entities like &lt; to become <.`, "1.0"))
 
+}
+
+func init() {
+	htmlNamespace.Lazy = Init
 }

--- a/std/http/a_http.go
+++ b/std/http/a_http.go
@@ -54,7 +54,7 @@ var start_server_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	httpNamespace.ResetMeta(MakeMeta(nil, "Provides HTTP client and server implementations", "1.0"))
 
@@ -87,4 +87,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("addr"), MakeSymbol("handler"))),
 			`Starts HTTP server on the TCP network address addr.`, "1.0"))
 
+}
+
+func init() {
+	httpNamespace.Lazy = Init
 }

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -38,7 +38,7 @@ var write_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	jsonNamespace.ResetMeta(MakeMeta(nil, "Implements encoding and decoding of JSON as defined in RFC 4627.", "1.0"))
 
@@ -53,4 +53,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("v"))),
 			`Returns the JSON encoding of v.`, "1.0"))
 
+}
+
+func init() {
+	jsonNamespace.Lazy = Init
 }

--- a/std/math/a_math.go
+++ b/std/math/a_math.go
@@ -54,7 +54,7 @@ var sin_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	mathNamespace.ResetMeta(MakeMeta(nil, "Provides basic constants and mathematical functions.", "1.0"))
 
@@ -78,4 +78,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("x"))),
 			`Returns the sine of the radian argument x.`, "1.0"))
 
+}
+
+func init() {
+	mathNamespace.Lazy = Init
 }

--- a/std/os/a_os.go
+++ b/std/os/a_os.go
@@ -245,7 +245,7 @@ var stat_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	osNamespace.ResetMeta(MakeMeta(nil, "Provides a platform-independent interface to operating system functionality.", "1.0"))
 
@@ -359,4 +359,8 @@ func init() {
   :modtime - modification time
   :dir? - true if file is a directory`, "1.0"))
 
+}
+
+func init() {
+	osNamespace.Lazy = Init
 }

--- a/std/package.tmpl
+++ b/std/package.tmpl
@@ -11,10 +11,14 @@ var {nsName}Namespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.{nsFullName
 {non-fns}
 
 {fns}
-func init() {
+func Init() {
 
 	{nsName}Namespace.ResetMeta(MakeMeta(nil, "{nsDocstring}", "1.0"))
 
 	{non-fns-interns}
 	{fns-interns}
+}
+
+func init() {
+	{nsName}Namespace.Lazy = Init
 }

--- a/std/strconv/a_strconv.go
+++ b/std/strconv/a_strconv.go
@@ -275,7 +275,7 @@ var unquote_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	strconvNamespace.ResetMeta(MakeMeta(nil, "Implements conversions to and from string representations of basic data types.", "1.0"))
 
@@ -381,4 +381,8 @@ func init() {
 			`Interprets s as a single-quoted, double-quoted, or backquoted string literal, returning the string value that s quotes.
   (If s is single-quoted, it would be a Go character literal; Unquote returns the corresponding one-character string.)`, "1.0"))
 
+}
+
+func init() {
+	strconvNamespace.Lazy = Init
 }

--- a/std/string/a_string.go
+++ b/std/string/a_string.go
@@ -390,7 +390,7 @@ var upper_case_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	stringNamespace.ResetMeta(MakeMeta(nil, "Implements simple functions to manipulate strings.", "1.0"))
 
@@ -532,4 +532,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("s"))),
 			`Converts string to all upper-case.`, "1.0"))
 
+}
+
+func init() {
+	stringNamespace.Lazy = Init
 }

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -296,7 +296,7 @@ var until_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	timeNamespace.ResetMeta(MakeMeta(nil, "Provides functionality for measuring and displaying time.", "1.0"))
 
@@ -504,4 +504,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("t"))),
 			`Returns the duration in nanoseconds until t.`, "1.0"))
 
+}
+
+func init() {
+	timeNamespace.Lazy = Init
 }

--- a/std/url/a_url.go
+++ b/std/url/a_url.go
@@ -67,7 +67,7 @@ var query_unescape_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	urlNamespace.ResetMeta(MakeMeta(nil, "Parses URLs and implements query escaping.", "1.0"))
 
@@ -98,4 +98,8 @@ func init() {
   substring of the form "%AB" into the hex-decoded byte 0xAB. It also converts
   '+' into ' ' (space). It returns an error if any % is not followed by two hexadecimal digits.`, "1.0"))
 
+}
+
+func init() {
+	urlNamespace.Lazy = Init
 }

--- a/std/yaml/a_yaml.go
+++ b/std/yaml/a_yaml.go
@@ -38,7 +38,7 @@ var write_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-func init() {
+func Init() {
 
 	yamlNamespace.ResetMeta(MakeMeta(nil, "Implements encoding and decoding of YAML.", "1.0"))
 
@@ -53,4 +53,8 @@ func init() {
 			NewListFrom(NewVectorFrom(MakeSymbol("v"))),
 			`Returns the YAML encoding of v.`, "1.0"))
 
+}
+
+func init() {
+	yamlNamespace.Lazy = Init
 }


### PR DESCRIPTION
This is something of a proof of concept, as it doesn't seem to speed up official Joker much that I can measure on the two machines I'm using while on vacation (and my main development machine, at home, is even less likely to show much of a difference).

But, applied to my `gostd` fork, the resulting Joker definitely starts up faster, though still not as quickly as official Joker. (I think there's room for further improvement, in terms of delaying `var`-time initialization until `Init()` is called. That might help things further.)

That suggests this PR, or something like it, could keep Joker startup times from getting much longer even if/as more namespaces and/or functions (vars) are added to its default library.

Note that, while trying different ideas out, I was disappointed to discover that Go currently does not offer much in the way of practical build-time initialization, beyond scalar constants. That is, arrays and maps, in particular, cannot be initialized at build time and thus be present, already-initialized, when the resulting executable starts up. I hope to see improvements in this situation someday soon, and might look into how feasible it is to do and possibly offer to help with them.