### PR TITLE
Generate code for core before depending on it for further generation

### DIFF
--- a/core/object.go
+++ b/core/object.go
@@ -1,6 +1,6 @@
-//go:generate go run gen_data/gen_data.go
 //go:generate go run gen/gen_types.go assert Comparable *Vector Char String Symbol Keyword Regex Boolean Time Number Seqable Callable *Type Meta Int Double Stack Map Set Associative Reversible Named Comparator *Ratio *Namespace *Var Error *Fn Deref *Atom Ref KVReduce Pending *File io.Reader io.Writer StringReader io.RuneReader *Future
 //go:generate go run gen/gen_types.go info *List *ArrayMapSeq *ArrayMap *HashMap *ExInfo *Fn *Var Nil *Ratio *BigInt *BigFloat Char Double Int Boolean Time Keyword Regex Symbol String *LazySeq *MappingSeq *ArraySeq *ConsSeq *NodeSeq *ArrayNodeSeq *MapSet *Vector *VectorSeq *VectorRSeq
+//go:generate go run gen_data/gen_data.go
 
 package core
 


### PR DESCRIPTION
gen_data.go imports Joker's core, which requires that to compile cleanly.

But gen_types.go generates code that is built into Joker's core, while not depending upon it.

Therefore, the "go:generate" lines that run gen_types.go should come before the one that runs gen_data.go.

Test this by editing (say) core/types_assert_gen.go to make it uncompilable and rebuilding (via run.sh or similar).

The "go generate ./..." step should regenerate core/types_assert_gen.go, replacing the uncompilable version with a working version, before gen_data.go is then run and imports core.