### PR TITLE
Add other meta tags

### DIFF
--- a/core/array_map.go
+++ b/core/array_map.go
@@ -152,6 +152,16 @@ func (m *ArrayMap) Add(key Object, value Object) bool {
 	return true
 }
 
+func (m *ArrayMap) Plus(key Object, value Object) *ArrayMap {
+	i := m.indexOf(key)
+	if i != -1 {
+		return m
+	}
+	m.arr = append(m.arr, key)
+	m.arr = append(m.arr, value)
+	return m
+}
+
 func (m *ArrayMap) Count() int {
 	return len(m.arr) / 2
 }

--- a/std/addmeta.tmpl
+++ b/std/addmeta.tmpl
@@ -1,0 +1,1 @@
+.Plus(MakeKeyword("{key}"), {value})

--- a/std/generate-std.joke
+++ b/std/generate-std.joke
@@ -18,6 +18,9 @@
 (def intern-template
   (slurp "intern.tmpl"))
 
+(def addmeta-template
+  (slurp "addmeta.tmpl"))
+
 (defn q
   [s]
   (str "\"" s "\""))
@@ -99,6 +102,23 @@
                       (str "MakeSymbol(" (q (str arg)) ")")))
        ")"))
 
+(defn make-value
+  "Returns code to make the Joker object representing the given value.
+
+  E.g. 'String{S: \"value\"}'. Except for integers, the values are treated as strings (for now)."
+  [v]
+  (condp = (str (type v))
+    "Int" (str "Int{I: " v "}")
+    (str "String{S: " (q v) "}")))
+
+(defn add-other-meta
+  "Append meta tags other than what are normally present or irrelevant (:go)."
+  [m]
+  (let [m (dissoc m :doc :added :arglists :ns :name :file :line :column :go)]
+    (s/trim-right (apply str (mapv #(-> addmeta-template
+                                        (rpl "{key}" (s/replace-first (str (key %)) ":" ""))
+                                        (rpl "{value}" (make-value (val %)))) m)))))
+
 (defn generate-fn-decl
   [ns-name ns-name-final k v]
   (let [m (meta v)
@@ -115,6 +135,7 @@
                        (rpl "{goName}" go-fn-name)
                        (rpl "{fnDocstring}" (raw-quoted-string (:doc m)))
                        (rpl "{added}" (:added m))
+                       (rpl "{moreMeta}" (add-other-meta m))
                        (rpl "{args}"
                             (str "NewListFrom("
                                  (s/join ", " (for [args arglists]
@@ -169,6 +190,7 @@
                        (rpl "{goName}" go-non-fn-name)
                        (rpl "{fnDocstring}" (raw-quoted-string (:doc m)))
                        (rpl "{added}" (:added m))
+                       (rpl "{moreMeta}" (add-other-meta m))
                        (rpl "{args}" "nil"))]
     [non-fn-str intern-str]))
 

--- a/std/generate-std.joke
+++ b/std/generate-std.joke
@@ -19,7 +19,7 @@
   (slurp "intern.tmpl"))
 
 (def addmeta-template
-  (slurp "addmeta.tmpl"))
+  (s/trim-right (slurp "addmeta.tmpl")))
 
 (defn q
   [s]
@@ -115,9 +115,9 @@
   "Append meta tags other than what are normally present or irrelevant (:go)."
   [m]
   (let [m (dissoc m :doc :added :arglists :ns :name :file :line :column :go)]
-    (s/trim-right (apply str (mapv #(-> addmeta-template
-                                        (rpl "{key}" (s/replace-first (str (key %)) ":" ""))
-                                        (rpl "{value}" (make-value (val %)))) m)))))
+    (s/join "" (map #(-> addmeta-template
+                    (rpl "{key}" (s/replace-first (str (key %)) ":" ""))
+                    (rpl "{value}" (make-value (val %)))) m))))
 
 (defn generate-fn-decl
   [ns-name ns-name-final k v]

--- a/std/intern.tmpl
+++ b/std/intern.tmpl
@@ -1,4 +1,4 @@
 {nsName}Namespace.InternVar("{fnName}", {goName},
 		MakeMeta(
 			{args},
-			{fnDocstring}, "{added}"))
+			{fnDocstring}, "{added}"){moreMeta})


### PR DESCRIPTION
This treats the `std/*.joke` more like the `core/data/*.joke` files in that "all" the metadata on each public symbol is provided during interning.

That being said, for now this PR doesn't really handle anything (for values of meta tags) other than strings and integers. Any other type is stringized.

While this is theoretically useful in canonical Joker, I found this helpful (for generating better documentation) in the `gostd` fork.