### PR TITLE
Doc all types

### DIFF
--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -4449,3 +4449,8 @@
   ^Map [multifn]
   (throw (ex-info "method preference not yet supported by joker.core" {})))
 
+(def ^{:private true
+       :doc "Returns currently registered types as a map."
+       :added "1.0"
+       :tag Map}
+  types__ types__)

--- a/core/procs.go
+++ b/core/procs.go
@@ -1545,6 +1545,15 @@ var procParse Proc = func(args []Object) Object {
 	return res.Dump(false)
 }
 
+var procTypes Proc = func(args []Object) Object {
+	CheckArity(args, 0, 0)
+	res := EmptyArrayMap()
+	for k, v := range TYPES {
+		res.Add(String{S: *k}, v)
+	}
+	return res
+}
+
 func PackReader(reader *Reader, filename string) ([]byte, error) {
 	var p []byte
 	packEnv := NewPackEnv()
@@ -2077,4 +2086,5 @@ func init() {
 	intern("intern-fake-var__", procInternFakeVar)
 	intern("parse__", procParse)
 	intern("inc-problem-count__", procIncProblemCount)
+	intern("types__", procTypes)
 }

--- a/docs/generate-docs.joke
+++ b/docs/generate-docs.joke
@@ -18,6 +18,9 @@
 (def namespace-template
   (slurp "templates/ns-summary.html"))
 
+(def type-template
+  (slurp "templates/type-summary.html"))
+
 (def link-item-template
   (slurp "templates/link-item.html"))
 
@@ -93,6 +96,19 @@
         (string/replace "{docstring}" (string/replace (str (:doc m)) "\n" "<br>\n"))
         (string/replace "{added}" (str (:added m))))))
 
+(defn type-doc
+  [k]
+  (let [m (meta (get (joker.core/types__) k))]
+    (when-not (:added m)
+      (println "WARNING: type without added meta key: " k))
+    (when-not (:doc m)
+      (println "WARNING: type without doc meta key: " k))
+    (-> type-template
+        (string/replace "{id}" k)
+        (string/replace "{name}" k)
+        (string/replace "{docstring}" (string/replace (str (:doc m)) "\n" "<br>\n"))
+        (string/replace "{added}" (str (:added m))))))
+
 (defn ns-doc
   [ns-sym]
   (let [ns (find-ns ns-sym)
@@ -113,7 +129,7 @@
         (string/replace "{index}" var-links-doc))))
 
 (defn index-doc
-  [namespaces]
+  [namespaces types]
   (let [namespaces-docs (string/join
                          ""
                          (for [ns-sym namespaces]
@@ -121,18 +137,31 @@
         ns-links-doc (string/join
                       ""
                       (->> namespaces
-                           (map #(link-item-doc (str %)))))]
+                           (map #(link-item-doc (str %)))))
+        types-docs (string/join
+                    ""
+                    (for [t types]
+                      (type-doc t)))
+        type-links-doc (string/join
+                        ""
+                        (->> types
+                             (map #(link-item-doc (str %)))))]
     (-> index-template
-        (string/replace "{index}" ns-links-doc)
-        (string/replace "{namespaces}" namespaces-docs))))
+        (string/replace "{index-of-namespaces}" ns-links-doc)
+        (string/replace "{namespaces}" namespaces-docs)
+        (string/replace "{index-of-types}" type-links-doc)
+        (string/replace "{types}" types-docs))))
 
 (defn full-doc
   []
   (let [namespaces (->> (all-ns)
                         (map ns-name)
                         (remove #(= 'user %))
-                        (sort))]
-    (spit "index.html" (index-doc namespaces))
+                        (sort))
+        types (->> (joker.core/types__)
+                   (map key)
+                   (sort))]
+    (spit "index.html" (index-doc namespaces types))
     (doseq [ns namespaces]
       (spit (str ns ".html") (ns-doc ns)))))
 

--- a/docs/generate-docs.joke
+++ b/docs/generate-docs.joke
@@ -5,6 +5,7 @@
 (require 'joker.template)
 (require 'joker.set)
 (require 'joker.repl)
+(require 'joker.html)
 
 (def index-template
   (slurp "templates/index.html"))
@@ -71,7 +72,7 @@
         (string/replace "{name}" (str k))
         (string/replace "{type}" (type-name v))
         (string/replace "{usage}" (usage k m))
-        (string/replace "{docstring}" (string/replace (str (:doc m)) "\n" "<br>\n"))
+        (string/replace "{docstring}" (string/replace (joker.html/escape (:doc m)) "\n" "<br>\n"))
         (string/replace "{added}" (str (:added m)))
         (string/replace
          "{source}"

--- a/docs/generate-docs.joke
+++ b/docs/generate-docs.joke
@@ -72,7 +72,7 @@
         (string/replace "{name}" (str k))
         (string/replace "{type}" (type-name v))
         (string/replace "{usage}" (usage k m))
-        (string/replace "{docstring}" (string/replace (joker.html/escape (:doc m)) "\n" "<br>\n"))
+        (string/replace "{docstring}" (string/replace (str (:doc m)) "\n" "<br>\n"))
         (string/replace "{added}" (str (:added m)))
         (string/replace
          "{source}"
@@ -107,7 +107,7 @@
     (-> type-template
         (string/replace "{id}" k)
         (string/replace "{name}" k)
-        (string/replace "{docstring}" (string/replace (str (:doc m)) "\n" "<br>\n"))
+        (string/replace "{docstring}" (string/replace (joker.html/escape (:doc m)) "\n" "<br>\n"))
         (string/replace "{added}" (str (:added m))))))
 
 (defn ns-doc

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -4,13 +4,24 @@
 </head>
 <body>
   <div class="main">
-    <h1>Joker Standard Namespaces</h1>
-    <h2>Index</h2>
+    <title>Joker Standard Namespaces and Types</title>
+    <h1>Indexes of Joker Standard Namespaces and Types</h1>
+    <h2>Index of <a href="#joker-std-ns">Namespaces</a></h2>
     <ul class="index">
-      {index}
+      {index-of-namespaces}
     </ul>
+    <h2>Index of <a href="#joker-std-types">Types</a></h2>
+    <ul class="index">
+      {index-of-types}
+    </ul>
+    <h1 id="joker-std-ns">Joker Standard Namespaces</h1>
     <ul>
       {namespaces}
+    </ul>
+    <h1 id="joker-std-types">Joker Standard Types</h1>
+    <p><em>Note:</em> These types are "omnipresent", in that they're not members of any particular namespace, but are available for resolution regardless of the current value of <tt>*ns*</tt> (the current namespace).</p>
+    <ul>
+      {types}
     </ul>
   </div>
 </body>

--- a/docs/templates/type-summary.html
+++ b/docs/templates/type-summary.html
@@ -1,0 +1,5 @@
+<li>
+  <h3 id="{id}">{name}</h3>
+  <span class="var-added">v{added}</span>
+  <p class="var-docstr">{docstring}</p>
+</li>

--- a/tests/eval/types.joke
+++ b/tests/eval/types.joke
@@ -1,0 +1,7 @@
+(ns joker.test-clojure.types
+  (:require [joker.test :refer [deftest is are testing]]
+            [tests.test-helper :refer [exception]]))
+
+(deftest test-types
+  (is (= (get (joker.core/types__) "Boolean") Boolean))
+  (is (= (get (joker.core/types__) "Int") Int)))


### PR DESCRIPTION
Assuming https://github.com/candid82/joker/pull/268 is merged, this could then be merged to actually use the new function when generating docs.

(I don't have strong feelings about the stylistic changes I made to the `index.html` page to accommodate listing types; just wanted to get it working and look fairly reasonable without being too intrusive.)