### PR TITLE
Add joker.repl to *loaded-libs*

### DIFF
--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3232,7 +3232,7 @@
   ^{:private true
     :doc "A set of symbols representing loaded libs"}
   *loaded-libs* #{'joker.base64 'joker.core 'joker.html 'joker.http 'joker.json 'joker.io
-                  'joker.math 'joker.os 'joker.string 'joker.time 'joker.url
+                  'joker.math 'joker.os 'joker.repl 'joker.string 'joker.time 'joker.url
                   'joker.yaml 'joker.strconv 'joker.crypto 'joker.hex 'joker.filepath
                   'joker.csv})
 


### PR DESCRIPTION
Happened to notice this and can't see any reason for it to be missing!