### PR TITLE
Merge more startup-time laziness/deferral from gostd fork

### DIFF
--- a/std/base64/a_base64.go
+++ b/std/base64/a_base64.go
@@ -10,7 +10,9 @@ var base64Namespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.base64"))
 
 
 
-var decode_string_ Proc = func(_args []Object) Object {
+var decode_string_ Proc
+
+func __decode_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -24,7 +26,9 @@ var decode_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var encode_string_ Proc = func(_args []Object) Object {
+var encode_string_ Proc
+
+func __encode_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -39,6 +43,9 @@ var encode_string_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	decode_string_ = __decode_string_
+	encode_string_ = __encode_string_
 
 	base64Namespace.ResetMeta(MakeMeta(nil, "Implements base64 encoding as specified by RFC 4648.", "1.0"))
 

--- a/std/crypto/a_crypto.go
+++ b/std/crypto/a_crypto.go
@@ -14,7 +14,9 @@ var cryptoNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.crypto"))
 
 
 
-var hmac_ Proc = func(_args []Object) Object {
+var hmac_ Proc
+
+func __hmac_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 3:
@@ -30,7 +32,9 @@ var hmac_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var md5_ Proc = func(_args []Object) Object {
+var md5_ Proc
+
+func __md5_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -45,7 +49,9 @@ var md5_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sha1_ Proc = func(_args []Object) Object {
+var sha1_ Proc
+
+func __sha1_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -60,7 +66,9 @@ var sha1_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sha224_ Proc = func(_args []Object) Object {
+var sha224_ Proc
+
+func __sha224_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -75,7 +83,9 @@ var sha224_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sha256_ Proc = func(_args []Object) Object {
+var sha256_ Proc
+
+func __sha256_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -90,7 +100,9 @@ var sha256_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sha384_ Proc = func(_args []Object) Object {
+var sha384_ Proc
+
+func __sha384_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -105,7 +117,9 @@ var sha384_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sha512_ Proc = func(_args []Object) Object {
+var sha512_ Proc
+
+func __sha512_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -120,7 +134,9 @@ var sha512_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sha512_224_ Proc = func(_args []Object) Object {
+var sha512_224_ Proc
+
+func __sha512_224_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -135,7 +151,9 @@ var sha512_224_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sha512_256_ Proc = func(_args []Object) Object {
+var sha512_256_ Proc
+
+func __sha512_256_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -151,6 +169,16 @@ var sha512_256_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	hmac_ = __hmac_
+	md5_ = __md5_
+	sha1_ = __sha1_
+	sha224_ = __sha224_
+	sha256_ = __sha256_
+	sha384_ = __sha384_
+	sha512_ = __sha512_
+	sha512_224_ = __sha512_224_
+	sha512_256_ = __sha512_256_
 
 	cryptoNamespace.ResetMeta(MakeMeta(nil, "Implements common cryptographic and hash functions.", "1.0"))
 

--- a/std/csv/a_csv.go
+++ b/std/csv/a_csv.go
@@ -10,7 +10,9 @@ var csvNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.csv"))
 
 
 
-var csv_seq_ Proc = func(_args []Object) Object {
+var csv_seq_ Proc
+
+func __csv_seq_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -30,7 +32,9 @@ var csv_seq_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var write_ Proc = func(_args []Object) Object {
+var write_ Proc
+
+func __write_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -52,7 +56,9 @@ var write_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var write_string_ Proc = func(_args []Object) Object {
+var write_string_ Proc
+
+func __write_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -73,6 +79,10 @@ var write_string_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	csv_seq_ = __csv_seq_
+	write_ = __write_
+	write_string_ = __write_string_
 
 	csvNamespace.ResetMeta(MakeMeta(nil, "Reads and writes comma-separated values (CSV) files as defined in RFC 4180.", "1.0"))
 

--- a/std/filepath/a_filepath.go
+++ b/std/filepath/a_filepath.go
@@ -9,10 +9,12 @@ import (
 
 var filepathNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.filepath"))
 
-var list_separator_ = MakeString(string(filepath.ListSeparator))
-var separator_ = MakeString(string(filepath.Separator))
+var list_separator_ String
+var separator_ String
 
-var abs_ Proc = func(_args []Object) Object {
+var abs_ Proc
+
+func __abs_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -27,7 +29,9 @@ var abs_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var isabs_ Proc = func(_args []Object) Object {
+var isabs_ Proc
+
+func __isabs_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -41,7 +45,9 @@ var isabs_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var base_ Proc = func(_args []Object) Object {
+var base_ Proc
+
+func __base_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -55,7 +61,9 @@ var base_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var clean_ Proc = func(_args []Object) Object {
+var clean_ Proc
+
+func __clean_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -69,7 +77,9 @@ var clean_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var dir_ Proc = func(_args []Object) Object {
+var dir_ Proc
+
+func __dir_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -83,7 +93,9 @@ var dir_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var eval_symlinks_ Proc = func(_args []Object) Object {
+var eval_symlinks_ Proc
+
+func __eval_symlinks_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -98,7 +110,9 @@ var eval_symlinks_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var ext_ Proc = func(_args []Object) Object {
+var ext_ Proc
+
+func __ext_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -112,7 +126,9 @@ var ext_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var file_seq_ Proc = func(_args []Object) Object {
+var file_seq_ Proc
+
+func __file_seq_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -126,7 +142,9 @@ var file_seq_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var from_slash_ Proc = func(_args []Object) Object {
+var from_slash_ Proc
+
+func __from_slash_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -140,7 +158,9 @@ var from_slash_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var glob_ Proc = func(_args []Object) Object {
+var glob_ Proc
+
+func __glob_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -155,7 +175,9 @@ var glob_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var join_ Proc = func(_args []Object) Object {
+var join_ Proc
+
+func __join_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case true:
@@ -170,7 +192,9 @@ var join_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var ismatches_ Proc = func(_args []Object) Object {
+var ismatches_ Proc
+
+func __ismatches_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -186,7 +210,9 @@ var ismatches_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var rel_ Proc = func(_args []Object) Object {
+var rel_ Proc
+
+func __rel_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -202,7 +228,9 @@ var rel_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var split_ Proc = func(_args []Object) Object {
+var split_ Proc
+
+func __split_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -217,7 +245,9 @@ var split_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var split_list_ Proc = func(_args []Object) Object {
+var split_list_ Proc
+
+func __split_list_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -231,7 +261,9 @@ var split_list_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var to_slash_ Proc = func(_args []Object) Object {
+var to_slash_ Proc
+
+func __to_slash_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -245,7 +277,9 @@ var to_slash_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var volume_name_ Proc = func(_args []Object) Object {
+var volume_name_ Proc
+
+func __volume_name_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -260,6 +294,25 @@ var volume_name_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+	list_separator_ = MakeString(string(filepath.ListSeparator))
+	separator_ = MakeString(string(filepath.Separator))
+	abs_ = __abs_
+	isabs_ = __isabs_
+	base_ = __base_
+	clean_ = __clean_
+	dir_ = __dir_
+	eval_symlinks_ = __eval_symlinks_
+	ext_ = __ext_
+	file_seq_ = __file_seq_
+	from_slash_ = __from_slash_
+	glob_ = __glob_
+	join_ = __join_
+	ismatches_ = __ismatches_
+	rel_ = __rel_
+	split_ = __split_
+	split_list_ = __split_list_
+	to_slash_ = __to_slash_
+	volume_name_ = __volume_name_
 
 	filepathNamespace.ResetMeta(MakeMeta(nil, "Implements utility routines for manipulating filename paths.", "1.0"))
 

--- a/std/fn.tmpl
+++ b/std/fn.tmpl
@@ -1,4 +1,6 @@
-var {fnName} Proc = func(_args []Object) Object {
+var {fnName} Proc
+
+func __{fnName}(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	{arities}

--- a/std/generate-std.joke
+++ b/std/generate-std.joke
@@ -29,6 +29,7 @@
   )
 
 (defn go-name
+  "Convert Clojure-style function name to unique Go-style name suitable as its internal implementation."
   [fn-name]
   (let [n (-> fn-name
               (rpl "-" "_")
@@ -98,7 +99,7 @@
                       (str "MakeSymbol(" (q (str arg)) ")")))
        ")"))
 
-(defn generate-fn
+(defn generate-fn-decl
   [ns-name ns-name-final k v]
   (let [m (meta v)
         arglists (:arglists m)
@@ -121,14 +122,46 @@
                                  ")")))]
     [fn-str intern-str]))
 
-(defn generate-non-fn
+(defn generate-fn-init
+  [v]
+  (let [g (go-name (str v))]
+    (format "\t%s = __%s" g g)))
+
+(defn go-return-type
+  "Returns the return type of the Make<t>() function. Would be unnecessary if Go code could declare a var as having 'the type returned by <func>'."
+  [t]
+  (condp = t
+    "BigInt" "*BigInt"
+    "BigIntU" "*BigInt"
+    "Number" "*BigInt"
+    "StringVector" "*Vector"
+    "Error" "String"
+    t))
+
+(defn generate-const-or-var-decl
+  [name m]
+  (let [type (type-name (:tag m))]
+    (if (= type "Var")
+      (format "var %s *GoVar" name)  ; Not yet supported by this version of Joker (see https://github.com/jcburley/joker/)
+      (format "var %s %s" name (go-return-type type)))))
+
+(defn generate-const-or-var-init
+  [name m]
+  (let [type (type-name (:tag m))]
+    (if (= type "Var")
+      (format "\t%s = &GoVar{Value: &%s}"  ; Get pointer to the actual var, not a copy of the var
+              name
+              (:go m))
+      (format "\t%s = Make%s(%s)"
+              name
+              type
+              (:go m)))))
+
+(defn generate-non-fn-decl
   [ns-name ns-name-final k v]
   (let [m (meta v)
         go-non-fn-name (go-name (str k))
-        non-fn-str (format "var %s = Make%s(%s)"
-                           go-non-fn-name
-                           (type-name (:tag m))
-                           (:go m))
+        non-fn-str (generate-const-or-var-decl go-non-fn-name m)
         intern-str (-> intern-template
                        (rpl "{nsFullName}" ns-name)
                        (rpl "{nsName}" ns-name-final)
@@ -138,6 +171,13 @@
                        (rpl "{added}" (:added m))
                        (rpl "{args}" "nil"))]
     [non-fn-str intern-str]))
+
+(defn generate-non-fn-init
+  [ns-name-final k v]
+  (let [m (meta v)
+        go-non-fn-name (go-name (str k))
+        non-fn-str (generate-const-or-var-init go-non-fn-name m)]
+    non-fn-str))
 
 (defn comment-out
   [s]
@@ -188,10 +228,14 @@
         m (meta ns)
         go-non-fns (sort-by first (ns-public-go-non-fns ns))
         go-fns (sort-by first (ns-public-go-fns ns))
-        fns (for [[k v] go-fns]
-              (generate-fn ns-name ns-name-final k v))
-        non-fns (for [[k v] go-non-fns]
-                  (generate-non-fn ns-name ns-name-final k v))
+        fn-decls (for [[k v] go-fns]
+              (generate-fn-decl ns-name ns-name-final k v))
+        fn-inits (for [[k _] go-fns]
+                    (generate-fn-init k))
+        non-fn-decls (for [[k v] go-non-fns]
+                       (generate-non-fn-decl ns-name ns-name-final k v))
+        non-fn-inits (for [[k v] go-non-fns]
+                       (generate-non-fn-init ns-name-final k v))
         res (-> package-template
                 (rpl "{nsFullName}" ns-name)
                 (rpl "{nsName}" ns-name-final)
@@ -199,11 +243,13 @@
                      (s/join "\n\t" (sort compare-imports (conj
                                                            (mapv q (:go-imports m))
                                                            ". \"github.com/candid82/joker/core\""))))
-                (rpl "{non-fns}" (s/join "\n" (map first non-fns)))
-                (rpl "{fns}" (s/join "\n" (map first fns)))
+                (rpl "{non-fn-decls}" (s/join "\n" (map first non-fn-decls)))
+                (rpl "{non-fn-inits}" (s/join "\n" non-fn-inits))
+                (rpl "{fn-decls}" (s/join "\n" (map first fn-decls)))
+                (rpl "{fn-inits}" (s/join "\n" fn-inits))
                 (rpl "{nsDocstring}" (:doc m))
-                (rpl "{non-fns-interns}" (s/join "\n\t" (map second non-fns)))
-                (rpl "{fns-interns}" (s/join "\n\t" (map second fns))))
+                (rpl "{non-fn-interns}" (s/join "\n\t" (map second non-fn-decls)))
+                (rpl "{fn-interns}" (s/join "\n\t" (map second fn-decls))))
         res (if (:empty m)
               (comment-out res)
               res)]

--- a/std/hex/a_hex.go
+++ b/std/hex/a_hex.go
@@ -11,7 +11,9 @@ var hexNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.hex"))
 
 
 
-var decode_string_ Proc = func(_args []Object) Object {
+var decode_string_ Proc
+
+func __decode_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -27,7 +29,9 @@ var decode_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var encode_string_ Proc = func(_args []Object) Object {
+var encode_string_ Proc
+
+func __encode_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -42,6 +46,9 @@ var encode_string_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	decode_string_ = __decode_string_
+	encode_string_ = __encode_string_
 
 	hexNamespace.ResetMeta(MakeMeta(nil, "Implements hexadecimal encoding and decoding.", "1.0"))
 

--- a/std/html/a_html.go
+++ b/std/html/a_html.go
@@ -11,7 +11,9 @@ var htmlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.html"))
 
 
 
-var escape_ Proc = func(_args []Object) Object {
+var escape_ Proc
+
+func __escape_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -25,7 +27,9 @@ var escape_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var unescape_ Proc = func(_args []Object) Object {
+var unescape_ Proc
+
+func __unescape_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -40,6 +44,9 @@ var unescape_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	escape_ = __escape_
+	unescape_ = __unescape_
 
 	htmlNamespace.ResetMeta(MakeMeta(nil, "Provides functions for escaping and unescaping HTML text.", "1.0"))
 

--- a/std/http/a_http.go
+++ b/std/http/a_http.go
@@ -10,7 +10,9 @@ var httpNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.http"))
 
 
 
-var send_ Proc = func(_args []Object) Object {
+var send_ Proc
+
+func __send_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -24,7 +26,9 @@ var send_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var start_file_server_ Proc = func(_args []Object) Object {
+var start_file_server_ Proc
+
+func __start_file_server_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -39,7 +43,9 @@ var start_file_server_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var start_server_ Proc = func(_args []Object) Object {
+var start_server_ Proc
+
+func __start_server_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -55,6 +61,10 @@ var start_server_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	send_ = __send_
+	start_file_server_ = __start_file_server_
+	start_server_ = __start_server_
 
 	httpNamespace.ResetMeta(MakeMeta(nil, "Provides HTTP client and server implementations", "1.0"))
 

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -10,7 +10,9 @@ var jsonNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.json"))
 
 
 
-var read_string_ Proc = func(_args []Object) Object {
+var read_string_ Proc
+
+func __read_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -24,7 +26,9 @@ var read_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var write_string_ Proc = func(_args []Object) Object {
+var write_string_ Proc
+
+func __write_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -39,6 +43,9 @@ var write_string_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	read_string_ = __read_string_
+	write_string_ = __write_string_
 
 	jsonNamespace.ResetMeta(MakeMeta(nil, "Implements encoding and decoding of JSON as defined in RFC 4627.", "1.0"))
 

--- a/std/math/a_math.go
+++ b/std/math/a_math.go
@@ -9,9 +9,11 @@ import (
 
 var mathNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.math"))
 
-var pi_ = MakeDouble(math.Pi)
+var pi_ Double
 
-var cos_ Proc = func(_args []Object) Object {
+var cos_ Proc
+
+func __cos_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -25,7 +27,9 @@ var cos_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var hypot_ Proc = func(_args []Object) Object {
+var hypot_ Proc
+
+func __hypot_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -40,7 +44,9 @@ var hypot_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sin_ Proc = func(_args []Object) Object {
+var sin_ Proc
+
+func __sin_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -55,6 +61,10 @@ var sin_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+	pi_ = MakeDouble(math.Pi)
+	cos_ = __cos_
+	hypot_ = __hypot_
+	sin_ = __sin_
 
 	mathNamespace.ResetMeta(MakeMeta(nil, "Provides basic constants and mathematical functions.", "1.0"))
 

--- a/std/os/a_os.go
+++ b/std/os/a_os.go
@@ -11,7 +11,9 @@ var osNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.os"))
 
 
 
-var args_ Proc = func(_args []Object) Object {
+var args_ Proc
+
+func __args_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 0:
@@ -24,7 +26,9 @@ var args_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var chdir_ Proc = func(_args []Object) Object {
+var chdir_ Proc
+
+func __chdir_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -38,7 +42,9 @@ var chdir_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var close_ Proc = func(_args []Object) Object {
+var close_ Proc
+
+func __close_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -54,7 +60,9 @@ var close_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var create_ Proc = func(_args []Object) Object {
+var create_ Proc
+
+func __create_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -69,7 +77,9 @@ var create_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var cwd_ Proc = func(_args []Object) Object {
+var cwd_ Proc
+
+func __cwd_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 0:
@@ -82,7 +92,9 @@ var cwd_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var env_ Proc = func(_args []Object) Object {
+var env_ Proc
+
+func __env_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 0:
@@ -95,7 +107,9 @@ var env_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var exec_ Proc = func(_args []Object) Object {
+var exec_ Proc
+
+func __exec_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -110,7 +124,9 @@ var exec_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var isexists_ Proc = func(_args []Object) Object {
+var isexists_ Proc
+
+func __isexists_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -124,7 +140,9 @@ var isexists_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var exit_ Proc = func(_args []Object) Object {
+var exit_ Proc
+
+func __exit_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -139,7 +157,9 @@ var exit_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var ls_ Proc = func(_args []Object) Object {
+var ls_ Proc
+
+func __ls_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -153,7 +173,9 @@ var ls_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var mkdir_ Proc = func(_args []Object) Object {
+var mkdir_ Proc
+
+func __mkdir_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -168,7 +190,9 @@ var mkdir_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var open_ Proc = func(_args []Object) Object {
+var open_ Proc
+
+func __open_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -183,7 +207,9 @@ var open_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var set_env_ Proc = func(_args []Object) Object {
+var set_env_ Proc
+
+func __set_env_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -198,7 +224,9 @@ var set_env_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sh_ Proc = func(_args []Object) Object {
+var sh_ Proc
+
+func __sh_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case true:
@@ -214,7 +242,9 @@ var sh_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sh_from_ Proc = func(_args []Object) Object {
+var sh_from_ Proc
+
+func __sh_from_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case true:
@@ -231,7 +261,9 @@ var sh_from_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var stat_ Proc = func(_args []Object) Object {
+var stat_ Proc
+
+func __stat_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -246,6 +278,23 @@ var stat_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	args_ = __args_
+	chdir_ = __chdir_
+	close_ = __close_
+	create_ = __create_
+	cwd_ = __cwd_
+	env_ = __env_
+	exec_ = __exec_
+	isexists_ = __isexists_
+	exit_ = __exit_
+	ls_ = __ls_
+	mkdir_ = __mkdir_
+	open_ = __open_
+	set_env_ = __set_env_
+	sh_ = __sh_
+	sh_from_ = __sh_from_
+	stat_ = __stat_
 
 	osNamespace.ResetMeta(MakeMeta(nil, "Provides a platform-independent interface to operating system functionality.", "1.0"))
 

--- a/std/package.tmpl
+++ b/std/package.tmpl
@@ -8,15 +8,17 @@ import (
 
 var {nsName}Namespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.{nsFullName}"))
 
-{non-fns}
+{non-fn-decls}
 
-{fns}
+{fn-decls}
 func Init() {
+{non-fn-inits}
+{fn-inits}
 
 	{nsName}Namespace.ResetMeta(MakeMeta(nil, "{nsDocstring}", "1.0"))
 
-	{non-fns-interns}
-	{fns-interns}
+	{non-fn-interns}
+	{fn-interns}
 }
 
 func init() {

--- a/std/strconv/a_strconv.go
+++ b/std/strconv/a_strconv.go
@@ -11,7 +11,9 @@ var strconvNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.strconv"))
 
 
 
-var atoi_ Proc = func(_args []Object) Object {
+var atoi_ Proc
+
+func __atoi_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -26,7 +28,9 @@ var atoi_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var iscan_backquote_ Proc = func(_args []Object) Object {
+var iscan_backquote_ Proc
+
+func __iscan_backquote_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -40,7 +44,9 @@ var iscan_backquote_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var format_bool_ Proc = func(_args []Object) Object {
+var format_bool_ Proc
+
+func __format_bool_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -54,7 +60,9 @@ var format_bool_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var format_double_ Proc = func(_args []Object) Object {
+var format_double_ Proc
+
+func __format_double_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 4:
@@ -71,7 +79,9 @@ var format_double_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var format_int_ Proc = func(_args []Object) Object {
+var format_int_ Proc
+
+func __format_int_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -86,7 +96,9 @@ var format_int_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var isgraphic_ Proc = func(_args []Object) Object {
+var isgraphic_ Proc
+
+func __isgraphic_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -100,7 +112,9 @@ var isgraphic_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var itoa_ Proc = func(_args []Object) Object {
+var itoa_ Proc
+
+func __itoa_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -114,7 +128,9 @@ var itoa_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var parse_bool_ Proc = func(_args []Object) Object {
+var parse_bool_ Proc
+
+func __parse_bool_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -129,7 +145,9 @@ var parse_bool_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var parse_double_ Proc = func(_args []Object) Object {
+var parse_double_ Proc
+
+func __parse_double_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -144,7 +162,9 @@ var parse_double_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var parse_int_ Proc = func(_args []Object) Object {
+var parse_int_ Proc
+
+func __parse_int_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 3:
@@ -162,7 +182,9 @@ var parse_int_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var isprintable_ Proc = func(_args []Object) Object {
+var isprintable_ Proc
+
+func __isprintable_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -176,7 +198,9 @@ var isprintable_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var quote_ Proc = func(_args []Object) Object {
+var quote_ Proc
+
+func __quote_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -190,7 +214,9 @@ var quote_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var quote_char_ Proc = func(_args []Object) Object {
+var quote_char_ Proc
+
+func __quote_char_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -204,7 +230,9 @@ var quote_char_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var quote_char_to_ascii_ Proc = func(_args []Object) Object {
+var quote_char_to_ascii_ Proc
+
+func __quote_char_to_ascii_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -218,7 +246,9 @@ var quote_char_to_ascii_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var quote_char_to_graphic_ Proc = func(_args []Object) Object {
+var quote_char_to_graphic_ Proc
+
+func __quote_char_to_graphic_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -232,7 +262,9 @@ var quote_char_to_graphic_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var quote_to_ascii_ Proc = func(_args []Object) Object {
+var quote_to_ascii_ Proc
+
+func __quote_to_ascii_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -246,7 +278,9 @@ var quote_to_ascii_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var quote_to_graphic_ Proc = func(_args []Object) Object {
+var quote_to_graphic_ Proc
+
+func __quote_to_graphic_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -260,7 +294,9 @@ var quote_to_graphic_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var unquote_ Proc = func(_args []Object) Object {
+var unquote_ Proc
+
+func __unquote_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -276,6 +312,25 @@ var unquote_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	atoi_ = __atoi_
+	iscan_backquote_ = __iscan_backquote_
+	format_bool_ = __format_bool_
+	format_double_ = __format_double_
+	format_int_ = __format_int_
+	isgraphic_ = __isgraphic_
+	itoa_ = __itoa_
+	parse_bool_ = __parse_bool_
+	parse_double_ = __parse_double_
+	parse_int_ = __parse_int_
+	isprintable_ = __isprintable_
+	quote_ = __quote_
+	quote_char_ = __quote_char_
+	quote_char_to_ascii_ = __quote_char_to_ascii_
+	quote_char_to_graphic_ = __quote_char_to_graphic_
+	quote_to_ascii_ = __quote_to_ascii_
+	quote_to_graphic_ = __quote_to_graphic_
+	unquote_ = __unquote_
 
 	strconvNamespace.ResetMeta(MakeMeta(nil, "Implements conversions to and from string representations of basic data types.", "1.0"))
 

--- a/std/string/a_string.go
+++ b/std/string/a_string.go
@@ -12,7 +12,9 @@ var stringNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.string"))
 
 
 
-var isblank_ Proc = func(_args []Object) Object {
+var isblank_ Proc
+
+func __isblank_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -26,7 +28,9 @@ var isblank_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var capitalize_ Proc = func(_args []Object) Object {
+var capitalize_ Proc
+
+func __capitalize_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -40,7 +44,9 @@ var capitalize_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var isends_with_ Proc = func(_args []Object) Object {
+var isends_with_ Proc
+
+func __isends_with_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -55,7 +61,9 @@ var isends_with_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var escape_ Proc = func(_args []Object) Object {
+var escape_ Proc
+
+func __escape_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -70,7 +78,9 @@ var escape_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var isincludes_ Proc = func(_args []Object) Object {
+var isincludes_ Proc
+
+func __isincludes_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -85,7 +95,9 @@ var isincludes_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var index_of_ Proc = func(_args []Object) Object {
+var index_of_ Proc
+
+func __index_of_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -107,7 +119,9 @@ var index_of_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var join_ Proc = func(_args []Object) Object {
+var join_ Proc
+
+func __join_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -127,7 +141,9 @@ var join_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var last_index_of_ Proc = func(_args []Object) Object {
+var last_index_of_ Proc
+
+func __last_index_of_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -149,7 +165,9 @@ var last_index_of_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var lower_case_ Proc = func(_args []Object) Object {
+var lower_case_ Proc
+
+func __lower_case_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -163,7 +181,9 @@ var lower_case_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var pad_left_ Proc = func(_args []Object) Object {
+var pad_left_ Proc
+
+func __pad_left_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 3:
@@ -179,7 +199,9 @@ var pad_left_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var pad_right_ Proc = func(_args []Object) Object {
+var pad_right_ Proc
+
+func __pad_right_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 3:
@@ -195,7 +217,9 @@ var pad_right_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var replace_ Proc = func(_args []Object) Object {
+var replace_ Proc
+
+func __replace_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 3:
@@ -211,7 +235,9 @@ var replace_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var replace_first_ Proc = func(_args []Object) Object {
+var replace_first_ Proc
+
+func __replace_first_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 3:
@@ -227,7 +253,9 @@ var replace_first_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var reverse_ Proc = func(_args []Object) Object {
+var reverse_ Proc
+
+func __reverse_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -241,7 +269,9 @@ var reverse_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var split_ Proc = func(_args []Object) Object {
+var split_ Proc
+
+func __split_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -263,7 +293,9 @@ var split_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var split_lines_ Proc = func(_args []Object) Object {
+var split_lines_ Proc
+
+func __split_lines_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -277,7 +309,9 @@ var split_lines_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var isstarts_with_ Proc = func(_args []Object) Object {
+var isstarts_with_ Proc
+
+func __isstarts_with_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -292,7 +326,9 @@ var isstarts_with_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var trim_ Proc = func(_args []Object) Object {
+var trim_ Proc
+
+func __trim_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -306,7 +342,9 @@ var trim_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var trim_left_ Proc = func(_args []Object) Object {
+var trim_left_ Proc
+
+func __trim_left_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -320,7 +358,9 @@ var trim_left_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var trim_newline_ Proc = func(_args []Object) Object {
+var trim_newline_ Proc
+
+func __trim_newline_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -334,7 +374,9 @@ var trim_newline_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var trim_right_ Proc = func(_args []Object) Object {
+var trim_right_ Proc
+
+func __trim_right_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -348,7 +390,9 @@ var trim_right_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var triml_ Proc = func(_args []Object) Object {
+var triml_ Proc
+
+func __triml_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -362,7 +406,9 @@ var triml_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var trimr_ Proc = func(_args []Object) Object {
+var trimr_ Proc
+
+func __trimr_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -376,7 +422,9 @@ var trimr_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var upper_case_ Proc = func(_args []Object) Object {
+var upper_case_ Proc
+
+func __upper_case_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -391,6 +439,31 @@ var upper_case_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	isblank_ = __isblank_
+	capitalize_ = __capitalize_
+	isends_with_ = __isends_with_
+	escape_ = __escape_
+	isincludes_ = __isincludes_
+	index_of_ = __index_of_
+	join_ = __join_
+	last_index_of_ = __last_index_of_
+	lower_case_ = __lower_case_
+	pad_left_ = __pad_left_
+	pad_right_ = __pad_right_
+	replace_ = __replace_
+	replace_first_ = __replace_first_
+	reverse_ = __reverse_
+	split_ = __split_
+	split_lines_ = __split_lines_
+	isstarts_with_ = __isstarts_with_
+	trim_ = __trim_
+	trim_left_ = __trim_left_
+	trim_newline_ = __trim_newline_
+	trim_right_ = __trim_right_
+	triml_ = __triml_
+	trimr_ = __trimr_
+	upper_case_ = __upper_case_
 
 	stringNamespace.ResetMeta(MakeMeta(nil, "Implements simple functions to manipulate strings.", "1.0"))
 

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -9,29 +9,31 @@ import (
 
 var timeNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.time"))
 
-var ansi_c_ = MakeString(time.ANSIC)
-var hour_ = MakeBigInt(int64(time.Hour))
-var kitchen_ = MakeString(time.Kitchen)
-var microsecond_ = MakeInt(int(time.Microsecond))
-var millisecond_ = MakeInt(int(time.Millisecond))
-var minute_ = MakeBigInt(int64(time.Minute))
-var nanosecond_ = MakeInt(int(time.Nanosecond))
-var rfc1123_ = MakeString(time.RFC1123)
-var rfc1123_z_ = MakeString(time.RFC1123Z)
-var rfc3339_ = MakeString(time.RFC3339)
-var rfc3339_nano_ = MakeString(time.RFC3339Nano)
-var rfc822_ = MakeString(time.RFC822)
-var rfc822_z_ = MakeString(time.RFC822Z)
-var rfc850_ = MakeString(time.RFC850)
-var ruby_date_ = MakeString(time.RubyDate)
-var second_ = MakeInt(int(time.Second))
-var stamp_ = MakeString(time.Stamp)
-var stamp_micro_ = MakeString(time.StampMicro)
-var stamp_milli_ = MakeString(time.StampMilli)
-var stamp_nano_ = MakeString(time.StampNano)
-var unix_date_ = MakeString(time.UnixDate)
+var ansi_c_ String
+var hour_ *BigInt
+var kitchen_ String
+var microsecond_ Int
+var millisecond_ Int
+var minute_ *BigInt
+var nanosecond_ Int
+var rfc1123_ String
+var rfc1123_z_ String
+var rfc3339_ String
+var rfc3339_nano_ String
+var rfc822_ String
+var rfc822_z_ String
+var rfc850_ String
+var ruby_date_ String
+var second_ Int
+var stamp_ String
+var stamp_micro_ String
+var stamp_milli_ String
+var stamp_nano_ String
+var unix_date_ String
 
-var add_ Proc = func(_args []Object) Object {
+var add_ Proc
+
+func __add_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -46,7 +48,9 @@ var add_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var add_date_ Proc = func(_args []Object) Object {
+var add_date_ Proc
+
+func __add_date_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 4:
@@ -63,7 +67,9 @@ var add_date_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var format_ Proc = func(_args []Object) Object {
+var format_ Proc
+
+func __format_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -78,7 +84,9 @@ var format_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var from_unix_ Proc = func(_args []Object) Object {
+var from_unix_ Proc
+
+func __from_unix_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -93,7 +101,9 @@ var from_unix_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var hours_ Proc = func(_args []Object) Object {
+var hours_ Proc
+
+func __hours_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -107,7 +117,9 @@ var hours_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var minutes_ Proc = func(_args []Object) Object {
+var minutes_ Proc
+
+func __minutes_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -121,7 +133,9 @@ var minutes_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var now_ Proc = func(_args []Object) Object {
+var now_ Proc
+
+func __now_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 0:
@@ -134,7 +148,9 @@ var now_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var parse_ Proc = func(_args []Object) Object {
+var parse_ Proc
+
+func __parse_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -150,7 +166,9 @@ var parse_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var parse_duration_ Proc = func(_args []Object) Object {
+var parse_duration_ Proc
+
+func __parse_duration_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -166,7 +184,9 @@ var parse_duration_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var round_ Proc = func(_args []Object) Object {
+var round_ Proc
+
+func __round_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -181,7 +201,9 @@ var round_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var seconds_ Proc = func(_args []Object) Object {
+var seconds_ Proc
+
+func __seconds_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -195,7 +217,9 @@ var seconds_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var since_ Proc = func(_args []Object) Object {
+var since_ Proc
+
+func __since_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -209,7 +233,9 @@ var since_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sleep_ Proc = func(_args []Object) Object {
+var sleep_ Proc
+
+func __sleep_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -224,7 +250,9 @@ var sleep_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var string_ Proc = func(_args []Object) Object {
+var string_ Proc
+
+func __string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -238,7 +266,9 @@ var string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var sub_ Proc = func(_args []Object) Object {
+var sub_ Proc
+
+func __sub_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -253,7 +283,9 @@ var sub_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var truncate_ Proc = func(_args []Object) Object {
+var truncate_ Proc
+
+func __truncate_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 2:
@@ -268,7 +300,9 @@ var truncate_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var unix_ Proc = func(_args []Object) Object {
+var unix_ Proc
+
+func __unix_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -282,7 +316,9 @@ var unix_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var until_ Proc = func(_args []Object) Object {
+var until_ Proc
+
+func __until_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -297,6 +333,45 @@ var until_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+	ansi_c_ = MakeString(time.ANSIC)
+	hour_ = MakeBigInt(int64(time.Hour))
+	kitchen_ = MakeString(time.Kitchen)
+	microsecond_ = MakeInt(int(time.Microsecond))
+	millisecond_ = MakeInt(int(time.Millisecond))
+	minute_ = MakeBigInt(int64(time.Minute))
+	nanosecond_ = MakeInt(int(time.Nanosecond))
+	rfc1123_ = MakeString(time.RFC1123)
+	rfc1123_z_ = MakeString(time.RFC1123Z)
+	rfc3339_ = MakeString(time.RFC3339)
+	rfc3339_nano_ = MakeString(time.RFC3339Nano)
+	rfc822_ = MakeString(time.RFC822)
+	rfc822_z_ = MakeString(time.RFC822Z)
+	rfc850_ = MakeString(time.RFC850)
+	ruby_date_ = MakeString(time.RubyDate)
+	second_ = MakeInt(int(time.Second))
+	stamp_ = MakeString(time.Stamp)
+	stamp_micro_ = MakeString(time.StampMicro)
+	stamp_milli_ = MakeString(time.StampMilli)
+	stamp_nano_ = MakeString(time.StampNano)
+	unix_date_ = MakeString(time.UnixDate)
+	add_ = __add_
+	add_date_ = __add_date_
+	format_ = __format_
+	from_unix_ = __from_unix_
+	hours_ = __hours_
+	minutes_ = __minutes_
+	now_ = __now_
+	parse_ = __parse_
+	parse_duration_ = __parse_duration_
+	round_ = __round_
+	seconds_ = __seconds_
+	since_ = __since_
+	sleep_ = __sleep_
+	string_ = __string_
+	sub_ = __sub_
+	truncate_ = __truncate_
+	unix_ = __unix_
+	until_ = __until_
 
 	timeNamespace.ResetMeta(MakeMeta(nil, "Provides functionality for measuring and displaying time.", "1.0"))
 

--- a/std/url/a_url.go
+++ b/std/url/a_url.go
@@ -11,7 +11,9 @@ var urlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.url"))
 
 
 
-var path_escape_ Proc = func(_args []Object) Object {
+var path_escape_ Proc
+
+func __path_escape_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -25,7 +27,9 @@ var path_escape_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var path_unescape_ Proc = func(_args []Object) Object {
+var path_unescape_ Proc
+
+func __path_unescape_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -39,7 +43,9 @@ var path_unescape_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var query_escape_ Proc = func(_args []Object) Object {
+var query_escape_ Proc
+
+func __query_escape_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -53,7 +59,9 @@ var query_escape_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var query_unescape_ Proc = func(_args []Object) Object {
+var query_unescape_ Proc
+
+func __query_unescape_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -68,6 +76,11 @@ var query_unescape_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	path_escape_ = __path_escape_
+	path_unescape_ = __path_unescape_
+	query_escape_ = __query_escape_
+	query_unescape_ = __query_unescape_
 
 	urlNamespace.ResetMeta(MakeMeta(nil, "Parses URLs and implements query escaping.", "1.0"))
 

--- a/std/yaml/a_yaml.go
+++ b/std/yaml/a_yaml.go
@@ -10,7 +10,9 @@ var yamlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.yaml"))
 
 
 
-var read_string_ Proc = func(_args []Object) Object {
+var read_string_ Proc
+
+func __read_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -24,7 +26,9 @@ var read_string_ Proc = func(_args []Object) Object {
 	return NIL
 }
 
-var write_string_ Proc = func(_args []Object) Object {
+var write_string_ Proc
+
+func __write_string_(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	case _c == 1:
@@ -39,6 +43,9 @@ var write_string_ Proc = func(_args []Object) Object {
 }
 
 func Init() {
+
+	read_string_ = __read_string_
+	write_string_ = __write_string_
 
 	yamlNamespace.ResetMeta(MakeMeta(nil, "Implements encoding and decoding of YAML.", "1.0"))
 


### PR DESCRIPTION
This defers most everything in the `std/` libraries.

The one remaining item (that I know of) is `client` in `std/http/http_native.go`, which the `gostd` fork defers using a general mechanism that could be ported over to here as well, if deemed worthwhile.