### PR TITLE
Improve diagnostics around wrong-arity function calls

### DIFF
--- a/tests/linter/defmethod/output.txt
+++ b/tests/linter/defmethod/output.txt
@@ -1,3 +1,3 @@
 tests/linter/defmethod/input.clj:6:3: Parse error: Unable to resolve symbol: b
 tests/linter/defmethod/input.clj:8:12: Parse error: Unable to resolve symbol: m2
-tests/linter/defmethod/input.clj:10:1: Eval error: Wrong number of args (1) passed to core/defmethod
+tests/linter/defmethod/input.clj:10:1: Eval error: Wrong number of args (1) passed to core/defmethod; expects at least 3

--- a/tests/linter/letfn/output.txt
+++ b/tests/linter/letfn/output.txt
@@ -1,1 +1,1 @@
-tests/linter/letfn/input.clj:6:1: Eval error: Wrong number of args (0) passed to core/letfn
+tests/linter/letfn/input.clj:6:1: Eval error: Wrong number of args (0) passed to core/letfn; expects at least 2

--- a/tests/linter/macro-call-1/output.txt
+++ b/tests/linter/macro-call-1/output.txt
@@ -1,1 +1,1 @@
-tests/linter/macro-call-1/input.clj:1:1: Eval error: Wrong number of args (0) passed to core/deftype
+tests/linter/macro-call-1/input.clj:1:1: Eval error: Wrong number of args (0) passed to core/deftype; expects at least 3

--- a/tests/linter/macro-call/output.txt
+++ b/tests/linter/macro-call/output.txt
@@ -6,4 +6,4 @@ tests/linter/macro-call/input.clj:5:1: Parse warning: Wrong number of args (0) p
 tests/linter/macro-call/input.clj:6:1: Parse warning: Wrong number of args (0) passed to core/definterface
 tests/linter/macro-call/input.clj:7:1: Parse warning: Wrong number of args (0) passed to core/proxy-super
 tests/linter/macro-call/input.clj:8:1: Parse warning: Wrong number of args (0) passed to core/with-open
-tests/linter/macro-call/input.clj:9:1: Eval error: Wrong number of args (0) passed to core/defrecord
+tests/linter/macro-call/input.clj:9:1: Eval error: Wrong number of args (0) passed to core/defrecord; expects at least 3


### PR DESCRIPTION
This helped me out on one of my development branches.