### PR TITLE
Make Regex a reference type

### DIFF
--- a/core/object.go
+++ b/core/object.go
@@ -1,5 +1,5 @@
-//go:generate go run gen/gen_types.go assert Comparable *Vector Char String Symbol Keyword Regex Boolean Time Number Seqable Callable *Type Meta Int Double Stack Map Set Associative Reversible Named Comparator *Ratio *Namespace *Var Error *Fn Deref *Atom Ref KVReduce Pending *File io.Reader io.Writer StringReader io.RuneReader *Channel
-//go:generate go run gen/gen_types.go info *List *ArrayMapSeq *ArrayMap *HashMap *ExInfo *Fn *Var Nil *Ratio *BigInt *BigFloat Char Double Int Boolean Time Keyword Regex Symbol String *LazySeq *MappingSeq *ArraySeq *ConsSeq *NodeSeq *ArrayNodeSeq *MapSet *Vector *VectorSeq *VectorRSeq
+//go:generate go run gen/gen_types.go assert Comparable *Vector Char String Symbol Keyword *Regex Boolean Time Number Seqable Callable *Type Meta Int Double Stack Map Set Associative Reversible Named Comparator *Ratio *Namespace *Var Error *Fn Deref *Atom Ref KVReduce Pending *File io.Reader io.Writer StringReader io.RuneReader *Channel
+//go:generate go run gen/gen_types.go info *List *ArrayMapSeq *ArrayMap *HashMap *ExInfo *Fn *Var Nil *Ratio *BigInt *BigFloat Char Double Int Boolean Time Keyword *Regex Symbol String *LazySeq *MappingSeq *ArraySeq *ConsSeq *NodeSeq *ArrayNodeSeq *MapSet *Vector *VectorSeq *VectorRSeq
 //go:generate go run gen_data/gen_data.go
 
 package core
@@ -398,7 +398,7 @@ func init() {
 		Proc:          RegRefType("Proc", (*Proc)(nil), "A callable function implemented via Go code"),
 		Ratio:         RegRefType("Ratio", (*Ratio)(nil), "Wraps the Go 'math.big/Rat' type"),
 		RecurBindings: RegRefType("RecurBindings", (*RecurBindings)(nil), ""),
-		Regex:         regType("Regex", (*Regex)(nil), "Wraps the Go 'regexp.Regexp' type"),
+		Regex:         RegRefType("Regex", (*Regex)(nil), "Wraps the Go 'regexp.Regexp' type"),
 		String:        regType("String", (*String)(nil), "Wraps the Go 'string' type"),
 		Symbol:        regType("Symbol", (*Symbol)(nil), ""),
 		Type:          RegRefType("Type", (*Type)(nil), ""),
@@ -1342,35 +1342,35 @@ func (k Keyword) Call(args []Object) Object {
 	return getMap(k, args)
 }
 
-func MakeRegex(r *regexp.Regexp) Regex {
-	return Regex{R: r}
+func MakeRegex(r *regexp.Regexp) *Regex {
+	return &Regex{R: r}
 }
 
-func (rx Regex) ToString(escape bool) string {
+func (rx *Regex) ToString(escape bool) string {
 	if escape {
 		return "#\"" + rx.R.String() + "\""
 	}
 	return rx.R.String()
 }
 
-func (rx Regex) Print(w io.Writer, printReadably bool) {
+func (rx *Regex) Print(w io.Writer, printReadably bool) {
 	fmt.Fprint(w, rx.ToString(true))
 }
 
-func (rx Regex) Equals(other interface{}) bool {
+func (rx *Regex) Equals(other interface{}) bool {
 	switch other := other.(type) {
-	case Regex:
+	case *Regex:
 		return rx.R == other.R
 	default:
 		return false
 	}
 }
 
-func (rx Regex) GetType() *Type {
+func (rx *Regex) GetType() *Type {
 	return TYPE.Regex
 }
 
-func (rx Regex) Hash() uint32 {
+func (rx *Regex) Hash() uint32 {
 	return HashPtr(uintptr(unsafe.Pointer(rx.R)))
 }
 

--- a/core/parse.go
+++ b/core/parse.go
@@ -1873,7 +1873,7 @@ func Parse(obj Object, ctx *ParseContext) Expr {
 	var res Expr
 	canHaveMeta := false
 	switch v := obj.(type) {
-	case Int, String, Char, Double, *BigInt, *BigFloat, Boolean, Nil, *Ratio, Keyword, Regex, *Type:
+	case Int, String, Char, Double, *BigInt, *BigFloat, Boolean, Nil, *Ratio, Keyword, *Regex, *Type:
 		res = NewLiteralExpr(obj)
 	case *Vector:
 		canHaveMeta = true

--- a/core/procs.go
+++ b/core/procs.go
@@ -371,7 +371,7 @@ var procRegex Proc = func(args []Object) Object {
 	if err != nil {
 		panic(RT.NewError("Invalid regex: " + err.Error()))
 	}
-	return Regex{R: r}
+	return &Regex{R: r}
 }
 
 func reGroups(s string, indexes []int) Object {
@@ -1920,7 +1920,7 @@ func ReadConfig(filename string, workingDir string) {
 		if ok1 {
 			s := seq.Seq()
 			for !s.IsEmpty() {
-				regex, ok2 := s.First().(Regex)
+				regex, ok2 := s.First().(*Regex)
 				if !ok2 {
 					printConfigError(configFileName, ":ignored-file-regexes elements must be regexes, got "+s.First().GetType().ToString(false))
 					return

--- a/core/read.go
+++ b/core/read.go
@@ -450,11 +450,11 @@ func readRegex(reader *Reader) Object {
 	regex, err := regexp.Compile(b.String())
 	if err != nil {
 		if LINTER_MODE {
-			return MakeReadObject(reader, Regex{})
+			return MakeReadObject(reader, &Regex{})
 		}
 		panic(MakeReadError(reader, "Invalid regex: "+err.Error()))
 	}
-	return MakeReadObject(reader, Regex{R: regex})
+	return MakeReadObject(reader, &Regex{R: regex})
 }
 
 func readUnicodeCharacterInString(reader *Reader, initial rune, length, base int, exactLength bool) rune {

--- a/core/types_assert_gen.go
+++ b/core/types_assert_gen.go
@@ -133,9 +133,9 @@ func EnsureKeyword(args []Object, index int) Keyword {
 	}
 }
 
-func AssertRegex(obj Object, msg string) Regex {
+func AssertRegex(obj Object, msg string) *Regex {
 	switch c := obj.(type) {
-	case Regex:
+	case *Regex:
 		return c
 	default:
 		if msg == "" {
@@ -145,9 +145,9 @@ func AssertRegex(obj Object, msg string) Regex {
 	}
 }
 
-func EnsureRegex(args []Object, index int) Regex {
+func EnsureRegex(args []Object, index int) *Regex {
 	switch c := args[index].(type) {
-	case Regex:
+	case *Regex:
 		return c
 	default:
 		panic(RT.NewArgTypeError(index, c, "Regex"))

--- a/core/types_info_gen.go
+++ b/core/types_info_gen.go
@@ -87,7 +87,7 @@ func (x Keyword) WithInfo(info *ObjectInfo) Object {
 	return x
 }
 
-func (x Regex) WithInfo(info *ObjectInfo) Object {
+func (x *Regex) WithInfo(info *ObjectInfo) Object {
 	x.info = info
 	return x
 }

--- a/std/string/string_native.go
+++ b/std/string/string_native.go
@@ -67,7 +67,7 @@ func splitOnStringOrRegex(s string, sep Object, n int) Object {
 			result = result.Conjoin(String{S: el})
 		}
 		return result
-	case Regex:
+	case *Regex:
 		return split(s, sep.R, n)
 	default:
 		panic(RT.NewArgTypeError(1, sep, "String or Regex"))
@@ -161,7 +161,7 @@ func replace(s string, match Object, repl string) string {
 	switch match := match.(type) {
 	case String:
 		return strings.Replace(s, match.S, repl, -1)
-	case Regex:
+	case *Regex:
 		return match.R.ReplaceAllString(s, repl)
 	default:
 		panic(RT.NewArgTypeError(1, match, "String or Regex"))
@@ -172,7 +172,7 @@ func replaceFirst(s string, match Object, repl string) string {
 	switch match := match.(type) {
 	case String:
 		return strings.Replace(s, match.S, repl, 1)
-	case Regex:
+	case *Regex:
 		m := match.R.FindStringIndex(s)
 		if m == nil {
 			return s


### PR DESCRIPTION
This allows `gen_code.go` (currently on the `gen-code` branch of my fork of Joker) to easily update, at lazy-initialization time, an `Object`'s `.Value` with the resulting of a `regex.MustCompile()` call.