### PR TITLE
Use first line only in namespace summaries, and HTML-escape :doc strings

### DIFF
--- a/core/data/walk.joke
+++ b/core/data/walk.joke
@@ -20,11 +20,11 @@
 
 (ns
   ^{:author "Stuart Sierra",
-    :doc "This file defines a generic tree walker for Clojure data
-         structures.  It takes any data structure (list, vector, map, set,
-         seq), calls a function on every element, and uses the return value
-         of the function in place of the original.  This makes it fairly
-         easy to write recursive search-and-replace functions, as shown in
+    :doc "Defines a generic tree walker for Clojure data structures.
+         Takes any data structure (list, vector, map, set, seq), calls
+         a function on every element, and uses the return value of the
+         function in place of the original.  This makes it fairly easy
+         to write recursive search-and-replace functions, as shown in
          the examples.
 
          Note: \"walk\" supports all Clojure data structures EXCEPT maps

--- a/docs/generate-docs.joke
+++ b/docs/generate-docs.joke
@@ -5,6 +5,7 @@
 (require 'joker.template)
 (require 'joker.set)
 (require 'joker.repl)
+(require 'joker.html)
 
 (def index-template
   (slurp "templates/index.html"))
@@ -68,7 +69,7 @@
         (string/replace "{name}" (str k))
         (string/replace "{type}" (type-name v))
         (string/replace "{usage}" (usage k m))
-        (string/replace "{docstring}" (string/replace (str (:doc m)) "\n" "<br>\n"))
+        (string/replace "{docstring}" (string/replace (joker.html/escape (:doc m)) "\n" "<br>\n"))
         (string/replace "{added}" (str (:added m)))
         (string/replace
          "{source}"
@@ -77,6 +78,10 @@
                    (source-file (:ns m))
                    (str (:line m)))
            "")))))
+
+(defn- first-line
+  [s]
+  (first (string/split s #"\n")))
 
 (defn namespace-doc
   [ns-sym]
@@ -90,7 +95,7 @@
     (-> namespace-template
         (string/replace "{id}" k)
         (string/replace "{name}" k)
-        (string/replace "{docstring}" (string/replace (str (:doc m)) "\n" "<br>\n"))
+        (string/replace "{docstring}" (string/replace (joker.html/escape (first-line (:doc m))) "\n" "<br>\n"))
         (string/replace "{added}" (str (:added m))))))
 
 (defn ns-doc
@@ -108,7 +113,7 @@
     (-> ns-template
         (string/replace "{name}" (name ns-sym))
         (string/replace "{added}" (str (:added m)))
-        (string/replace "{docstring}" (string/replace (str (:doc m)) "\n" "<br>\n"))
+        (string/replace "{docstring}" (string/replace (joker.html/escape (:doc m)) "\n" "<br>\n"))
         (string/replace  "{vars}" vars-doc)
         (string/replace "{index}" var-links-doc))))
 

--- a/std/http.joke
+++ b/std/http.joke
@@ -1,6 +1,6 @@
 (ns
   ^{:go-imports []
-    :doc "Provides HTTP client and server implementations"}
+    :doc "Provides HTTP client and server implementations."}
   http)
 
 (defn send

--- a/std/http/a_http.go
+++ b/std/http/a_http.go
@@ -66,7 +66,7 @@ func Init() {
 	start_file_server_ = __start_file_server_
 	start_server_ = __start_server_
 
-	httpNamespace.ResetMeta(MakeMeta(nil, `Provides HTTP client and server implementations`, "1.0"))
+	httpNamespace.ResetMeta(MakeMeta(nil, `Provides HTTP client and server implementations.`, "1.0"))
 
 	
 	httpNamespace.InternVar("send", send_,


### PR DESCRIPTION
This should improve consistency and readability of the generated docs, and avoid issues when "special" character (in HTML) are in `:doc` strings.