### PR TITLE
Add joker.markup namespace

### DIFF
--- a/core/data/markup.joke
+++ b/core/data/markup.joke
@@ -1,0 +1,166 @@
+(ns joker.markup
+  "Renders HTML, XML, or XHTML markup to a string, based on prior work in Hiccup.
+
+  https://github.com/weavejester/hiccup"
+  {:added "0.14.0"}
+  (:require
+   [joker.html :refer [escape]]
+   [joker.string :as str]))
+
+(defn ^:private named?
+  [v]
+  (or (keyword? v)
+      (string? v)
+      (symbol? v)))
+
+(defn ^:private as-str
+  [v]
+  (cond
+    (named? v)
+    (name v)
+
+    (nil? v)
+    ""
+
+    (number? v)
+    (str v)
+
+    :else
+    (str v)))
+
+(defn ^:private xml-mode?
+  [mode]
+  (#{:xml :xhtml} mode))
+
+(defn ^:private html-mode?
+  [mode]
+  (#{:html :xhtml} mode))
+
+(defn ^:private end-tag
+  [mode]
+  (if (xml-mode? mode) " />" ">"))
+
+(defn ^:private escape-html
+  [v]
+  (-> v as-str escape))
+
+(defn ^:private xml-attribute
+  [name value]
+  (str " " (as-str name) "=" \" (escape-html value) \"))
+
+(defn ^:private render-attribute
+  [mode name value]
+  (cond
+    (true? value)
+    (if (xml-mode? mode)
+      (xml-attribute name name)
+      (str " " (as-str name)))
+
+    (not value)
+    ""
+
+    :else
+    (xml-attribute name value)))
+
+(defn ^:private render-attr-map
+  [mode attrs]
+  (->> attrs
+       (map (fn [[name value]]
+              (render-attribute mode name value)))
+       sort
+       str/join))
+
+(def ^:private void-tags
+  "HTML Elements that must be rendered without a closing tag."
+  #{"area" "base" "br" "col" "command" "embed" "hr" "img" "input" "keygen" "link"
+    "meta" "param" "source" "track" "wbr"})
+
+(defn ^:private container-tag?
+  [mode tag content]
+  (or content
+      (and (html-mode? mode) (not (void-tags tag)))))
+
+(defn ^:private merge-attributes [{:keys [id class]} map-attrs]
+  (->> map-attrs
+       (merge (when id {:id id}))
+       (merge-with #(if %1 (str %1 " " %2) %2) (when class {:class class}))))
+
+;; RE for parsing CSS-style id and class from element tag.
+(def ^:private re-tag #"([^\s\.#]+)(?:#([^\s\.#]+))?(?:\.([^\s#]+))?")
+
+(defn ^:private normalize-element
+  "Ensure an element vector is of the form [tag-name attrs content]."
+  [[tag & content]]
+  (when (not (named? tag))
+    (throw (ex-info (str tag " is not a valid element name" {:tag tag}))))
+  (let [[_ tag id class] (re-matches re-tag (as-str tag))
+        tag-attrs        {:id id
+                          :class (if class (str/replace  class "." " "))}
+        map-attrs        (first content)]
+    (if (map? map-attrs)
+      [tag (merge-attributes tag-attrs map-attrs) (next content)]
+      [tag tag-attrs content])))
+
+(def ^:private render-element)
+
+(defn ^:private render-markup
+  [mode content]
+  (cond
+    (string? content)
+    (escape content)
+    
+    (nil? content)
+    ""
+
+    (vector? content)
+    (render-element mode content)
+
+    (seq? content)
+    ;; Any other kind of list, typically a lazy list via for
+    (->> content
+         (map #(render-markup mode %))
+         str/join)
+
+    (named? content)
+    (name content)
+        
+    :else
+    ;; Not sure what it might be at this point
+    (escape-html content)))
+
+(defn ^:private render-element
+  [mode element]
+  (if (= ::raw-string (first element))
+    (second element)
+    (let [[tag attrs content] (normalize-element element)
+          attribute-markup (render-attr-map mode attrs)
+          content-markup (when content
+                           (render-markup mode content))]
+      (if (container-tag? mode tag content)
+        (str "<" tag attribute-markup ">"
+             content-markup
+             "</" tag ">")
+        (str "<" tag attribute-markup (end-tag mode))))))
+
+(defn raw-string
+  "A raw string is pre-rendered content that is added directly to the output markup
+   without any interpretation or escaping."
+  {:added "0.14.0"}
+  [content]
+  [::raw-string content])
+
+(defn html
+  "Renders the Hiccup-style content as HTML markup, returning a string of
+  the markup.
+
+  The first parameter may be a map, which is options for the entire render.
+
+  The :mode option defaults to :xhtml but can also be :html, :xml, or :sgml."
+  {:added "0.14.0"}
+  [& content]
+  (let [maybe-options (first content)
+        [options content'] (if (map? maybe-options)
+                             [maybe-options (rest content)]
+                             [nil content])
+        mode (or (:mode options) :xhtml)]
+    (render-markup mode content')))

--- a/core/gen_data/gen_data.go
+++ b/core/gen_data/gen_data.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	. "github.com/candid82/joker/core"
+	_ "github.com/candid82/joker/std/html"
 	_ "github.com/candid82/joker/std/string"
 )
 
@@ -75,6 +76,10 @@ var files []FileInfo = []FileInfo{
 	{
 		name:     "<joker.core>",
 		filename: "linter_cljs.joke",
+	},
+	{
+		name:     "<joker.markup>",
+		filename: "markup.joke",
 	},
 }
 

--- a/core/procs.go
+++ b/core/procs.go
@@ -33,6 +33,7 @@ var (
 	linter_cljxData  []byte
 	linter_cljData   []byte
 	linter_cljsData  []byte
+	markupData       []byte
 )
 
 type (
@@ -70,6 +71,7 @@ func InitInternalLibs() {
 		"joker.test":      testData,
 		"joker.set":       setData,
 		"joker.tools.cli": tools_cliData,
+		"joker.markup":    markupData,
 	}
 }
 

--- a/docs/generate-docs.joke
+++ b/docs/generate-docs.joke
@@ -6,6 +6,7 @@
 (require 'joker.set)
 (require 'joker.repl)
 (require 'joker.html)
+(require 'joker.markup)
 
 (def index-template
   (slurp "templates/index.html"))

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,6 +39,9 @@
   <a href="#joker.json">joker.json</a>
 </li>
 <li>
+  <a href="#joker.markup">joker.markup</a>
+</li>
+<li>
   <a href="#joker.math">joker.math</a>
 </li>
 <li>
@@ -342,6 +345,12 @@
   <span class="var-added">v1.0</span>
   <p class="var-docstr">Implements encoding and decoding of JSON as defined in RFC 4627.</p>
   <a href="joker.json.html">details</a>
+</li>
+<li>
+  <h3 id="joker.markup">joker.markup</h3>
+  <span class="var-added">v0.14.0</span>
+  <p class="var-docstr">Renders HTML, XML, or XHTML markup to a string, based on prior work in Hiccup.</p>
+  <a href="joker.markup.html">details</a>
 </li>
 <li>
   <h3 id="joker.math">joker.math</h3>

--- a/docs/joker.markup.html
+++ b/docs/joker.markup.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+  <link rel="stylesheet" type="text/css" href="main.css">
+</head>
+<body>
+  <div class="main">
+    <h1>Namespace: joker.markup</h1>
+    <span class="var-added">v0.14.0</span>
+    <p class="var-docstr">Renders HTML, XML, or XHTML markup to a string, based on prior work in Hiccup.<br>
+<br>
+  https://github.com/weavejester/hiccup</p>
+    <h2>Index</h2>
+    <ul class="index">
+      <li>
+  <a href="#html">html</a>
+</li>
+<li>
+  <a href="#raw-string">raw-string</a>
+</li>
+
+    </ul>
+    <ul>
+      <li>
+  <h3 id="html">html</h3>
+  <span class="var-type Function">Function</span>
+  <span class="var-added">v0.14.0</span>
+  <pre class="var-usage"><div><code>(html & content)</code></div>
+</pre>
+  <p class="var-docstr">Renders the Hiccup-style content as HTML markup, returning a string of<br>
+  the markup.<br>
+<br>
+  The first parameter may be a map, which is options for the entire render.<br>
+<br>
+  The :mode option defaults to :xhtml but can also be :html, :xml, or :sgml.</p>
+  <a href="https://github.com/candid82/joker/blob/master/core/data/markup.joke#L152">source</a>
+</li>
+<li>
+  <h3 id="raw-string">raw-string</h3>
+  <span class="var-type Function">Function</span>
+  <span class="var-added">v0.14.0</span>
+  <pre class="var-usage"><div><code>(raw-string content)</code></div>
+</pre>
+  <p class="var-docstr">A raw string is pre-rendered content that is added directly to the output markup<br>
+   without any interpretation or escaping.</p>
+  <a href="https://github.com/candid82/joker/blob/master/core/data/markup.joke#L145">source</a>
+</li>
+
+    </ul>
+  </div>
+</body>
+</html>

--- a/tests/eval/markup.joke
+++ b/tests/eval/markup.joke
@@ -1,0 +1,110 @@
+(ns joker.test-joker.markup
+  (:require
+   [joker.test :refer [deftest is testing]]
+   [joker.markup :refer [html raw-string]]))
+
+;; These tests are largely copied from the Hiccup source
+
+(deftest tag-names
+  (testing "basic tags"
+    (is (= (html [:div]) "<div></div>"))
+    (is (= (html ["div"]) "<div></div>"))
+    (is (= (html ['div]) "<div></div>")))
+  (testing "tag syntax sugar"
+    (is (= (html [:div#foo]) "<div id=\"foo\"></div>"))
+    (is (= (html [:div.foo]) "<div class=\"foo\"></div>"))
+    (is (= (html [:div.foo (str "bar" "baz")])
+           "<div class=\"foo\">barbaz</div>"))
+    (is (= (html [:div.a.b]) "<div class=\"a b\"></div>"))
+    (is (= (html [:div.a.b.c]) "<div class=\"a b c\"></div>"))
+    (is (= (html [:div#foo.bar.baz])
+           "<div class=\"bar baz\" id=\"foo\"></div>"))))
+
+(deftest tag-contents
+  (testing "empty tags"
+    (is (= (html [:div]) "<div></div>"))
+    (is (= (html [:h1]) "<h1></h1>"))
+    (is (= (html [:script]) "<script></script>"))
+    (is (= (html [:text]) "<text></text>"))
+    (is (= (html [:a]) "<a></a>"))
+    (is (= (html [:iframe]) "<iframe></iframe>"))
+    (is (= (html [:title]) "<title></title>"))
+    (is (= (html [:section]) "<section></section>"))
+    (is (= (html [:select]) "<select></select>"))
+    (is (= (html [:object]) "<object></object>"))
+    (is (= (html [:video]) "<video></video>")))
+  (testing "void tags"
+    (is (= (html [:br]) "<br />"))
+    (is (= (html [:link]) "<link />"))
+    (is (= (html [:colgroup {:span 2}] "<colgroup span=\"2\" />")))
+    (is (= (html [:colgroup [:col]] "<colgroup><col /></colgroup>"))))
+  (testing "tags containing text"
+    (is (= (html [:text "Lorem Ipsum"]) "<text>Lorem Ipsum</text>")))
+  (testing "contents are concatenated"
+    (is (= (html [:body "foo" "bar"]) "<body>foobar</body>"))
+    (is (= (html [:body [:p] [:br]]) "<body><p></p><br /></body>")))
+  (testing "seqs are expanded"
+    (is (= (html [:body (list "foo" "bar")]) "<body>foobar</body>"))
+    (is (= (html (list [:p "a"] [:p "b"])) "<p>a</p><p>b</p>")))
+  (testing "keywords are turned into strings"
+    (is (= (html [:div :foo]) "<div>foo</div>")))
+  (testing "vecs don't expand - error if vec doesn't have tag name"
+    (is (thrown? Error
+                 (html (vector [:p "a"] [:p "b"])))))
+  (testing "tags can contain tags"
+    (is (= (html [:div [:p]]) "<div><p></p></div>"))
+    (is (= (html [:div [:b]]) "<div><b></b></div>"))
+    (is (= (html [:p [:span [:a "foo"]]])
+           "<p><span><a>foo</a></span></p>"))))
+
+(deftest tag-attributes
+  (testing "tag with blank attribute map"
+    (is (= (html [:xml {}]) "<xml></xml>")))
+  (testing "tag with populated attribute map"
+    (is (= (html [:xml {:a "1", :b "2"}]) "<xml a=\"1\" b=\"2\"></xml>"))
+    (is (= (html [:img {"id" "foo"}]) "<img id=\"foo\" />"))
+    (is (= (html [:img {'id "foo"}]) "<img id=\"foo\" />"))
+    (is (= (html [:xml {:a "1", 'b "2", "c" "3"}])
+           "<xml a=\"1\" b=\"2\" c=\"3\"></xml>")))
+  ;; This logic differs from Clojure Hiccup, due to use of joker.html/escape
+  #_ (testing "attribute values are escaped"
+       (is (= (html [:div {:id "\""}]) "<div id=\"&quot;\"></div>")))
+  (testing "attributes are escaped via joker.html/escape"
+    (is (= (html [:div {:id "<_&_>_\"_'"}])
+           "<div id=\"&lt;_&amp;_&gt;_&#34;_&#39;\"></div>")))
+  (testing "boolean attributes"
+    (is (= (html [:input {:type "checkbox" :checked true}])
+           "<input checked=\"checked\" type=\"checkbox\" />"))
+    (is (= (html [:input {:type "checkbox" :checked false}])
+           "<input type=\"checkbox\" />")))
+  (testing "nil attributes"
+    (is (= (html [:span {:class nil} "foo"])
+           "<span>foo</span>")))
+  (testing "resolving conflicts between attributes in the map and tag"
+    (is (= (html [:div.foo {:class "bar"} "baz"])
+           "<div class=\"foo bar\">baz</div>"))
+    (is (= (html [:div#bar.foo {:id "baq"} "baz"])
+           "<div class=\"foo\" id=\"baq\">baz</div>"))))
+
+(deftest render-modes
+  (testing "closed tag"
+    (is (= (html [:p] [:br]) "<p></p><br />"))
+    (is (= (html {:mode :xhtml} [:p] [:br]) "<p></p><br />"))
+    (is (= (html {:mode :html} [:p] [:br]) "<p></p><br>"))
+    (is (= (html {:mode :xml} [:p] [:br]) "<p /><br />"))
+    (is (= (html {:mode :sgml} [:p] [:br]) "<p><br>")))
+  (testing "boolean attributes"
+    (is (= (html {:mode :xml} [:input {:type "checkbox" :checked true}])
+           "<input checked=\"checked\" type=\"checkbox\" />"))
+    (is (= (html {:mode :sgml} [:input {:type "checkbox" :checked true}])
+           "<input checked type=\"checkbox\">")))
+  (testing "laziness and binding scope"
+    (is (= (html {:mode :sgml} [:html [:link] (list [:link])])
+           "<html><link><link></html>"))))
+
+(deftest raw-and-escaped-content
+  (let [text "The <blink> tag should not be used"]
+    (is (= (html [:div text])
+           "<div>The &lt;blink&gt; tag should not be used</div>"))
+    (is (= (html [:div (raw-string text)])
+           "<div>The <blink> tag should not be used</div>"))))


### PR DESCRIPTION
Patterned on Hiccup, this namespace allows for rendering of XHTML (and variants) markup from vectors and strings.

It is not a direct port of Hiccup, as it is strictly interpretive, but its basic API is compatible with Hiccup (nearly all tests were just copied over unchanged), and should be quite sufficient for generating blog posts, XML configuration files, or other similar operations in Joker's intended domain.