### PR TITLE
Quote namespace doc string

### DIFF
--- a/std/base64/a_base64.go
+++ b/std/base64/a_base64.go
@@ -47,7 +47,7 @@ func Init() {
 	decode_string_ = __decode_string_
 	encode_string_ = __encode_string_
 
-	base64Namespace.ResetMeta(MakeMeta(nil, "Implements base64 encoding as specified by RFC 4648.", "1.0"))
+	base64Namespace.ResetMeta(MakeMeta(nil, `Implements base64 encoding as specified by RFC 4648.`, "1.0"))
 
 	
 	base64Namespace.InternVar("decode-string", decode_string_,

--- a/std/crypto/a_crypto.go
+++ b/std/crypto/a_crypto.go
@@ -180,7 +180,7 @@ func Init() {
 	sha512_224_ = __sha512_224_
 	sha512_256_ = __sha512_256_
 
-	cryptoNamespace.ResetMeta(MakeMeta(nil, "Implements common cryptographic and hash functions.", "1.0"))
+	cryptoNamespace.ResetMeta(MakeMeta(nil, `Implements common cryptographic and hash functions.`, "1.0"))
 
 	
 	cryptoNamespace.InternVar("hmac", hmac_,

--- a/std/csv/a_csv.go
+++ b/std/csv/a_csv.go
@@ -84,7 +84,7 @@ func Init() {
 	write_ = __write_
 	write_string_ = __write_string_
 
-	csvNamespace.ResetMeta(MakeMeta(nil, "Reads and writes comma-separated values (CSV) files as defined in RFC 4180.", "1.0"))
+	csvNamespace.ResetMeta(MakeMeta(nil, `Reads and writes comma-separated values (CSV) files as defined in RFC 4180.`, "1.0"))
 
 	
 	csvNamespace.InternVar("csv-seq", csv_seq_,

--- a/std/filepath/a_filepath.go
+++ b/std/filepath/a_filepath.go
@@ -314,7 +314,7 @@ func Init() {
 	to_slash_ = __to_slash_
 	volume_name_ = __volume_name_
 
-	filepathNamespace.ResetMeta(MakeMeta(nil, "Implements utility routines for manipulating filename paths.", "1.0"))
+	filepathNamespace.ResetMeta(MakeMeta(nil, `Implements utility routines for manipulating filename paths.`, "1.0"))
 
 	filepathNamespace.InternVar("list-separator", list_separator_,
 		MakeMeta(

--- a/std/generate-std.joke
+++ b/std/generate-std.joke
@@ -247,7 +247,7 @@
                 (rpl "{non-fn-inits}" (s/join "\n" non-fn-inits))
                 (rpl "{fn-decls}" (s/join "\n" (map first fn-decls)))
                 (rpl "{fn-inits}" (s/join "\n" fn-inits))
-                (rpl "{nsDocstring}" (:doc m))
+                (rpl "{nsDocstring}" (raw-quoted-string (:doc m)))
                 (rpl "{non-fn-interns}" (s/join "\n\t" (map second non-fn-decls)))
                 (rpl "{fn-interns}" (s/join "\n\t" (map second fn-decls))))
         res (if (:empty m)

--- a/std/hex/a_hex.go
+++ b/std/hex/a_hex.go
@@ -50,7 +50,7 @@ func Init() {
 	decode_string_ = __decode_string_
 	encode_string_ = __encode_string_
 
-	hexNamespace.ResetMeta(MakeMeta(nil, "Implements hexadecimal encoding and decoding.", "1.0"))
+	hexNamespace.ResetMeta(MakeMeta(nil, `Implements hexadecimal encoding and decoding.`, "1.0"))
 
 	
 	hexNamespace.InternVar("decode-string", decode_string_,

--- a/std/html/a_html.go
+++ b/std/html/a_html.go
@@ -48,7 +48,7 @@ func Init() {
 	escape_ = __escape_
 	unescape_ = __unescape_
 
-	htmlNamespace.ResetMeta(MakeMeta(nil, "Provides functions for escaping and unescaping HTML text.", "1.0"))
+	htmlNamespace.ResetMeta(MakeMeta(nil, `Provides functions for escaping and unescaping HTML text.`, "1.0"))
 
 	
 	htmlNamespace.InternVar("escape", escape_,

--- a/std/http/a_http.go
+++ b/std/http/a_http.go
@@ -66,7 +66,7 @@ func Init() {
 	start_file_server_ = __start_file_server_
 	start_server_ = __start_server_
 
-	httpNamespace.ResetMeta(MakeMeta(nil, "Provides HTTP client and server implementations", "1.0"))
+	httpNamespace.ResetMeta(MakeMeta(nil, `Provides HTTP client and server implementations`, "1.0"))
 
 	
 	httpNamespace.InternVar("send", send_,

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -59,7 +59,9 @@ func Init() {
 	jsonNamespace.InternVar("read-string", read_string_,
 		MakeMeta(
 			NewListFrom(NewVectorFrom(MakeSymbol("s")), NewVectorFrom(MakeSymbol("s"), MakeSymbol("opts"))),
-			`Parses the JSON-encoded data and return the result as a Joker value.`, "1.0"))
+			`Parses the JSON-encoded data and return the result as a Joker value.
+  Optional opts map may have the following keys:
+  :keywords? - if true, JSON keys will be converted from strings to keywords.`, "1.0"))
 
 	jsonNamespace.InternVar("write-string", write_string_,
 		MakeMeta(

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -53,7 +53,7 @@ func Init() {
 	read_string_ = __read_string_
 	write_string_ = __write_string_
 
-	jsonNamespace.ResetMeta(MakeMeta(nil, "Implements encoding and decoding of JSON as defined in RFC 4627.", "1.0"))
+	jsonNamespace.ResetMeta(MakeMeta(nil, `Implements encoding and decoding of JSON as defined in RFC 4627.`, "1.0"))
 
 	
 	jsonNamespace.InternVar("read-string", read_string_,

--- a/std/math/a_math.go
+++ b/std/math/a_math.go
@@ -66,7 +66,7 @@ func Init() {
 	hypot_ = __hypot_
 	sin_ = __sin_
 
-	mathNamespace.ResetMeta(MakeMeta(nil, "Provides basic constants and mathematical functions.", "1.0"))
+	mathNamespace.ResetMeta(MakeMeta(nil, `Provides basic constants and mathematical functions.`, "1.0"))
 
 	mathNamespace.InternVar("pi", pi_,
 		MakeMeta(

--- a/std/os/a_os.go
+++ b/std/os/a_os.go
@@ -296,7 +296,7 @@ func Init() {
 	sh_from_ = __sh_from_
 	stat_ = __stat_
 
-	osNamespace.ResetMeta(MakeMeta(nil, "Provides a platform-independent interface to operating system functionality.", "1.0"))
+	osNamespace.ResetMeta(MakeMeta(nil, `Provides a platform-independent interface to operating system functionality.`, "1.0"))
 
 	
 	osNamespace.InternVar("args", args_,

--- a/std/package.tmpl
+++ b/std/package.tmpl
@@ -15,7 +15,7 @@ func Init() {
 {non-fn-inits}
 {fn-inits}
 
-	{nsName}Namespace.ResetMeta(MakeMeta(nil, "{nsDocstring}", "1.0"))
+	{nsName}Namespace.ResetMeta(MakeMeta(nil, {nsDocstring}, "1.0"))
 
 	{non-fn-interns}
 	{fn-interns}

--- a/std/strconv/a_strconv.go
+++ b/std/strconv/a_strconv.go
@@ -332,7 +332,7 @@ func Init() {
 	quote_to_graphic_ = __quote_to_graphic_
 	unquote_ = __unquote_
 
-	strconvNamespace.ResetMeta(MakeMeta(nil, "Implements conversions to and from string representations of basic data types.", "1.0"))
+	strconvNamespace.ResetMeta(MakeMeta(nil, `Implements conversions to and from string representations of basic data types.`, "1.0"))
 
 	
 	strconvNamespace.InternVar("atoi", atoi_,

--- a/std/string/a_string.go
+++ b/std/string/a_string.go
@@ -465,7 +465,7 @@ func Init() {
 	trimr_ = __trimr_
 	upper_case_ = __upper_case_
 
-	stringNamespace.ResetMeta(MakeMeta(nil, "Implements simple functions to manipulate strings.", "1.0"))
+	stringNamespace.ResetMeta(MakeMeta(nil, `Implements simple functions to manipulate strings.`, "1.0"))
 
 	
 	stringNamespace.InternVar("blank?", isblank_,

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -373,7 +373,7 @@ func Init() {
 	unix_ = __unix_
 	until_ = __until_
 
-	timeNamespace.ResetMeta(MakeMeta(nil, "Provides functionality for measuring and displaying time.", "1.0"))
+	timeNamespace.ResetMeta(MakeMeta(nil, `Provides functionality for measuring and displaying time.`, "1.0"))
 
 	timeNamespace.InternVar("ansi-c", ansi_c_,
 		MakeMeta(

--- a/std/url/a_url.go
+++ b/std/url/a_url.go
@@ -82,7 +82,7 @@ func Init() {
 	query_escape_ = __query_escape_
 	query_unescape_ = __query_unescape_
 
-	urlNamespace.ResetMeta(MakeMeta(nil, "Parses URLs and implements query escaping.", "1.0"))
+	urlNamespace.ResetMeta(MakeMeta(nil, `Parses URLs and implements query escaping.`, "1.0"))
 
 	
 	urlNamespace.InternVar("path-escape", path_escape_,

--- a/std/yaml/a_yaml.go
+++ b/std/yaml/a_yaml.go
@@ -47,7 +47,7 @@ func Init() {
 	read_string_ = __read_string_
 	write_string_ = __write_string_
 
-	yamlNamespace.ResetMeta(MakeMeta(nil, "Implements encoding and decoding of YAML.", "1.0"))
+	yamlNamespace.ResetMeta(MakeMeta(nil, `Implements encoding and decoding of YAML.`, "1.0"))
 
 	
 	yamlNamespace.InternVar("read-string", read_string_,


### PR DESCRIPTION
This should have no effect on official Joker, but (besides being
correct and consistent with how the :doc tags are treated elsewhere)
it fixed the `gostd` fork when reading the generated online docs, on
my website, for `html/template`, which include this gem:

```
"<script>alert('you have been pwned')</script>"
```

(I was actually getting that alert whenever reloading that page!)