### PR TITLE
Fix deps.joke to use source filename directly

### DIFF
--- a/tests/eval/deps.joke
+++ b/tests/eval/deps.joke
@@ -3,8 +3,7 @@
             [joker.string :as str]))
 
 (def lib-dir
-  (-> (os/args)
-       (second)
+  (-> *main-file*
        (str/split #"/")
        (butlast)
        (concat ["lib"])


### PR DESCRIPTION
Instead of guessing which argument, in the original invocation of Joker,
has the filename, or even using the Joker-provided `*command-line-args*`
variable, just use `*main-file*` directly (it's a new-ish feature).

This allows the test to pass even if Joker options (not options to the
Joker script being invoked) are provided. E.g. this works:

```
./joker --evaluate tests/run-eval-tests.joke
```