### PR TITLE
Exec 'test' directly, not via '/usr/bin/env'

### DIFF
--- a/tests/run-eval-tests.joke
+++ b/tests/run-eval-tests.joke
@@ -2,7 +2,7 @@
   (require [joker.test :refer [run-tests]]
            [joker.os :as os]))
 
-(let [res (os/exec "/usr/bin/env" {:stdin *in* :args ["test" "-t" "0"]})]
+(let [res (os/exec "test" {:stdin *in* :args ["-t" "0"]})]
   (when (:success res)
     (os/set-env "TTY_TESTS" "1")))
 


### PR DESCRIPTION
This fixes one issue, but there's a downstream failure involving `lib/test-local/lib.joke` and pathname separators running under Git Bash on Windows that should be fixed.

Note that I'm not entirely sure why I went with `/usr/bin/env` in the first place, below, other than it's canonical. Nor have I investigated why that approach yields this message (without this fix):

```
tests/run-eval-tests.joke:5:11: Eval error: exec: "/usr/bin/env": file does not exist
```

I hope this change doesn't break other OSes!