### PR TITLE
Create joker.better-cond from Engleberg/better-cond

### DIFF
--- a/core/data/better_cond.joke
+++ b/core/data/better_cond.joke
@@ -1,0 +1,79 @@
+(ns joker.better-cond
+  "A collection of variations on Clojure's core macros. Let's see which features
+   end up being useful."
+  {:author "Christophe Grand and Mark Engelberg"}
+  ;; Based on better-cond 1.0.1 and 2.0.1
+  (:refer-clojure :exclude [cond when-let if-let when-some if-some]))
+
+(defmacro if-let
+  "A variation on if-let where all the exprs in the bindings vector must be true.
+   Also supports :let."
+  ([bindings then]
+   `(if-let ~bindings ~then nil))
+  ([bindings then else]
+   (if (seq bindings)
+     (if (or (= :let (bindings 0)) (= 'let (bindings 0)))
+       `(let ~(bindings 1)
+          (if-let ~(subvec bindings 2) ~then ~else))
+       `(let [test# ~(bindings 1)]
+          (if test#
+            (let [~(bindings 0) test#]
+              (if-let ~(subvec bindings 2) ~then ~else))
+            ~else)))
+     then)))
+
+(defmacro when-let
+  "A variation on when-let where all the exprs in the bindings vector must be true.
+   Also supports :let."
+  [bindings & body]
+  `(if-let ~bindings (do ~@body)))
+
+(defmacro if-some
+  "A variation on if-some where all the exprs in the bindings vector must be non-nil.
+   Also supports :let."
+  ([bindings then]
+   `(if-some ~bindings ~then nil))
+  ([bindings then else]
+   (if (seq bindings)
+     (if (or (= :let (bindings 0)) (= 'let (bindings 0)))
+       `(let ~(bindings 1)
+          (if-some ~(subvec bindings 2) ~then ~else))
+       `(let [test# ~(bindings 1)]
+          (if (nil? test#)
+            ~else
+            (let [~(bindings 0) test#]
+              (if-some ~(subvec bindings 2) ~then ~else)))))
+     then)))
+
+(defmacro when-some
+  "A variation on when-some where all the exprs in the bindings vector must be non-nil.
+   Also supports :let."
+  [bindings & body]
+  `(if-some ~bindings (do ~@body)))
+
+(defmacro cond
+  "A variation on cond which sports let bindings, do and implicit else:
+     (cond 
+       (odd? a) 1
+       :do (println a)
+       :let [a (quot a 2)]
+       (odd? a) 2
+       3).
+   Also supports :when-let and :when-some. 
+   :let, :when-let, :when-some and :do do not need to be written as keywords."
+  [& clauses]
+  (when-let [[test expr & more-clauses] (seq clauses)]
+    (if (next clauses)
+      (if (or (= :do test) (= 'do test))
+        `(do ~expr (cond ~@more-clauses))
+        (if (or (= :let test) (= 'let test))
+          `(let ~expr (cond ~@more-clauses))
+          (if (or (= :when test) (= 'when test))
+            `(when ~expr (cond ~@more-clauses))
+            (if (or (= :when-let test) (= 'when-let test))
+              `(when-let ~expr (cond ~@more-clauses))
+              (if (or (= :when-some test) (= 'when-some test))
+                `(when-some ~expr (cond ~@more-clauses))
+                `(if ~test ~expr (cond ~@more-clauses)))))))
+      test)))
+

--- a/core/data/better_cond.joke
+++ b/core/data/better_cond.joke
@@ -1,8 +1,6 @@
 (ns joker.better-cond
-  "A collection of variations on Clojure's core macros. Let's see which features
-   end up being useful."
+  "A collection of variations on Clojure's core macros."
   {:author "Christophe Grand and Mark Engelberg"}
-  ;; Based on better-cond 1.0.1 and 2.0.1
   (:refer-clojure :exclude [cond when-let if-let when-some if-some]))
 
 (defmacro if-let

--- a/core/gen_data/gen_data.go
+++ b/core/gen_data/gen_data.go
@@ -81,6 +81,10 @@ var files []FileInfo = []FileInfo{
 		name:     "<joker.hiccup>",
 		filename: "hiccup.joke",
 	},
+	{
+		name:     "<joker.better-cond>",
+		filename: "better_cond.joke",
+	},
 }
 
 const hextable = "0123456789abcdef"

--- a/core/procs.go
+++ b/core/procs.go
@@ -34,6 +34,7 @@ var (
 	linter_cljData   []byte
 	linter_cljsData  []byte
 	hiccupData       []byte
+	better_condData  []byte
 )
 
 type (
@@ -65,13 +66,14 @@ const (
 
 func InitInternalLibs() {
 	internalLibs = map[string][]byte{
-		"joker.walk":      walkData,
-		"joker.template":  templateData,
-		"joker.repl":      replData,
-		"joker.test":      testData,
-		"joker.set":       setData,
-		"joker.tools.cli": tools_cliData,
-		"joker.hiccup":    hiccupData,
+		"joker.walk":        walkData,
+		"joker.template":    templateData,
+		"joker.repl":        replData,
+		"joker.test":        testData,
+		"joker.set":         setData,
+		"joker.tools.cli":   tools_cliData,
+		"joker.hiccup":      hiccupData,
+		"joker.better-cond": better_condData,
 	}
 }
 

--- a/tests/eval/better-cond-test.joke
+++ b/tests/eval/better-cond-test.joke
@@ -1,0 +1,38 @@
+(ns joker.better-cond-test
+  (:refer-clojure :exclude [cond if-let when-let if-some when-some])
+  (:require [joker.test :refer [deftest are]]
+            [joker.better-cond :refer [cond]]))
+
+(deftest better-cond
+  (are [x y] (= x y)
+    2 (cond (even? 3) 5
+            (odd? 3) 2)
+    2 (cond (even? 3) 5
+            :else 2)
+    2 (cond
+        :let [x 2]
+        x)
+    2 (cond
+        :when-let [x 2]
+        x)
+    2 (cond
+        :when-some [x 2]
+        x)
+    nil (cond
+          :when-let [x false]
+          2)
+    2 (cond
+        :when-let [x true]
+        2)
+    nil (cond
+          :when-let [x nil]
+          2)
+    2 (cond
+        :when-some [x false]
+        2)
+    2 (cond
+        :when (even? 4)
+        2)
+    nil (cond
+          :when (even? 3)
+          2)))


### PR DESCRIPTION
This PR adds namespace `joker.better-cond`, based on code extracted from https://github.com/Engelberg/better-cond.

I've found that nearly every Joker script I've written has needed `cond-let` (a more limited version of better-cond's version of `cond`).

Original work licensed under Eclipse Public License.