### PR TITLE
Improve tty testing so it works outside of the eval-tests.sh script

### DIFF
--- a/eval-tests.sh
+++ b/eval-tests.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-# Let test suite know to try.
-[[ -t 0 ]] && export TTY_TESTS=1
-
 ./joker tests/run-eval-tests.joke "$@"

--- a/tests/run-eval-tests.joke
+++ b/tests/run-eval-tests.joke
@@ -1,5 +1,10 @@
 (ns joker.test.run-eval-tests
-  (require [joker.test :refer [run-tests]]))
+  (require [joker.test :refer [run-tests]]
+           [joker.os :as os]))
+
+(let [res (os/exec "/usr/bin/env" {:stdin *in* :args ["test" "-t" "0"]})]
+  (when (:success res)
+    (os/set-env "TTY_TESTS" "1")))
 
 (defn- slurp-or
   [path alt]


### PR DESCRIPTION
This allows `./joker tests/run-eval-tests.joke` (run from a command line,
so stdin is a tty) to support tty-related testing.