### PR TITLE
Add doc and meta for *main-file*

### DIFF
--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3768,6 +3768,12 @@
   When there is no file, e.g. in the REPL, the value is not defined."
   {:added "1.0"})
 
+(add-doc-and-meta *main-file*
+  "The absolute path of <filename> on the command line, as a String.
+
+  When there is no file, e.g. in the REPL, the value is not defined."
+  {:added "1.0"})
+
 (add-doc-and-meta *command-line-args*
   "A sequence of the supplied command line arguments, or nil if
   none were supplied"


### PR DESCRIPTION
My `gostd` branch's `generate-docs.joke` documents constants, and crashed due to missing metadata on this (helpful!) new var.