### PR TITLE
Bring verbosity improvements over from gen-code branch

### DIFF
--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3222,11 +3222,19 @@
      (when-not (bound? v#)
        (def ~name ~expr))))
 
+(defonce ^:dynamic
+  ^{:private true
+    :doc "True while a verbose load is pending"}
+  *loading-verbosely* false)
+
 (defn in-ns
   "Sets *ns* to the namespace named by the symbol, creating it if needed."
   {:added "1.0"}
   ^Namespace [^Symbol name]
-  (var-set #'joker.core/*ns* (joker.core/create-ns name)))
+  (let [new-ns (joker.core/create-ns name)]
+    (when *loading-verbosely*
+      (printf "joker.core/in-ns: changing from %s to %s\n" joker.core/*ns* new-ns) (flush))
+    (var-set #'joker.core/*ns* new-ns)))
 
 (defonce ^:dynamic
   ^{:private true
@@ -3245,11 +3253,6 @@
   ^{:private true
     :doc "A stack of paths currently being loaded"}
   *pending-paths* ())
-
-(defonce ^:dynamic
-  ^{:private true
-    :doc "True while a verbose load is pending"}
-  *loading-verbosely* false)
 
 (defonce ^:dynamic
   ^{:private true
@@ -3546,7 +3549,7 @@
   (doseq [^Symbol lib libs]
     (let [^String path (lib-path__ lib)]
       (when *loading-verbosely*
-        (printf "(joker.core/load \"%s\")\n" path))
+        (printf "(joker.core/load %s from \"%s\")\n" lib path))
       (check-cyclic-dependency path lib)
       (when-not (= path (first *pending-paths*))
         (binding [*pending-paths* (conj *pending-paths* path)
@@ -3850,6 +3853,33 @@
 
   Defaults to true"
   {:added "1.0"})
+
+(add-doc-and-meta *verbose*
+  "Whether --verbose (or equivalent) was specified by the Joker invocation.
+
+  Note: changing this (via e.g. var-set) affects only running Joker code; it
+  does not change the value used by the Go code that implements Joker. If
+  needed, it's probably better to add a set-verbose function that changes
+  both, rather than changing Joker's internals so this variable is always checked."
+  {:added "1.0"})
+
+(add-doc-and-meta *verbosity-level*
+  "Verbosity level as (initially) specified by the Joker invocation.
+
+  Note: changing this (via e.g. var-set) affects only running Joker code; it
+  does not change the value used by the Go code that implements Joker. If
+  needed, it's probably better to add a set-verbosity-level function that
+  changes both, rather than changing Joker's internals so this variable is
+  always checked."
+  {:added "1.0"})
+
+(defn- verbosity
+  "Verbosity level in effect; 0 if verbosity disabled."
+  {:added "1.0"}
+  []
+  (if *verbose*
+    *verbosity-level*
+    0))
 
 (defmacro letfn
   "fnspec ==> (fname [params*] exprs) or (fname ([params*] exprs)+)

--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3854,33 +3854,6 @@
   Defaults to true"
   {:added "1.0"})
 
-(add-doc-and-meta *verbose*
-  "Whether --verbose (or equivalent) was specified by the Joker invocation.
-
-  Note: changing this (via e.g. var-set) affects only running Joker code; it
-  does not change the value used by the Go code that implements Joker. If
-  needed, it's probably better to add a set-verbose function that changes
-  both, rather than changing Joker's internals so this variable is always checked."
-  {:added "1.0"})
-
-(add-doc-and-meta *verbosity-level*
-  "Verbosity level as (initially) specified by the Joker invocation.
-
-  Note: changing this (via e.g. var-set) affects only running Joker code; it
-  does not change the value used by the Go code that implements Joker. If
-  needed, it's probably better to add a set-verbosity-level function that
-  changes both, rather than changing Joker's internals so this variable is
-  always checked."
-  {:added "1.0"})
-
-(defn- verbosity
-  "Verbosity level in effect; 0 if verbosity disabled."
-  {:added "1.0"}
-  []
-  (if *verbose*
-    *verbosity-level*
-    0))
-
 (defmacro letfn
   "fnspec ==> (fname [params*] exprs) or (fname ([params*] exprs)+)
 
@@ -4594,3 +4567,9 @@
    (go-spew__ o))
   (^Boolean [o ^Map cfg]
    (go-spew__ o cfg)))
+
+(defn- verbosity-level
+  "Verbosity level as specified via the --verbose option to Joker."
+  {:added "1.0"}
+  []
+  (verbosity-level__))

--- a/core/environment.go
+++ b/core/environment.go
@@ -12,7 +12,6 @@ var (
 	Stdin          io.Reader = os.Stdin
 	Stdout         io.Writer = os.Stdout
 	Stderr         io.Writer = os.Stderr
-	Verbose                  = false
 	VerbosityLevel           = 0
 )
 
@@ -72,18 +71,6 @@ func (env *Env) SetClassPath(cp string) {
 		cpVec = cpVec.Conjoin(MakeString(""))
 	}
 	env.classPath.Value = cpVec
-}
-
-func (env *Env) SetVerbosity() {
-	env.verbose.Value = Boolean{B: Verbose}
-	env.verbosity.Value = Int{I: VerbosityLevel}
-}
-
-func Verbosity() int {
-	if Verbose {
-		return VerbosityLevel
-	}
-	return 0
 }
 
 /* Called by parse.go in an outer var block, this runs before func main(). */

--- a/core/environment.go
+++ b/core/environment.go
@@ -27,8 +27,6 @@ type (
 		MainFile      *Var
 		args          *Var
 		classPath     *Var
-		verbose       *Var
-		verbosity     *Var
 		ns            *Var
 		NS_VAR        *Var
 		IN_NS_VAR     *Var
@@ -111,12 +109,6 @@ func NewEnv(currentNs Symbol, stdin io.Reader, stdout io.Writer, stderr io.Write
 		MakeMeta(nil, "true if Joker is running in linter mode", "1.0"))
 	res.CoreNamespace.InternVar("*linter-config*", EmptyArrayMap(),
 		MakeMeta(nil, "Map of configuration key/value pairs for linter mode", "1.0"))
-	res.verbose = res.CoreNamespace.Intern(MakeSymbol("*verbose*"))
-	res.verbose.Value = Boolean{B: false}
-	res.verbose.isPrivate = true
-	res.verbosity = res.CoreNamespace.Intern(MakeSymbol("*verbosity-level*"))
-	res.verbosity.Value = Int{I: 0}
-	res.verbosity.isPrivate = true
 	return res
 }
 

--- a/core/ns.go
+++ b/core/ns.go
@@ -62,6 +62,16 @@ func (ns *Namespace) Hash() uint32 {
 	return ns.hash
 }
 
+func (ns *Namespace) MaybeLazy(doc string) {
+	if ns.Lazy != nil {
+		ns.Lazy()
+		if Verbosity() > 0 {
+			fmt.Fprintf(Stderr, "NamespaceFor: Lazily initialized %s for %s\n", *ns.Name.name, doc)
+		}
+		ns.Lazy = nil
+	}
+}
+
 const nsHashMask uint32 = 0x90569f6f
 
 func NewNamespace(sym Symbol) *Namespace {

--- a/core/ns.go
+++ b/core/ns.go
@@ -65,7 +65,7 @@ func (ns *Namespace) Hash() uint32 {
 func (ns *Namespace) MaybeLazy(doc string) {
 	if ns.Lazy != nil {
 		ns.Lazy()
-		if Verbosity() > 0 {
+		if VerbosityLevel > 0 {
 			fmt.Fprintf(Stderr, "NamespaceFor: Lazily initialized %s for %s\n", *ns.Name.name, doc)
 		}
 		ns.Lazy = nil

--- a/core/procs.go
+++ b/core/procs.go
@@ -1642,6 +1642,11 @@ var procGo Proc = func(args []Object) Object {
 	return ch
 }
 
+var procVerbosityLevel Proc = func(args []Object) Object {
+	CheckArity(args, 0, 0)
+	return MakeInt(VerbosityLevel)
+}
+
 func PackReader(reader *Reader, filename string) ([]byte, error) {
 	var p []byte
 	packEnv := NewPackEnv()
@@ -2237,4 +2242,5 @@ func init() {
 	intern("close!__", procCloseChan)
 
 	intern("go-spew__", procGoSpew)
+	intern("verbosity-level__", procVerbosityLevel)
 }

--- a/main.go
+++ b/main.go
@@ -440,6 +440,16 @@ func notOption(arg string) bool {
 }
 
 func parseArgs(args []string) {
+	if len(args) > 1 {
+		// peek to see if the first arg is "--debug*"
+		switch args[1] {
+		case "--debug", "--debug=stderr":
+			debugOut = Stderr
+		case "--debug=stdout":
+			debugOut = Stdout
+		}
+	}
+
 	length := len(args)
 	stop := false
 	missing := false
@@ -469,6 +479,22 @@ func parseArgs(args []string) {
 			debugOut = Stdout
 		case "--verbose":
 			Verbose = true
+			if i < length-1 && notOption(args[i+1]) {
+				i += 1 // shift
+				verbosity, err := strconv.ParseInt(args[i], 10, 64)
+				if err != nil {
+					fmt.Fprintln(Stderr, "Error: ", err)
+					return
+				}
+				if verbosity <= 0 {
+					Verbose = false
+					VerbosityLevel = 0
+				} else {
+					VerbosityLevel = int(verbosity)
+				}
+			} else {
+				VerbosityLevel++
+			}
 		case "--help", "-h":
 			helpFlag = true
 			return // don't bother parsing anything else
@@ -651,31 +677,24 @@ var runningProfile interface {
 }
 
 func main() {
-	RT.GIL.Lock()
-	InitInternalLibs()
-	ProcessCoreData()
-
 	SetExitJoker(func(code int) {
 		finish()
 		os.Exit(code)
 	})
-	GLOBAL_ENV.FindNamespace(MakeSymbol("user")).ReferAll(GLOBAL_ENV.CoreNamespace)
 
-	if len(os.Args) > 1 {
-		// peek to see if the first arg is "--debug*"
-		switch os.Args[1] {
-		case "--debug", "--debug=stderr":
-			debugOut = Stderr
-		case "--debug=stdout":
-			debugOut = Stdout
-		}
-	}
+	parseArgs(os.Args) // Do this early enough so --verbose can show joker.core being processed.
 
-	parseArgs(os.Args)
 	saveForRepl = saveForRepl && (exitToRepl || errorToRepl) // don't bother saving stuff if no repl
+
+	RT.GIL.Lock()
+	InitInternalLibs()
+	ProcessCoreData()
+
+	GLOBAL_ENV.FindNamespace(MakeSymbol("user")).ReferAll(GLOBAL_ENV.CoreNamespace)
 
 	GLOBAL_ENV.SetEnvArgs(remainingArgs)
 	GLOBAL_ENV.SetClassPath(classPath)
+	GLOBAL_ENV.SetVerbosity()
 
 	if debugOut != nil {
 		fmt.Fprintf(debugOut, "debugOut=%v\n", debugOut)

--- a/main.go
+++ b/main.go
@@ -478,7 +478,6 @@ func parseArgs(args []string) {
 		case "--debug=stdout":
 			debugOut = Stdout
 		case "--verbose":
-			Verbose = true
 			if i < length-1 && notOption(args[i+1]) {
 				i += 1 // shift
 				verbosity, err := strconv.ParseInt(args[i], 10, 64)
@@ -487,7 +486,6 @@ func parseArgs(args []string) {
 					return
 				}
 				if verbosity <= 0 {
-					Verbose = false
 					VerbosityLevel = 0
 				} else {
 					VerbosityLevel = int(verbosity)
@@ -694,7 +692,6 @@ func main() {
 
 	GLOBAL_ENV.SetEnvArgs(remainingArgs)
 	GLOBAL_ENV.SetClassPath(classPath)
-	GLOBAL_ENV.SetVerbosity()
 
 	if debugOut != nil {
 		fmt.Fprintf(debugOut, "debugOut=%v\n", debugOut)


### PR DESCRIPTION
This is not strictly necessary, but I found it invaluable, mainly when adding tests for verbosity levels greater than 1 (the default for one specification of `--verbose`) that would use `go-spew` to output substantial data sets.