### PR TITLE
Avoid breaking developer builds during gen-code integration

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,7 @@
 
 build() {
   go clean
+  rm -f core/a_*.go  # In case switching from a gen-code branch or similar (any existing files might break the build here)
   go generate ./...
   go vet ./...
   go build


### PR DESCRIPTION
Various changes made in the `gen-code` branch not only produce additional `a_*code.go` files, but change the way `a_*data.go` files are generated.

So it's best to start with a clean slate before running `go generate ./...`, to prevent it picking up those stale files.

Another approach to this could be to use build tags so `go generate`-run tools don't pick up any `a_*.go` files at all, but this seems easier and more effective.