### PR TITLE
Support joker.repl/doc of types

### DIFF
--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3582,11 +3582,6 @@
   (^Map [^Associative m k ^Callable f x y z & more]
    (assoc m k (apply f (get m k) x y z more))))
 
-(defmacro type?
-  "Returns whether the object is a type"
-  {:added "1.0"}
-  ^Boolean [x] `(= (type ~x) ~Type))
-
 (defn coll?
   "Returns true if x implements Collection"
   {:added "1.0"}

--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3582,6 +3582,11 @@
   (^Map [^Associative m k ^Callable f x y z & more]
    (assoc m k (apply f (get m k) x y z more))))
 
+(defmacro type?
+  "Returns whether the object is a type"
+  {:added "1.0"}
+  ^Boolean [x] `(= (type ~x) ~Type))
+
 (defn coll?
   "Returns true if x implements Collection"
   {:added "1.0"}

--- a/core/data/repl.joke
+++ b/core/data/repl.joke
@@ -71,7 +71,7 @@
   (when doc (println " " doc)))
 
 (defmacro doc
-  "Prints documentation for a var or special form given its name,
+  "Prints documentation for a var, type, or special form given its name,
   or for a spec if given a keyword"
   {:added "1.0"}
   [name]
@@ -81,8 +81,11 @@
       (special-doc-map name) `(#'print-doc (#'special-doc '~name))
       (keyword? name) (println "Keywords (spec) not yet supported")
       (find-ns name) `(#'print-doc (#'namespace-doc (find-ns '~name)))
-      (resolve name) `(#'print-doc (meta (var ~name))))))
-
+      (resolve name) (let [x# (resolve name)
+                           v# (if (type? x#)
+                                name
+                                `(var ~name))]
+                       `(#'print-doc (meta ~v#))))))
 
 ;; ----------------------------------------------------------------------
 ;; Examine Clojure functions (Vars, really)

--- a/core/data/repl.joke
+++ b/core/data/repl.joke
@@ -82,7 +82,7 @@
       (keyword? name) (println "Keywords (spec) not yet supported")
       (find-ns name) `(#'print-doc (#'namespace-doc (find-ns '~name)))
       (resolve name) (let [x# (resolve name)
-                           v# (if (type? x#)
+                           v# (if (= (type x#) Type)
                                 name
                                 `(var ~name))]
                        `(#'print-doc (meta ~v#))))))

--- a/core/object.go
+++ b/core/object.go
@@ -305,7 +305,7 @@ func RegRefType(name string, inst interface{}, doc string) *Type {
 	if doc != "" {
 		doc = "\n  " + doc
 	}
-	meta := MakeMeta(nil, "(Concrete reference 'Type')"+doc, "1.0")
+	meta := MakeMeta(nil, "(Concrete reference type)"+doc, "1.0")
 	meta.Add(KEYWORDS.name, MakeString(name))
 	t := &Type{MetaHolder{meta}, name, reflect.TypeOf(inst)}
 	TYPES[STRINGS.Intern(name)] = t
@@ -316,7 +316,7 @@ func regType(name string, inst interface{}, doc string) *Type {
 	if doc != "" {
 		doc = "\n  " + doc
 	}
-	meta := MakeMeta(nil, "(Concrete 'Type')"+doc, "1.0")
+	meta := MakeMeta(nil, "(Concrete type)"+doc, "1.0")
 	meta.Add(KEYWORDS.name, MakeString(name))
 	t := &Type{MetaHolder{meta}, name, reflect.TypeOf(inst).Elem()}
 	TYPES[STRINGS.Intern(name)] = t
@@ -327,7 +327,7 @@ func regInterface(name string, inst interface{}, doc string) *Type {
 	if doc != "" {
 		doc = "\n  " + doc
 	}
-	meta := MakeMeta(nil, "(Abstract type, aka 'interface')"+doc, "1.0")
+	meta := MakeMeta(nil, "(Interface type)"+doc, "1.0")
 	meta.Add(KEYWORDS.name, MakeString(name))
 	t := &Type{MetaHolder{meta}, name, reflect.TypeOf(inst).Elem()}
 	TYPES[STRINGS.Intern(name)] = t

--- a/core/object.go
+++ b/core/object.go
@@ -35,6 +35,7 @@ type (
 		Equals(interface{}) bool
 	}
 	Type struct {
+		MetaHolder
 		name        string
 		reflectType reflect.Type
 	}
@@ -300,92 +301,108 @@ type (
 var TYPES = map[*string]*Type{}
 var TYPE Types
 
-func RegRefType(name string, inst interface{}) *Type {
-	t := &Type{name: name, reflectType: reflect.TypeOf(inst)}
+func RegRefType(name string, inst interface{}, doc string) *Type {
+	if doc != "" {
+		doc = "\n  " + doc
+	}
+	meta := MakeMeta(nil, "(Concrete reference 'Type')"+doc, "1.0")
+	meta.Add(KEYWORDS.name, MakeString(name))
+	t := &Type{MetaHolder{meta}, name, reflect.TypeOf(inst)}
 	TYPES[STRINGS.Intern(name)] = t
 	return t
 }
 
-func regType(name string, inst interface{}) *Type {
-	t := &Type{name: name, reflectType: reflect.TypeOf(inst).Elem()}
+func regType(name string, inst interface{}, doc string) *Type {
+	if doc != "" {
+		doc = "\n  " + doc
+	}
+	meta := MakeMeta(nil, "(Concrete 'Type')"+doc, "1.0")
+	meta.Add(KEYWORDS.name, MakeString(name))
+	t := &Type{MetaHolder{meta}, name, reflect.TypeOf(inst).Elem()}
 	TYPES[STRINGS.Intern(name)] = t
 	return t
 }
 
-func regInterface(name string, inst interface{}) *Type {
-	t := &Type{name: name, reflectType: reflect.TypeOf(inst).Elem()}
+func regInterface(name string, inst interface{}, doc string) *Type {
+	if doc != "" {
+		doc = "\n  " + doc
+	}
+	meta := MakeMeta(nil, "(Abstract type, aka 'interface')"+doc, "1.0")
+	meta.Add(KEYWORDS.name, MakeString(name))
+	t := &Type{MetaHolder{meta}, name, reflect.TypeOf(inst).Elem()}
 	TYPES[STRINGS.Intern(name)] = t
 	return t
 }
 
 func init() {
 	TYPE = Types{
-		Associative:    regInterface("Associative", (*Associative)(nil)),
-		Callable:       regInterface("Callable", (*Callable)(nil)),
-		Collection:     regInterface("Collection", (*Collection)(nil)),
-		Comparable:     regInterface("Comparable", (*Comparable)(nil)),
-		Comparator:     regInterface("Comparator", (*Comparator)(nil)),
-		Counted:        regInterface("Counted", (*Counted)(nil)),
-		Deref:          regInterface("Deref", (*Deref)(nil)),
-		Error:          regInterface("Error", (*Error)(nil)),
-		Gettable:       regInterface("Gettable", (*Gettable)(nil)),
-		Indexed:        regInterface("Indexed", (*Indexed)(nil)),
-		IOReader:       regInterface("IOReader", (*io.Reader)(nil)),
-		IOWriter:       regInterface("IOWriter", (*io.Writer)(nil)),
-		KVReduce:       regInterface("KVReduce", (*KVReduce)(nil)),
-		Map:            regInterface("Map", (*Map)(nil)),
-		Meta:           regInterface("Meta", (*Meta)(nil)),
-		Named:          regInterface("Named", (*Named)(nil)),
-		Number:         regInterface("Number", (*Number)(nil)),
-		Pending:        regInterface("Pending", (*Pending)(nil)),
-		Ref:            regInterface("Ref", (*Ref)(nil)),
-		Reversible:     regInterface("Reversible", (*Reversible)(nil)),
-		Seq:            regInterface("Seq", (*Seq)(nil)),
-		Seqable:        regInterface("Seqable", (*Seqable)(nil)),
-		Sequential:     regInterface("Sequential", (*Sequential)(nil)),
-		Set:            regInterface("Set", (*Set)(nil)),
-		Stack:          regInterface("Stack", (*Stack)(nil)),
-		ArrayMap:       RegRefType("ArrayMap", (*ArrayMap)(nil)),
-		ArrayMapSeq:    RegRefType("ArrayMapSeq", (*ArrayMapSeq)(nil)),
-		ArrayNodeSeq:   RegRefType("ArrayNodeSeq", (*ArrayNodeSeq)(nil)),
-		ArraySeq:       RegRefType("ArraySeq", (*ArraySeq)(nil)),
-		MapSet:         RegRefType("MapSet", (*MapSet)(nil)),
-		Atom:           RegRefType("Atom", (*Atom)(nil)),
-		BigFloat:       RegRefType("BigFloat", (*BigFloat)(nil)),
-		BigInt:         RegRefType("BigInt", (*BigInt)(nil)),
-		Boolean:        regType("Boolean", (*Boolean)(nil)),
-		Time:           regType("Time", (*Time)(nil)),
-		Buffer:         RegRefType("Buffer", (*Buffer)(nil)),
-		Char:           regType("Char", (*Char)(nil)),
-		ConsSeq:        RegRefType("ConsSeq", (*ConsSeq)(nil)),
-		Delay:          RegRefType("Delay", (*Delay)(nil)),
-		Double:         regType("Double", (*Double)(nil)),
-		EvalError:      RegRefType("EvalError", (*EvalError)(nil)),
-		ExInfo:         RegRefType("ExInfo", (*ExInfo)(nil)),
-		Fn:             RegRefType("Fn", (*Fn)(nil)),
-		File:           RegRefType("File", (*File)(nil)),
-		BufferedReader: RegRefType("BufferedReader", (*BufferedReader)(nil)),
-		HashMap:        RegRefType("HashMap", (*HashMap)(nil)),
-		Int:            regType("Int", (*Int)(nil)),
-		Keyword:        regType("Keyword", (*Keyword)(nil)),
-		LazySeq:        RegRefType("LazySeq", (*LazySeq)(nil)),
-		List:           RegRefType("List", (*List)(nil)),
-		MappingSeq:     RegRefType("MappingSeq", (*MappingSeq)(nil)),
-		Namespace:      RegRefType("Namespace", (*Namespace)(nil)),
-		Nil:            regType("Nil", (*Nil)(nil)),
-		NodeSeq:        RegRefType("NodeSeq", (*NodeSeq)(nil)),
-		ParseError:     RegRefType("ParseError", (*ParseError)(nil)),
-		Proc:           RegRefType("Proc", (*Proc)(nil)),
-		Ratio:          RegRefType("Ratio", (*Ratio)(nil)),
-		RecurBindings:  RegRefType("RecurBindings", (*RecurBindings)(nil)),
-		Regex:          regType("Regex", (*Regex)(nil)),
-		String:         regType("String", (*String)(nil)),
-		Symbol:         regType("Symbol", (*Symbol)(nil)),
-		Type:           RegRefType("Type", (*Type)(nil)),
-		Var:            RegRefType("Var", (*Var)(nil)),
-		Vector:         RegRefType("Vector", (*Vector)(nil)),
-		VectorRSeq:     RegRefType("VectorRSeq", (*VectorRSeq)(nil)),
-		VectorSeq:      RegRefType("VectorSeq", (*VectorSeq)(nil)),
+		Associative:    regInterface("Associative", (*Associative)(nil), ""),
+		Callable:       regInterface("Callable", (*Callable)(nil), ""),
+		Collection:     regInterface("Collection", (*Collection)(nil), ""),
+		Comparable:     regInterface("Comparable", (*Comparable)(nil), ""),
+		Comparator:     regInterface("Comparator", (*Comparator)(nil), ""),
+		Counted:        regInterface("Counted", (*Counted)(nil), ""),
+		Deref:          regInterface("Deref", (*Deref)(nil), ""),
+		Error:          regInterface("Error", (*Error)(nil), ""),
+		Gettable:       regInterface("Gettable", (*Gettable)(nil), ""),
+		Indexed:        regInterface("Indexed", (*Indexed)(nil), ""),
+		IOReader:       regInterface("IOReader", (*io.Reader)(nil), ""),
+		IOWriter:       regInterface("IOWriter", (*io.Writer)(nil), ""),
+		KVReduce:       regInterface("KVReduce", (*KVReduce)(nil), ""),
+		Map:            regInterface("Map", (*Map)(nil), ""),
+		Meta:           regInterface("Meta", (*Meta)(nil), ""),
+		Named:          regInterface("Named", (*Named)(nil), ""),
+		Number:         regInterface("Number", (*Number)(nil), ""),
+		Pending:        regInterface("Pending", (*Pending)(nil), ""),
+		Ref:            regInterface("Ref", (*Ref)(nil), ""),
+		Reversible:     regInterface("Reversible", (*Reversible)(nil), ""),
+		Seq:            regInterface("Seq", (*Seq)(nil), ""),
+		Seqable:        regInterface("Seqable", (*Seqable)(nil), ""),
+		Sequential:     regInterface("Sequential", (*Sequential)(nil), ""),
+		Set:            regInterface("Set", (*Set)(nil), ""),
+		Stack:          regInterface("Stack", (*Stack)(nil), ""),
+		ArrayMap:       RegRefType("ArrayMap", (*ArrayMap)(nil), ""),
+		ArrayMapSeq:    RegRefType("ArrayMapSeq", (*ArrayMapSeq)(nil), ""),
+		ArrayNodeSeq:   RegRefType("ArrayNodeSeq", (*ArrayNodeSeq)(nil), ""),
+		ArraySeq:       RegRefType("ArraySeq", (*ArraySeq)(nil), ""),
+		MapSet:         RegRefType("MapSet", (*MapSet)(nil), ""),
+		Atom:           RegRefType("Atom", (*Atom)(nil), ""),
+		BigFloat:       RegRefType("BigFloat", (*BigFloat)(nil), ""),
+		BigInt:         RegRefType("BigInt", (*BigInt)(nil), ""),
+		Boolean:        regType("Boolean", (*Boolean)(nil), ""),
+		Time:           regType("Time", (*Time)(nil), ""),
+		Buffer:         RegRefType("Buffer", (*Buffer)(nil), ""),
+		Char:           regType("Char", (*Char)(nil), ""),
+		ConsSeq:        RegRefType("ConsSeq", (*ConsSeq)(nil), ""),
+		Delay:          RegRefType("Delay", (*Delay)(nil), ""),
+		Double:         regType("Double", (*Double)(nil), ""),
+		EvalError:      RegRefType("EvalError", (*EvalError)(nil), ""),
+		ExInfo:         RegRefType("ExInfo", (*ExInfo)(nil), ""),
+		Fn:             RegRefType("Fn", (*Fn)(nil), ""),
+		File:           RegRefType("File", (*File)(nil), ""),
+		BufferedReader: RegRefType("BufferedReader", (*BufferedReader)(nil), ""),
+		HashMap:        RegRefType("HashMap", (*HashMap)(nil), ""),
+		Int: regType("Int", (*Int)(nil),
+			"Wraps the Go 'int' type, which is 32 bits wide on 32-bit hosts, 64 bits wide on 64-bit hosts, etc."),
+		Keyword:       regType("Keyword", (*Keyword)(nil), ""),
+		LazySeq:       RegRefType("LazySeq", (*LazySeq)(nil), ""),
+		List:          RegRefType("List", (*List)(nil), ""),
+		MappingSeq:    RegRefType("MappingSeq", (*MappingSeq)(nil), ""),
+		Namespace:     RegRefType("Namespace", (*Namespace)(nil), ""),
+		Nil:           regType("Nil", (*Nil)(nil), ""),
+		NodeSeq:       RegRefType("NodeSeq", (*NodeSeq)(nil), ""),
+		ParseError:    RegRefType("ParseError", (*ParseError)(nil), ""),
+		Proc:          RegRefType("Proc", (*Proc)(nil), ""),
+		Ratio:         RegRefType("Ratio", (*Ratio)(nil), ""),
+		RecurBindings: RegRefType("RecurBindings", (*RecurBindings)(nil), ""),
+		Regex:         regType("Regex", (*Regex)(nil), ""),
+		String:        regType("String", (*String)(nil), ""),
+		Symbol:        regType("Symbol", (*Symbol)(nil), ""),
+		Type:          RegRefType("Type", (*Type)(nil), ""),
+		Var:           RegRefType("Var", (*Var)(nil), ""),
+		Vector:        RegRefType("Vector", (*Vector)(nil), ""),
+		VectorRSeq:    RegRefType("VectorRSeq", (*VectorRSeq)(nil), ""),
+		VectorSeq:     RegRefType("VectorSeq", (*VectorSeq)(nil), ""),
 	}
 }
 

--- a/core/procs.go
+++ b/core/procs.go
@@ -152,6 +152,11 @@ var procMeta Proc = func(args []Object) Object {
 		if meta != nil {
 			return meta
 		}
+	case *Type:
+		meta := obj.GetMeta()
+		if meta != nil {
+			return meta
+		}
 	}
 	return NIL
 }


### PR DESCRIPTION
Not sure this is the best approach, but wanted to try it before working on adding (autogenerated) documentation of (Joker-wrapped) Go types in the `gostd` fork, to prevent the fork from straying further from the official version.

So, feedback highly welcome!

(Note that I added actual documentation to only the `Int` type, just to try it out.)