### PR TITLE
Support joker.string/split string separator

### DIFF
--- a/std/string.joke
+++ b/std/string.joke
@@ -28,12 +28,13 @@
   [^String s ^Stringable pad ^Int n])
 
 (defn split
-  "Splits string on a regular expression. Returns vector of the splits."
+  "Splits string on a string or regular expression. Returns vector of the splits."
   {:added "1.0"
-  :go {2 "split(s, re, 0)"
-       3 "split(s, re, n)"}}
-  ([^String s ^Regex re])
-  ([^String s ^Regex re ^Int n]))
+  :go {2 "splitOnStringOrRegex(s, sep, 0)"
+       3 "splitOnStringOrRegex(s, sep, n)"}}
+  ;; TODO: ^"String|Regex" sep
+  ([^String s ^Object sep])
+  ([^String s ^Object sep ^Int n]))
 
 (defn split-lines
   "Splits string on \\n or \\r\\n. Returns vector of the splits."

--- a/std/string/a_string.go
+++ b/std/string/a_string.go
@@ -276,15 +276,15 @@ func __split_(_args []Object) Object {
 	switch {
 	case _c == 2:
 		s := ExtractString(_args, 0)
-		re := ExtractRegex(_args, 1)
-		_res := split(s, re, 0)
+		sep := ExtractObject(_args, 1)
+		_res := splitOnStringOrRegex(s, sep, 0)
 		return _res
 
 	case _c == 3:
 		s := ExtractString(_args, 0)
-		re := ExtractRegex(_args, 1)
+		sep := ExtractObject(_args, 1)
 		n := ExtractInt(_args, 2)
-		_res := split(s, re, n)
+		_res := splitOnStringOrRegex(s, sep, n)
 		return _res
 
 	default:
@@ -557,8 +557,8 @@ func Init() {
 
 	stringNamespace.InternVar("split", split_,
 		MakeMeta(
-			NewListFrom(NewVectorFrom(MakeSymbol("s"), MakeSymbol("re")), NewVectorFrom(MakeSymbol("s"), MakeSymbol("re"), MakeSymbol("n"))),
-			`Splits string on a regular expression. Returns vector of the splits.`, "1.0"))
+			NewListFrom(NewVectorFrom(MakeSymbol("s"), MakeSymbol("sep")), NewVectorFrom(MakeSymbol("s"), MakeSymbol("sep"), MakeSymbol("n"))),
+			`Splits string on a string or regular expression. Returns vector of the splits.`, "1.0"))
 
 	stringNamespace.InternVar("split-lines", split_lines_,
 		MakeMeta(

--- a/std/string/string_native.go
+++ b/std/string/string_native.go
@@ -58,6 +58,22 @@ func split(s string, r *regexp.Regexp, n int) Object {
 	return result
 }
 
+func splitOnStringOrRegex(s string, sep Object, n int) Object {
+	switch sep := sep.(type) {
+	case String:
+		v := strings.Split(s, sep.S)
+		result := EmptyVector()
+		for _, el := range v {
+			result = result.Conjoin(String{S: el})
+		}
+		return result
+	case Regex:
+		return split(s, sep.R, n)
+	default:
+		panic(RT.NewArgTypeError(1, sep, "String or Regex"))
+	}
+}
+
 func join(sep string, seqable Seqable) string {
 	seq := seqable.Seq()
 	var b bytes.Buffer

--- a/tests/eval/string.joke
+++ b/tests/eval/string.joke
@@ -1,0 +1,10 @@
+(ns joker.test-joker.string
+  (:require [joker.string :as str]
+            [joker.test :refer [deftest is]]))
+
+(deftest split-of-regex
+  (is (= ["a" "c" "ef"] (str/split "abcdef" #"(b|d)"))))
+
+(deftest split-of-string
+  (is (= ["ab" "def"] (str/split "abcdef" "c")))
+  (is (= ["abcdef"] (str/split "abcdef" "(b|d)"))))


### PR DESCRIPTION
This extends `split` beyond what `clojure.string/split` provides, makes `split` more consistent with other `joker.string` functions, and sets the stage for a straightforward fix to the Windows bug in `deps.joke`.

With this, https://github.com/candid82/joker/pull/319 is (for me) less urgent.