### PR TITLE
Show unexpected errors from the generate-std.joke step

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,12 @@ if [ "$1" == "-v" ]; then
 fi
 
 SUM256="$(go run tools/sum256dir/main.go std)"
-(cd std; ../joker generate-std.joke 2> /dev/null)
+OUT="$(cd std; ../joker generate-std.joke 2>&1 | grep -v 'WARNING:.*already refers' | grep '.')" || : # grep returns non-zero if no lines match
+if [ -n "$OUT" ]; then
+    echo "$OUT"
+    echo >&2 "Unable to generate fresh library files; exiting."
+    exit 2
+fi
 NEW_SUM256="$(go run tools/sum256dir/main.go std)"
 
 if [ "$SUM256" != "$NEW_SUM256" ]; then


### PR DESCRIPTION
The current behavior is to silently fail, which is confusing (when it happens to us developers).

However, this approach relies on failures printing an unexpected diagnostic; merely exiting with a nonzero return code no longer suffices.

I'm not sure whether it's worth fixing that possibility, given that a better fix might be to inhibit the expected warnings (and blank lines) entirely, rely solely on the return code, and not /dev/null the output.