### PR TITLE
Make Proc's self-identify

### DIFF
--- a/core/object.go
+++ b/core/object.go
@@ -402,7 +402,6 @@ func init() {
 		NodeSeq:       RegRefType("NodeSeq", (*NodeSeq)(nil), ""),
 		ParseError:    RegRefType("ParseError", (*ParseError)(nil), ""),
 		Proc:          RegRefType("Proc", (*Proc)(nil), "A self-identifying callable function implemented via Go code"),
-		ProcFn:        RegRefType("ProcFn", (*ProcFn)(nil), "A callable function implemented via Go code"),
 		Ratio:         RegRefType("Ratio", (*Ratio)(nil), "Wraps the Go 'math.big/Rat' type"),
 		RecurBindings: RegRefType("RecurBindings", (*RecurBindings)(nil), ""),
 		Regex:         RegRefType("Regex", (*Regex)(nil), "Wraps the Go 'regexp.Regexp' type"),

--- a/core/object.go
+++ b/core/object.go
@@ -149,8 +149,9 @@ type (
 	}
 	ProcFn func([]Object) Object
 	Proc   struct {
-		Fn   ProcFn
-		Name string
+		Fn      ProcFn
+		Name    string
+		Package string // "' for core (this package), else e.g. "std/string"
 	}
 	Fn struct {
 		InfoHolder
@@ -857,7 +858,11 @@ func (p Proc) Compare(a, b Object) int {
 }
 
 func (p Proc) ToString(escape bool) string {
-	return fmt.Sprintf("#object[Proc:%s]", p.Name)
+	pkg := ""
+	if p.Package != "" {
+		pkg = p.Package + "."
+	}
+	return fmt.Sprintf("#object[Proc:%s%s]", pkg, p.Name)
 }
 
 func (p Proc) Equals(other interface{}) bool {

--- a/core/object.go
+++ b/core/object.go
@@ -151,7 +151,7 @@ type (
 	Proc   struct {
 		Fn      ProcFn
 		Name    string
-		Package string // "' for core (this package), else e.g. "std/string"
+		Package string // "" for core (this package), else e.g. "std/string"
 	}
 	Fn struct {
 		InfoHolder

--- a/core/object.go
+++ b/core/object.go
@@ -858,9 +858,9 @@ func (p Proc) Compare(a, b Object) int {
 }
 
 func (p Proc) ToString(escape bool) string {
-	pkg := ""
-	if p.Package != "" {
-		pkg = p.Package + "."
+	pkg := p.Package
+	if pkg != "" {
+		pkg += "."
 	}
 	return fmt.Sprintf("#object[Proc:%s%s]", pkg, p.Name)
 }

--- a/core/object.go
+++ b/core/object.go
@@ -867,7 +867,7 @@ func (p Proc) ToString(escape bool) string {
 func (p Proc) Equals(other interface{}) bool {
 	switch other := other.(type) {
 	case Proc:
-		return p.Fn.Equals(other.Fn)
+		return reflect.ValueOf(p.Fn).Pointer() == reflect.ValueOf(other.Fn).Pointer()
 	}
 	return false
 }
@@ -885,23 +885,11 @@ func (p Proc) GetType() *Type {
 }
 
 func (p Proc) Hash() uint32 {
-	return p.Fn.Hash()
+	return HashPtr(reflect.ValueOf(p.Fn).Pointer())
 }
 
 func (p ProcFn) Call(args []Object) Object {
 	return p(args)
-}
-
-func (p ProcFn) Equals(other interface{}) bool {
-	switch other := other.(type) {
-	case ProcFn:
-		return reflect.ValueOf(p).Pointer() == reflect.ValueOf(other).Pointer()
-	}
-	return false
-}
-
-func (p ProcFn) Hash() uint32 {
-	return HashPtr(reflect.ValueOf(p).Pointer())
 }
 
 func (i InfoHolder) GetInfo() *ObjectInfo {

--- a/core/object.go
+++ b/core/object.go
@@ -888,10 +888,6 @@ func (p Proc) Hash() uint32 {
 	return HashPtr(reflect.ValueOf(p.Fn).Pointer())
 }
 
-func (p ProcFn) Call(args []Object) Object {
-	return p(args)
-}
-
 func (i InfoHolder) GetInfo() *ObjectInfo {
 	return i.info
 }

--- a/core/object.go
+++ b/core/object.go
@@ -147,8 +147,12 @@ type (
 		isGloballyUsed bool
 		taggedType     *Type
 	}
-	Proc func([]Object) Object
-	Fn   struct {
+	ProcFn func([]Object) Object
+	Proc   struct {
+		Fn   ProcFn
+		Name string
+	}
+	Fn struct {
 		InfoHolder
 		MetaHolder
 		isMacro bool
@@ -287,6 +291,7 @@ type (
 		NodeSeq        *Type
 		ParseError     *Type
 		Proc           *Type
+		ProcFn         *Type
 		Ratio          *Type
 		RecurBindings  *Type
 		Regex          *Type
@@ -395,7 +400,8 @@ func init() {
 		Nil:           regType("Nil", (*Nil)(nil), "The 'nil' value"),
 		NodeSeq:       RegRefType("NodeSeq", (*NodeSeq)(nil), ""),
 		ParseError:    RegRefType("ParseError", (*ParseError)(nil), ""),
-		Proc:          RegRefType("Proc", (*Proc)(nil), "A callable function implemented via Go code"),
+		Proc:          RegRefType("Proc", (*Proc)(nil), "A self-identifying callable function implemented via Go code"),
+		ProcFn:        RegRefType("ProcFn", (*ProcFn)(nil), "A callable function implemented via Go code"),
 		Ratio:         RegRefType("Ratio", (*Ratio)(nil), "Wraps the Go 'math.big/Rat' type"),
 		RecurBindings: RegRefType("RecurBindings", (*RecurBindings)(nil), ""),
 		Regex:         RegRefType("Regex", (*Regex)(nil), "Wraps the Go 'regexp.Regexp' type"),
@@ -843,7 +849,7 @@ func (fn *Fn) Compare(a, b Object) int {
 }
 
 func (p Proc) Call(args []Object) Object {
-	return p(args)
+	return p.Fn(args)
 }
 
 func (p Proc) Compare(a, b Object) int {
@@ -851,13 +857,13 @@ func (p Proc) Compare(a, b Object) int {
 }
 
 func (p Proc) ToString(escape bool) string {
-	return "#object[Proc]"
+	return fmt.Sprintf("#object[Proc:%s]", p.Name)
 }
 
 func (p Proc) Equals(other interface{}) bool {
 	switch other := other.(type) {
 	case Proc:
-		return reflect.ValueOf(p).Pointer() == reflect.ValueOf(other).Pointer()
+		return p.Fn.Equals(other.Fn)
 	}
 	return false
 }
@@ -875,6 +881,42 @@ func (p Proc) GetType() *Type {
 }
 
 func (p Proc) Hash() uint32 {
+	return p.Fn.Hash()
+}
+
+func (p ProcFn) Call(args []Object) Object {
+	return p(args)
+}
+
+func (p ProcFn) Compare(a, b Object) int {
+	return compare(p, a, b)
+}
+
+func (p ProcFn) ToString(escape bool) string {
+	return "#object[ProcFn]"
+}
+
+func (p ProcFn) Equals(other interface{}) bool {
+	switch other := other.(type) {
+	case ProcFn:
+		return reflect.ValueOf(p).Pointer() == reflect.ValueOf(other).Pointer()
+	}
+	return false
+}
+
+func (p ProcFn) GetInfo() *ObjectInfo {
+	return nil
+}
+
+func (p ProcFn) WithInfo(*ObjectInfo) Object {
+	return p
+}
+
+func (p ProcFn) GetType() *Type {
+	return TYPE.ProcFn
+}
+
+func (p ProcFn) Hash() uint32 {
 	return HashPtr(reflect.ValueOf(p).Pointer())
 }
 

--- a/core/object.go
+++ b/core/object.go
@@ -892,32 +892,12 @@ func (p ProcFn) Call(args []Object) Object {
 	return p(args)
 }
 
-func (p ProcFn) Compare(a, b Object) int {
-	return compare(p, a, b)
-}
-
-func (p ProcFn) ToString(escape bool) string {
-	return "#object[ProcFn]"
-}
-
 func (p ProcFn) Equals(other interface{}) bool {
 	switch other := other.(type) {
 	case ProcFn:
 		return reflect.ValueOf(p).Pointer() == reflect.ValueOf(other).Pointer()
 	}
 	return false
-}
-
-func (p ProcFn) GetInfo() *ObjectInfo {
-	return nil
-}
-
-func (p ProcFn) WithInfo(*ObjectInfo) Object {
-	return p
-}
-
-func (p ProcFn) GetType() *Type {
-	return TYPE.ProcFn
 }
 
 func (p ProcFn) Hash() uint32 {

--- a/core/procs.go
+++ b/core/procs.go
@@ -153,7 +153,7 @@ func ExtractIOWriter(args []Object, index int) io.Writer {
 	return Ensureio_Writer(args, index)
 }
 
-var procMeta Proc = func(args []Object) Object {
+var procMeta = func(args []Object) Object {
 	switch obj := args[0].(type) {
 	case Meta:
 		meta := obj.GetMeta()
@@ -169,7 +169,7 @@ var procMeta Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procWithMeta Proc = func(args []Object) Object {
+var procWithMeta = func(args []Object) Object {
 	CheckArity(args, 2, 2)
 	m := EnsureMeta(args, 0)
 	if args[1].Equals(NIL) {
@@ -178,53 +178,53 @@ var procWithMeta Proc = func(args []Object) Object {
 	return m.WithMeta(EnsureMap(args, 1))
 }
 
-var procIsZero Proc = func(args []Object) Object {
+var procIsZero = func(args []Object) Object {
 	n := EnsureNumber(args, 0)
 	ops := GetOps(n)
 	return Boolean{B: ops.IsZero(n)}
 }
 
-var procIsPos Proc = func(args []Object) Object {
+var procIsPos = func(args []Object) Object {
 	n := EnsureNumber(args, 0)
 	ops := GetOps(n)
 	return Boolean{B: ops.Gt(n, Int{I: 0})}
 }
 
-var procIsNeg Proc = func(args []Object) Object {
+var procIsNeg = func(args []Object) Object {
 	n := EnsureNumber(args, 0)
 	ops := GetOps(n)
 	return Boolean{B: ops.Lt(n, Int{I: 0})}
 }
 
-var procAdd Proc = func(args []Object) Object {
+var procAdd = func(args []Object) Object {
 	x := AssertNumber(args[0], "")
 	y := AssertNumber(args[1], "")
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Add(x, y)
 }
 
-var procAddEx Proc = func(args []Object) Object {
+var procAddEx = func(args []Object) Object {
 	x := AssertNumber(args[0], "")
 	y := AssertNumber(args[1], "")
 	ops := GetOps(x).Combine(GetOps(y)).Combine(BIGINT_OPS)
 	return ops.Add(x, y)
 }
 
-var procMultiply Proc = func(args []Object) Object {
+var procMultiply = func(args []Object) Object {
 	x := AssertNumber(args[0], "")
 	y := AssertNumber(args[1], "")
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Multiply(x, y)
 }
 
-var procMultiplyEx Proc = func(args []Object) Object {
+var procMultiplyEx = func(args []Object) Object {
 	x := AssertNumber(args[0], "")
 	y := AssertNumber(args[1], "")
 	ops := GetOps(x).Combine(GetOps(y)).Combine(BIGINT_OPS)
 	return ops.Multiply(x, y)
 }
 
-var procSubtract Proc = func(args []Object) Object {
+var procSubtract = func(args []Object) Object {
 	var a, b Object
 	if len(args) == 1 {
 		a = Int{I: 0}
@@ -237,7 +237,7 @@ var procSubtract Proc = func(args []Object) Object {
 	return ops.Subtract(AssertNumber(a, ""), AssertNumber(b, ""))
 }
 
-var procSubtractEx Proc = func(args []Object) Object {
+var procSubtractEx = func(args []Object) Object {
 	var a, b Object
 	if len(args) == 1 {
 		a = Int{I: 0}
@@ -250,28 +250,28 @@ var procSubtractEx Proc = func(args []Object) Object {
 	return ops.Subtract(AssertNumber(a, ""), AssertNumber(b, ""))
 }
 
-var procDivide Proc = func(args []Object) Object {
+var procDivide = func(args []Object) Object {
 	x := EnsureNumber(args, 0)
 	y := EnsureNumber(args, 1)
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Divide(x, y)
 }
 
-var procQuot Proc = func(args []Object) Object {
+var procQuot = func(args []Object) Object {
 	x := EnsureNumber(args, 0)
 	y := EnsureNumber(args, 1)
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Quotient(x, y)
 }
 
-var procRem Proc = func(args []Object) Object {
+var procRem = func(args []Object) Object {
 	x := EnsureNumber(args, 0)
 	y := EnsureNumber(args, 1)
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Rem(x, y)
 }
 
-var procBitNot Proc = func(args []Object) Object {
+var procBitNot = func(args []Object) Object {
 	x := AssertInt(args[0], "Bit operation not supported for "+args[0].GetType().ToString(false))
 	return Int{I: ^x.I}
 }
@@ -282,62 +282,62 @@ func AssertInts(args []Object) (Int, Int) {
 	return x, y
 }
 
-var procBitAnd Proc = func(args []Object) Object {
+var procBitAnd = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I & y.I}
 }
 
-var procBitOr Proc = func(args []Object) Object {
+var procBitOr = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I | y.I}
 }
 
-var procBitXor Proc = func(args []Object) Object {
+var procBitXor = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I ^ y.I}
 }
 
-var procBitAndNot Proc = func(args []Object) Object {
+var procBitAndNot = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I &^ y.I}
 }
 
-var procBitClear Proc = func(args []Object) Object {
+var procBitClear = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I &^ (1 << uint(y.I))}
 }
 
-var procBitSet Proc = func(args []Object) Object {
+var procBitSet = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I | (1 << uint(y.I))}
 }
 
-var procBitFlip Proc = func(args []Object) Object {
+var procBitFlip = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I ^ (1 << uint(y.I))}
 }
 
-var procBitTest Proc = func(args []Object) Object {
+var procBitTest = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Boolean{B: x.I&(1<<uint(y.I)) != 0}
 }
 
-var procBitShiftLeft Proc = func(args []Object) Object {
+var procBitShiftLeft = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I << uint(y.I)}
 }
 
-var procBitShiftRight Proc = func(args []Object) Object {
+var procBitShiftRight = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: x.I >> uint(y.I)}
 }
 
-var procUnsignedBitShiftRight Proc = func(args []Object) Object {
+var procUnsignedBitShiftRight = func(args []Object) Object {
 	x, y := AssertInts(args)
 	return Int{I: int(uint(x.I) >> uint(y.I))}
 }
 
-var procExInfo Proc = func(args []Object) Object {
+var procExInfo = func(args []Object) Object {
 	CheckArity(args, 2, 3)
 	res := &ExInfo{
 		rt: RT.clone(),
@@ -350,25 +350,25 @@ var procExInfo Proc = func(args []Object) Object {
 	return res
 }
 
-var procExData Proc = func(args []Object) Object {
+var procExData = func(args []Object) Object {
 	if ok, res := args[0].(*ExInfo).Get(KEYWORDS.data); ok {
 		return res
 	}
 	return NIL
 }
 
-var procExCause Proc = func(args []Object) Object {
+var procExCause = func(args []Object) Object {
 	if ok, res := args[0].(*ExInfo).Get(KEYWORDS.cause); ok {
 		return res
 	}
 	return NIL
 }
 
-var procExMessage Proc = func(args []Object) Object {
+var procExMessage = func(args []Object) Object {
 	return args[0].(Error).Message()
 }
 
-var procRegex Proc = func(args []Object) Object {
+var procRegex = func(args []Object) Object {
 	r, err := regexp.Compile(EnsureString(args, 0).S)
 	if err != nil {
 		panic(RT.NewError("Invalid regex: " + err.Error()))
@@ -398,7 +398,7 @@ func reGroups(s string, indexes []int) Object {
 	}
 }
 
-var procReSeq Proc = func(args []Object) Object {
+var procReSeq = func(args []Object) Object {
 	re := EnsureRegex(args, 0)
 	s := EnsureString(args, 1)
 	matches := re.R.FindAllStringSubmatchIndex(s.S, -1)
@@ -412,23 +412,23 @@ var procReSeq Proc = func(args []Object) Object {
 	return &ArraySeq{arr: res}
 }
 
-var procReFind Proc = func(args []Object) Object {
+var procReFind = func(args []Object) Object {
 	re := EnsureRegex(args, 0)
 	s := EnsureString(args, 1)
 	match := re.R.FindStringSubmatchIndex(s.S)
 	return reGroups(s.S, match)
 }
 
-var procRand Proc = func(args []Object) Object {
+var procRand = func(args []Object) Object {
 	r := rand.Float64()
 	return Double{D: r}
 }
 
-var procIsSpecialSymbol Proc = func(args []Object) Object {
+var procIsSpecialSymbol = func(args []Object) Object {
 	return Boolean{B: IsSpecialSymbol(args[0])}
 }
 
-var procSubs Proc = func(args []Object) Object {
+var procSubs = func(args []Object) Object {
 	s := EnsureString(args, 0).S
 	start := EnsureInt(args, 1).I
 	slen := utf8.RuneCountInString(s)
@@ -555,23 +555,23 @@ var procFormat = func(args []Object) Object {
 	return String{S: res}
 }
 
-var procList Proc = func(args []Object) Object {
+var procList = func(args []Object) Object {
 	return NewListFrom(args...)
 }
 
-var procCons Proc = func(args []Object) Object {
+var procCons = func(args []Object) Object {
 	CheckArity(args, 2, 2)
 	s := EnsureSeqable(args, 1).Seq()
 	return s.Cons(args[0])
 }
 
-var procFirst Proc = func(args []Object) Object {
+var procFirst = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	s := EnsureSeqable(args, 0).Seq()
 	return s.First()
 }
 
-var procNext Proc = func(args []Object) Object {
+var procNext = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	s := EnsureSeqable(args, 0).Seq()
 	res := s.Rest()
@@ -581,13 +581,13 @@ var procNext Proc = func(args []Object) Object {
 	return res
 }
 
-var procRest Proc = func(args []Object) Object {
+var procRest = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	s := EnsureSeqable(args, 0).Seq()
 	return s.Rest()
 }
 
-var procConj Proc = func(args []Object) Object {
+var procConj = func(args []Object) Object {
 	switch c := args[0].(type) {
 	case Conjable:
 		return c.Conj(args[1])
@@ -598,7 +598,7 @@ var procConj Proc = func(args []Object) Object {
 	}
 }
 
-var procSeq Proc = func(args []Object) Object {
+var procSeq = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	s := EnsureSeqable(args, 0).Seq()
 	if s.IsEmpty() {
@@ -607,21 +607,21 @@ var procSeq Proc = func(args []Object) Object {
 	return s
 }
 
-var procIsInstance Proc = func(args []Object) Object {
+var procIsInstance = func(args []Object) Object {
 	CheckArity(args, 2, 2)
 	t := EnsureType(args, 0)
 	return Boolean{B: IsInstance(t, args[1])}
 }
 
-var procAssoc Proc = func(args []Object) Object {
+var procAssoc = func(args []Object) Object {
 	return EnsureAssociative(args, 0).Assoc(args[1], args[2])
 }
 
-var procEquals Proc = func(args []Object) Object {
+var procEquals = func(args []Object) Object {
 	return Boolean{B: args[0].Equals(args[1])}
 }
 
-var procCount Proc = func(args []Object) Object {
+var procCount = func(args []Object) Object {
 	switch obj := args[0].(type) {
 	case Counted:
 		return Int{I: obj.Count()}
@@ -631,7 +631,7 @@ var procCount Proc = func(args []Object) Object {
 	}
 }
 
-var procSubvec Proc = func(args []Object) Object {
+var procSubvec = func(args []Object) Object {
 	// TODO: implement proper Subvector structure
 	v := EnsureVector(args, 0)
 	start := EnsureInt(args, 1).I
@@ -646,7 +646,7 @@ var procSubvec Proc = func(args []Object) Object {
 	return NewVectorFrom(subv...)
 }
 
-var procCast Proc = func(args []Object) Object {
+var procCast = func(args []Object) Object {
 	t := EnsureType(args, 0)
 	if t.reflectType.Kind() == reflect.Interface &&
 		args[1].GetType().reflectType.Implements(t.reflectType) ||
@@ -656,18 +656,18 @@ var procCast Proc = func(args []Object) Object {
 	panic(RT.NewError("Cannot cast " + args[1].GetType().ToString(false) + " to " + t.ToString(false)))
 }
 
-var procVec Proc = func(args []Object) Object {
+var procVec = func(args []Object) Object {
 	return NewVectorFromSeq(EnsureSeqable(args, 0).Seq())
 }
 
-var procHashMap Proc = func(args []Object) Object {
+var procHashMap = func(args []Object) Object {
 	if len(args)%2 != 0 {
 		panic(RT.NewError("No value supplied for key " + args[len(args)-1].ToString(false)))
 	}
 	return NewHashMap(args...)
 }
 
-var procHashSet Proc = func(args []Object) Object {
+var procHashSet = func(args []Object) Object {
 	res := EmptySet()
 	for i := 0; i < len(args); i++ {
 		res.Add(args[i])
@@ -675,7 +675,7 @@ var procHashSet Proc = func(args []Object) Object {
 	return res
 }
 
-var procStr Proc = func(args []Object) Object {
+var procStr = func(args []Object) Object {
 	var buffer bytes.Buffer
 	for _, obj := range args {
 		if !obj.Equals(NIL) {
@@ -688,7 +688,7 @@ var procStr Proc = func(args []Object) Object {
 	return String{S: buffer.String()}
 }
 
-var procSymbol Proc = func(args []Object) Object {
+var procSymbol = func(args []Object) Object {
 	if len(args) == 1 {
 		return MakeSymbol(EnsureString(args, 0).S)
 	}
@@ -702,7 +702,7 @@ var procSymbol Proc = func(args []Object) Object {
 	}
 }
 
-var procKeyword Proc = func(args []Object) Object {
+var procKeyword = func(args []Object) Object {
 	if len(args) == 1 {
 		switch obj := args[0].(type) {
 		case String:
@@ -729,11 +729,11 @@ var procKeyword Proc = func(args []Object) Object {
 	}
 }
 
-var procGensym Proc = func(args []Object) Object {
+var procGensym = func(args []Object) Object {
 	return genSym(EnsureString(args, 0).S, "")
 }
 
-var procApply Proc = func(args []Object) Object {
+var procApply = func(args []Object) Object {
 	// TODO:
 	// Stacktrace is broken. Need to somehow know
 	// the name of the function passed ...
@@ -741,19 +741,19 @@ var procApply Proc = func(args []Object) Object {
 	return f.Call(ToSlice(EnsureSeqable(args, 1).Seq()))
 }
 
-var procLazySeq Proc = func(args []Object) Object {
+var procLazySeq = func(args []Object) Object {
 	return &LazySeq{
 		fn: args[0].(*Fn),
 	}
 }
 
-var procDelay Proc = func(args []Object) Object {
+var procDelay = func(args []Object) Object {
 	return &Delay{
 		fn: args[0].(*Fn),
 	}
 }
 
-var procForce Proc = func(args []Object) Object {
+var procForce = func(args []Object) Object {
 	switch d := args[0].(type) {
 	case *Delay:
 		return d.Force()
@@ -762,11 +762,11 @@ var procForce Proc = func(args []Object) Object {
 	}
 }
 
-var procIdentical Proc = func(args []Object) Object {
+var procIdentical = func(args []Object) Object {
 	return Boolean{B: args[0] == args[1]}
 }
 
-var procCompare Proc = func(args []Object) Object {
+var procCompare = func(args []Object) Object {
 	k1, k2 := args[0], args[1]
 	if k1.Equals(k2) {
 		return Int{I: 0}
@@ -784,7 +784,7 @@ var procCompare Proc = func(args []Object) Object {
 	panic(RT.NewError(fmt.Sprintf("%s (type: %s) is not a Comparable", k1.ToString(true), k1.GetType().ToString(false))))
 }
 
-var procInt Proc = func(args []Object) Object {
+var procInt = func(args []Object) Object {
 	switch obj := args[0].(type) {
 	case Char:
 		return Int{I: int(obj.Ch)}
@@ -795,16 +795,16 @@ var procInt Proc = func(args []Object) Object {
 	}
 }
 
-var procNumber Proc = func(args []Object) Object {
+var procNumber = func(args []Object) Object {
 	return AssertNumber(args[0], fmt.Sprintf("Cannot cast %s (type: %s) to Number", args[0].ToString(true), args[0].GetType().ToString(false)))
 }
 
-var procDouble Proc = func(args []Object) Object {
+var procDouble = func(args []Object) Object {
 	n := AssertNumber(args[0], fmt.Sprintf("Cannot cast %s (type: %s) to Double", args[0].ToString(true), args[0].GetType().ToString(false)))
 	return n.Double()
 }
 
-var procChar Proc = func(args []Object) Object {
+var procChar = func(args []Object) Object {
 	switch c := args[0].(type) {
 	case Char:
 		return c
@@ -819,21 +819,21 @@ var procChar Proc = func(args []Object) Object {
 	}
 }
 
-var procBoolean Proc = func(args []Object) Object {
+var procBoolean = func(args []Object) Object {
 	return Boolean{B: ToBool(args[0])}
 }
 
-var procNumerator Proc = func(args []Object) Object {
+var procNumerator = func(args []Object) Object {
 	bi := EnsureRatio(args, 0).r.Num()
 	return &BigInt{b: *bi}
 }
 
-var procDenominator Proc = func(args []Object) Object {
+var procDenominator = func(args []Object) Object {
 	bi := EnsureRatio(args, 0).r.Denom()
 	return &BigInt{b: *bi}
 }
 
-var procBigInt Proc = func(args []Object) Object {
+var procBigInt = func(args []Object) Object {
 	switch n := args[0].(type) {
 	case Number:
 		return &BigInt{b: *n.BigInt()}
@@ -848,7 +848,7 @@ var procBigInt Proc = func(args []Object) Object {
 	}
 }
 
-var procBigFloat Proc = func(args []Object) Object {
+var procBigFloat = func(args []Object) Object {
 	switch n := args[0].(type) {
 	case Number:
 		return &BigFloat{b: *n.BigFloat()}
@@ -863,7 +863,7 @@ var procBigFloat Proc = func(args []Object) Object {
 	}
 }
 
-var procNth Proc = func(args []Object) Object {
+var procNth = func(args []Object) Object {
 	n := EnsureNumber(args, 1).Int().I
 	switch coll := args[0].(type) {
 	case Indexed:
@@ -885,83 +885,83 @@ var procNth Proc = func(args []Object) Object {
 	panic(RT.NewError("nth not supported on this type: " + args[0].GetType().ToString(false)))
 }
 
-var procLt Proc = func(args []Object) Object {
+var procLt = func(args []Object) Object {
 	a := AssertNumber(args[0], "")
 	b := AssertNumber(args[1], "")
 	return Boolean{B: GetOps(a).Combine(GetOps(b)).Lt(a, b)}
 }
 
-var procLte Proc = func(args []Object) Object {
+var procLte = func(args []Object) Object {
 	a := AssertNumber(args[0], "")
 	b := AssertNumber(args[1], "")
 	return Boolean{B: GetOps(a).Combine(GetOps(b)).Lte(a, b)}
 }
 
-var procGt Proc = func(args []Object) Object {
+var procGt = func(args []Object) Object {
 	a := AssertNumber(args[0], "")
 	b := AssertNumber(args[1], "")
 	return Boolean{B: GetOps(a).Combine(GetOps(b)).Gt(a, b)}
 }
 
-var procGte Proc = func(args []Object) Object {
+var procGte = func(args []Object) Object {
 	a := AssertNumber(args[0], "")
 	b := AssertNumber(args[1], "")
 	return Boolean{B: GetOps(a).Combine(GetOps(b)).Gte(a, b)}
 }
 
-var procEq Proc = func(args []Object) Object {
+var procEq = func(args []Object) Object {
 	a := AssertNumber(args[0], "")
 	b := AssertNumber(args[1], "")
 	return MakeBoolean(numbersEq(a, b))
 }
 
-var procMax Proc = func(args []Object) Object {
+var procMax = func(args []Object) Object {
 	a := AssertNumber(args[0], "")
 	b := AssertNumber(args[1], "")
 	return Max(a, b)
 }
 
-var procMin Proc = func(args []Object) Object {
+var procMin = func(args []Object) Object {
 	a := AssertNumber(args[0], "")
 	b := AssertNumber(args[1], "")
 	return Min(a, b)
 }
 
-var procIncEx Proc = func(args []Object) Object {
+var procIncEx = func(args []Object) Object {
 	x := EnsureNumber(args, 0)
 	ops := GetOps(x).Combine(BIGINT_OPS)
 	return ops.Add(x, Int{I: 1})
 }
 
-var procDecEx Proc = func(args []Object) Object {
+var procDecEx = func(args []Object) Object {
 	x := EnsureNumber(args, 0)
 	ops := GetOps(x).Combine(BIGINT_OPS)
 	return ops.Subtract(x, Int{I: 1})
 }
 
-var procInc Proc = func(args []Object) Object {
+var procInc = func(args []Object) Object {
 	x := EnsureNumber(args, 0)
 	ops := GetOps(x).Combine(INT_OPS)
 	return ops.Add(x, Int{I: 1})
 }
 
-var procDec Proc = func(args []Object) Object {
+var procDec = func(args []Object) Object {
 	x := EnsureNumber(args, 0)
 	ops := GetOps(x).Combine(INT_OPS)
 	return ops.Subtract(x, Int{I: 1})
 }
 
-var procPeek Proc = func(args []Object) Object {
+var procPeek = func(args []Object) Object {
 	s := AssertStack(args[0], "")
 	return s.Peek()
 }
 
-var procPop Proc = func(args []Object) Object {
+var procPop = func(args []Object) Object {
 	s := AssertStack(args[0], "")
 	return s.Pop().(Object)
 }
 
-var procContains Proc = func(args []Object) Object {
+var procContains = func(args []Object) Object {
 	switch c := args[0].(type) {
 	case Gettable:
 		ok, _ := c.Get(args[1])
@@ -973,7 +973,7 @@ var procContains Proc = func(args []Object) Object {
 	panic(RT.NewError("contains? not supported on type " + args[0].GetType().ToString(false)))
 }
 
-var procGet Proc = func(args []Object) Object {
+var procGet = func(args []Object) Object {
 	switch c := args[0].(type) {
 	case Gettable:
 		ok, v := c.Get(args[1])
@@ -987,15 +987,15 @@ var procGet Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procDissoc Proc = func(args []Object) Object {
+var procDissoc = func(args []Object) Object {
 	return EnsureMap(args, 0).Without(args[1])
 }
 
-var procDisj Proc = func(args []Object) Object {
+var procDisj = func(args []Object) Object {
 	return EnsureSet(args, 0).Disjoin(args[1])
 }
 
-var procFind Proc = func(args []Object) Object {
+var procFind = func(args []Object) Object {
 	res := EnsureAssociative(args, 0).EntryAt(args[1])
 	if res == nil {
 		return NIL
@@ -1003,23 +1003,23 @@ var procFind Proc = func(args []Object) Object {
 	return res
 }
 
-var procKeys Proc = func(args []Object) Object {
+var procKeys = func(args []Object) Object {
 	return EnsureMap(args, 0).Keys()
 }
 
-var procVals Proc = func(args []Object) Object {
+var procVals = func(args []Object) Object {
 	return EnsureMap(args, 0).Vals()
 }
 
-var procRseq Proc = func(args []Object) Object {
+var procRseq = func(args []Object) Object {
 	return EnsureReversible(args, 0).Rseq()
 }
 
-var procName Proc = func(args []Object) Object {
+var procName = func(args []Object) Object {
 	return String{S: EnsureNamed(args, 0).Name()}
 }
 
-var procNamespace Proc = func(args []Object) Object {
+var procNamespace = func(args []Object) Object {
 	ns := EnsureNamed(args, 0).Namespace()
 	if ns == "" {
 		return NIL
@@ -1027,7 +1027,7 @@ var procNamespace Proc = func(args []Object) Object {
 	return String{S: ns}
 }
 
-var procFindVar Proc = func(args []Object) Object {
+var procFindVar = func(args []Object) Object {
 	sym := EnsureSymbol(args, 0)
 	if sym.ns == nil {
 		panic(RT.NewError("find-var argument must be namespace-qualified symbol"))
@@ -1038,7 +1038,7 @@ var procFindVar Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procSort Proc = func(args []Object) Object {
+var procSort = func(args []Object) Object {
 	cmp := EnsureComparator(args, 0)
 	coll := EnsureSeqable(args, 1)
 	s := SortableSlice{
@@ -1049,17 +1049,17 @@ var procSort Proc = func(args []Object) Object {
 	return &ArraySeq{arr: s.s}
 }
 
-var procEval Proc = func(args []Object) Object {
+var procEval = func(args []Object) Object {
 	parseContext := &ParseContext{GlobalEnv: GLOBAL_ENV}
 	expr := Parse(args[0], parseContext)
 	return Eval(expr, nil)
 }
 
-var procType Proc = func(args []Object) Object {
+var procType = func(args []Object) Object {
 	return args[0].GetType()
 }
 
-var procPprint Proc = func(args []Object) Object {
+var procPprint = func(args []Object) Object {
 	obj := args[0]
 	w := Assertio_Writer(GLOBAL_ENV.stdout.Value, "")
 	pprintObject(obj, 0, w)
@@ -1077,7 +1077,7 @@ func PrintObject(obj Object, w io.Writer) {
 	}
 }
 
-var procPr Proc = func(args []Object) Object {
+var procPr = func(args []Object) Object {
 	n := len(args)
 	if n > 0 {
 		f := Assertio_Writer(GLOBAL_ENV.stdout.Value, "")
@@ -1090,13 +1090,13 @@ var procPr Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procNewline Proc = func(args []Object) Object {
+var procNewline = func(args []Object) Object {
 	f := Assertio_Writer(GLOBAL_ENV.stdout.Value, "")
 	fmt.Fprintln(f)
 	return NIL
 }
 
-var procFlush Proc = func(args []Object) Object {
+var procFlush = func(args []Object) Object {
 	switch f := args[0].(type) {
 	case *File:
 		f.Sync()
@@ -1111,12 +1111,12 @@ func readFromReader(reader io.RuneReader) Object {
 	return obj
 }
 
-var procRead Proc = func(args []Object) Object {
+var procRead = func(args []Object) Object {
 	f := Ensureio_RuneReader(args, 0)
 	return readFromReader(f)
 }
 
-var procReadString Proc = func(args []Object) Object {
+var procReadString = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	return readFromReader(strings.NewReader(EnsureString(args, 0).S))
 }
@@ -1138,7 +1138,7 @@ func readLine(r StringReader) (s string, e error) {
 	return
 }
 
-var procReadLine Proc = func(args []Object) Object {
+var procReadLine = func(args []Object) Object {
 	CheckArity(args, 0, 0)
 	f := AssertStringReader(GLOBAL_ENV.stdin.Value, "")
 	line, err := readLine(f)
@@ -1148,7 +1148,7 @@ var procReadLine Proc = func(args []Object) Object {
 	return String{S: line}
 }
 
-var procReaderReadLine Proc = func(args []Object) Object {
+var procReaderReadLine = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	rdr := EnsureStringReader(args, 0)
 	line, err := readLine(rdr)
@@ -1158,11 +1158,11 @@ var procReaderReadLine Proc = func(args []Object) Object {
 	return String{S: line}
 }
 
-var procNanoTime Proc = func(args []Object) Object {
+var procNanoTime = func(args []Object) Object {
 	return &BigInt{b: *big.NewInt(time.Now().UnixNano())}
 }
 
-var procMacroexpand1 Proc = func(args []Object) Object {
+var procMacroexpand1 = func(args []Object) Object {
 	switch s := args[0].(type) {
 	case Seq:
 		parseContext := &ParseContext{GlobalEnv: GLOBAL_ENV}
@@ -1194,7 +1194,7 @@ func loadReader(reader *Reader) (Object, error) {
 	}
 }
 
-var procLoadString Proc = func(args []Object) Object {
+var procLoadString = func(args []Object) Object {
 	s := EnsureString(args, 0)
 	obj, err := loadReader(NewReader(strings.NewReader(s.S), "<string>"))
 	if err != nil {
@@ -1203,7 +1203,7 @@ var procLoadString Proc = func(args []Object) Object {
 	return obj
 }
 
-var procFindNamespace Proc = func(args []Object) Object {
+var procFindNamespace = func(args []Object) Object {
 	ns := GLOBAL_ENV.FindNamespace(EnsureSymbol(args, 0))
 	if ns == nil {
 		return NIL
@@ -1211,7 +1211,7 @@ var procFindNamespace Proc = func(args []Object) Object {
 	return ns
 }
 
-var procCreateNamespace Proc = func(args []Object) Object {
+var procCreateNamespace = func(args []Object) Object {
 	sym := EnsureSymbol(args, 0)
 	res := GLOBAL_ENV.EnsureNamespace(sym)
 	// In linter mode the latest create-ns call overrides position info.
@@ -1224,7 +1224,7 @@ var procCreateNamespace Proc = func(args []Object) Object {
 	return res
 }
 
-var procInjectNamespace Proc = func(args []Object) Object {
+var procInjectNamespace = func(args []Object) Object {
 	sym := EnsureSymbol(args, 0)
 	ns := GLOBAL_ENV.EnsureNamespace(sym)
 	ns.isUsed = true
@@ -1232,7 +1232,7 @@ var procInjectNamespace Proc = func(args []Object) Object {
 	return ns
 }
 
-var procRemoveNamespace Proc = func(args []Object) Object {
+var procRemoveNamespace = func(args []Object) Object {
 	ns := GLOBAL_ENV.RemoveNamespace(EnsureSymbol(args, 0))
 	if ns == nil {
 		return NIL
@@ -1240,7 +1240,7 @@ var procRemoveNamespace Proc = func(args []Object) Object {
 	return ns
 }
 
-var procAllNamespaces Proc = func(args []Object) Object {
+var procAllNamespaces = func(args []Object) Object {
 	s := make([]Object, 0, len(GLOBAL_ENV.Namespaces))
 	for _, ns := range GLOBAL_ENV.Namespaces {
 		s = append(s, ns)
@@ -1248,11 +1248,11 @@ var procAllNamespaces Proc = func(args []Object) Object {
 	return &ArraySeq{arr: s}
 }
 
-var procNamespaceName Proc = func(args []Object) Object {
+var procNamespaceName = func(args []Object) Object {
 	return EnsureNamespace(args, 0).Name
 }
 
-var procNamespaceMap Proc = func(args []Object) Object {
+var procNamespaceMap = func(args []Object) Object {
 	r := &ArrayMap{}
 	for k, v := range EnsureNamespace(args, 0).mappings {
 		r.Add(MakeSymbol(*k), v)
@@ -1260,7 +1260,7 @@ var procNamespaceMap Proc = func(args []Object) Object {
 	return r
 }
 
-var procNamespaceUnmap Proc = func(args []Object) Object {
+var procNamespaceUnmap = func(args []Object) Object {
 	ns := EnsureNamespace(args, 0)
 	sym := EnsureSymbol(args, 1)
 	if sym.ns != nil {
@@ -1270,24 +1270,24 @@ var procNamespaceUnmap Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procVarNamespace Proc = func(args []Object) Object {
+var procVarNamespace = func(args []Object) Object {
 	v := EnsureVar(args, 0)
 	return v.ns
 }
 
-var procRefer Proc = func(args []Object) Object {
+var procRefer = func(args []Object) Object {
 	ns := EnsureNamespace(args, 0)
 	sym := EnsureSymbol(args, 1)
 	v := EnsureVar(args, 2)
 	return ns.Refer(sym, v)
 }
 
-var procAlias Proc = func(args []Object) Object {
+var procAlias = func(args []Object) Object {
 	EnsureNamespace(args, 0).AddAlias(EnsureSymbol(args, 1), EnsureNamespace(args, 2))
 	return NIL
 }
 
-var procNamespaceAliases Proc = func(args []Object) Object {
+var procNamespaceAliases = func(args []Object) Object {
 	r := &ArrayMap{}
 	for k, v := range EnsureNamespace(args, 0).aliases {
 		r.Add(MakeSymbol(*k), v)
@@ -1295,7 +1295,7 @@ var procNamespaceAliases Proc = func(args []Object) Object {
 	return r
 }
 
-var procNamespaceUnalias Proc = func(args []Object) Object {
+var procNamespaceUnalias = func(args []Object) Object {
 	ns := EnsureNamespace(args, 0)
 	sym := EnsureSymbol(args, 1)
 	if sym.ns != nil {
@@ -1305,16 +1305,16 @@ var procNamespaceUnalias Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procVarGet Proc = func(args []Object) Object {
+var procVarGet = func(args []Object) Object {
 	return EnsureVar(args, 0).Resolve()
 }
 
-var procVarSet Proc = func(args []Object) Object {
+var procVarSet = func(args []Object) Object {
 	EnsureVar(args, 0).Value = args[1]
 	return args[1]
 }
 
-var procNsResolve Proc = func(args []Object) Object {
+var procNsResolve = func(args []Object) Object {
 	ns := EnsureNamespace(args, 0)
 	sym := EnsureSymbol(args, 1)
 	if sym.ns == nil && TYPES[sym.name] != nil {
@@ -1326,7 +1326,7 @@ var procNsResolve Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procArrayMap Proc = func(args []Object) Object {
+var procArrayMap = func(args []Object) Object {
 	if len(args)%2 == 1 {
 		panic(RT.NewError("No value supplied for key " + args[len(args)-1].ToString(false)))
 	}
@@ -1339,7 +1339,7 @@ var procArrayMap Proc = func(args []Object) Object {
 
 const bufferHashMask uint32 = 0x5ed19e84
 
-var procBuffer Proc = func(args []Object) Object {
+var procBuffer = func(args []Object) Object {
 	if len(args) > 0 {
 		s := EnsureString(args, 0)
 		return MakeBuffer(bytes.NewBufferString(s.S))
@@ -1347,7 +1347,7 @@ var procBuffer Proc = func(args []Object) Object {
 	return MakeBuffer(&bytes.Buffer{})
 }
 
-var procBufferedReader Proc = func(args []Object) Object {
+var procBufferedReader = func(args []Object) Object {
 	switch rdr := args[0].(type) {
 	case io.Reader:
 		return MakeBufferedReader(rdr)
@@ -1356,13 +1356,13 @@ var procBufferedReader Proc = func(args []Object) Object {
 	}
 }
 
-var procSlurp Proc = func(args []Object) Object {
+var procSlurp = func(args []Object) Object {
 	b, err := ioutil.ReadFile(EnsureString(args, 0).S)
 	PanicOnErr(err)
 	return String{S: string(b)}
 }
 
-var procSpit Proc = func(args []Object) Object {
+var procSpit = func(args []Object) Object {
 	filename := EnsureString(args, 0)
 	content := EnsureString(args, 1)
 	opts := EnsureMap(args, 2)
@@ -1384,7 +1384,7 @@ var procSpit Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procShuffle Proc = func(args []Object) Object {
+var procShuffle = func(args []Object) Object {
 	s := ToSlice(EnsureSeqable(args, 0).Seq())
 	for i := range s {
 		j := rand.Intn(i + 1)
@@ -1393,21 +1393,21 @@ var procShuffle Proc = func(args []Object) Object {
 	return NewVectorFrom(s...)
 }
 
-var procIsRealized Proc = func(args []Object) Object {
+var procIsRealized = func(args []Object) Object {
 	return Boolean{B: EnsurePending(args, 0).IsRealized()}
 }
 
-var procDeriveInfo Proc = func(args []Object) Object {
+var procDeriveInfo = func(args []Object) Object {
 	dest := args[0]
 	src := args[1]
 	return dest.WithInfo(src.GetInfo())
 }
 
-var procJokerVersion Proc = func(args []Object) Object {
+var procJokerVersion = func(args []Object) Object {
 	return String{S: VERSION[1:]}
 }
 
-var procHash Proc = func(args []Object) Object {
+var procHash = func(args []Object) Object {
 	return Int{I: int(args[0].Hash())}
 }
 
@@ -1420,12 +1420,12 @@ func loadFile(filename string) Object {
 	return NIL
 }
 
-var procLoadFile Proc = func(args []Object) Object {
+var procLoadFile = func(args []Object) Object {
 	filename := EnsureString(args, 0)
 	return loadFile(filename.S)
 }
 
-var procLoadLibFromPath Proc = func(args []Object) Object {
+var procLoadLibFromPath = func(args []Object) Object {
 	libname := EnsureSymbol(args, 0).Name()
 	pathname := EnsureString(args, 1).S
 	if d := internalLibs[libname]; d != nil {
@@ -1464,14 +1464,14 @@ var procLoadLibFromPath Proc = func(args []Object) Object {
 	return NIL
 }
 
-var procReduceKv Proc = func(args []Object) Object {
+var procReduceKv = func(args []Object) Object {
 	f := EnsureCallable(args, 0)
 	init := args[1]
 	coll := EnsureKVReduce(args, 2)
 	return coll.kvreduce(f, init)
 }
 
-var procIndexOf Proc = func(args []Object) Object {
+var procIndexOf = func(args []Object) Object {
 	s := EnsureString(args, 0)
 	ch := EnsureChar(args, 1)
 	for i, r := range s.S {
@@ -1507,7 +1507,7 @@ func libExternalPath(sym Symbol) (path string, ok bool) {
 	return
 }
 
-var procLibPath Proc = func(args []Object) Object {
+var procLibPath = func(args []Object) Object {
 	sym := EnsureSymbol(args, 0)
 	var path string
 
@@ -1534,7 +1534,7 @@ var procLibPath Proc = func(args []Object) Object {
 	return String{S: path}
 }
 
-var procInternFakeVar Proc = func(args []Object) Object {
+var procInternFakeVar = func(args []Object) Object {
 	nsSym := EnsureSymbol(args, 0)
 	sym := EnsureSymbol(args, 1)
 	isMacro := ToBool(args[2])
@@ -1543,7 +1543,7 @@ var procInternFakeVar Proc = func(args []Object) Object {
 	return res
 }
 
-var procParse Proc = func(args []Object) Object {
+var procParse = func(args []Object) Object {
 	lm, _ := GLOBAL_ENV.Resolve(MakeSymbol("joker.core/*linter-mode*"))
 	lm.Value = Boolean{B: true}
 	LINTER_MODE = true
@@ -1556,7 +1556,7 @@ var procParse Proc = func(args []Object) Object {
 	return res.Dump(false)
 }
 
-var procTypes Proc = func(args []Object) Object {
+var procTypes = func(args []Object) Object {
 	CheckArity(args, 0, 0)
 	res := EmptyArrayMap()
 	for k, v := range TYPES {
@@ -1565,20 +1565,20 @@ var procTypes Proc = func(args []Object) Object {
 	return res
 }
 
-var procCreateChan Proc = func(args []Object) Object {
+var procCreateChan = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	n := EnsureInt(args, 0)
 	ch := make(chan FutureResult, n.I)
 	return MakeChannel(ch)
 }
 
-var procCloseChan Proc = func(args []Object) Object {
+var procCloseChan = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	EnsureChannel(args, 0).Close()
 	return NIL
 }
 
-var procSend Proc = func(args []Object) (obj Object) {
+var procSend = func(args []Object) (obj Object) {
 	CheckArity(args, 2, 2)
 	ch := EnsureChannel(args, 0)
 	v := args[1]
@@ -1601,7 +1601,7 @@ var procSend Proc = func(args []Object) (obj Object) {
 	return
 }
 
-var procReceive Proc = func(args []Object) Object {
+var procReceive = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	ch := EnsureChannel(args, 0)
 	RT.GIL.Unlock()
@@ -1616,7 +1616,7 @@ var procReceive Proc = func(args []Object) Object {
 	return res.value
 }
 
-var procGo Proc = func(args []Object) Object {
+var procGo = func(args []Object) Object {
 	CheckArity(args, 1, 1)
 	f := EnsureCallable(args, 0)
 	ch := MakeChannel(make(chan FutureResult, 1))
@@ -1644,7 +1644,7 @@ var procGo Proc = func(args []Object) Object {
 	return ch
 }
 
-var procVerbosityLevel Proc = func(args []Object) Object {
+var procVerbosityLevel = func(args []Object) Object {
 	CheckArity(args, 0, 0)
 	return MakeInt(VerbosityLevel)
 }
@@ -1687,7 +1687,7 @@ func PackReader(reader *Reader, filename string) ([]byte, error) {
 	}
 }
 
-var procIncProblemCount Proc = func(args []Object) Object {
+var procIncProblemCount = func(args []Object) Object {
 	PROBLEM_COUNT++
 	return NIL
 }
@@ -1763,9 +1763,9 @@ func ProcessReaderFromEval(reader *Reader, filename string) {
 
 var privateMeta Map = EmptyArrayMap().Assoc(KEYWORDS.private, Boolean{B: true}).(Map)
 
-func intern(name string, proc Proc) {
+func intern(name string, proc ProcFn, procName string) {
 	vr := GLOBAL_ENV.CoreNamespace.Intern(MakeSymbol(name))
-	vr.Value = proc
+	vr.Value = Proc{Fn: proc, Name: procName}
 	vr.isPrivate = true
 	vr.meta = privateMeta
 }
@@ -2077,172 +2077,172 @@ func init() {
 	GLOBAL_ENV.CoreNamespace.InternVar("*assert*", Boolean{B: true},
 		MakeMeta(nil, "When set to logical false, assert is a noop. Defaults to true.", "1.0"))
 
-	intern("list__", procList)
-	intern("cons__", procCons)
-	intern("first__", procFirst)
-	intern("next__", procNext)
-	intern("rest__", procRest)
-	intern("conj__", procConj)
-	intern("seq__", procSeq)
-	intern("instance?__", procIsInstance)
-	intern("assoc__", procAssoc)
-	intern("meta__", procMeta)
-	intern("with-meta__", procWithMeta)
-	intern("=__", procEquals)
-	intern("count__", procCount)
-	intern("subvec__", procSubvec)
-	intern("cast__", procCast)
-	intern("vec__", procVec)
-	intern("hash-map__", procHashMap)
-	intern("hash-set__", procHashSet)
-	intern("str__", procStr)
-	intern("symbol__", procSymbol)
-	intern("gensym__", procGensym)
-	intern("keyword__", procKeyword)
-	intern("apply__", procApply)
-	intern("lazy-seq__", procLazySeq)
-	intern("delay__", procDelay)
-	intern("force__", procForce)
-	intern("identical__", procIdentical)
-	intern("compare__", procCompare)
-	intern("zero?__", procIsZero)
-	intern("int__", procInt)
-	intern("nth__", procNth)
-	intern("<__", procLt)
-	intern("<=__", procLte)
-	intern(">__", procGt)
-	intern(">=__", procGte)
-	intern("==__", procEq)
-	intern("inc'__", procIncEx)
-	intern("inc__", procInc)
-	intern("dec'__", procDecEx)
-	intern("dec__", procDec)
-	intern("add'__", procAddEx)
-	intern("add__", procAdd)
-	intern("multiply'__", procMultiplyEx)
-	intern("multiply__", procMultiply)
-	intern("divide__", procDivide)
-	intern("subtract'__", procSubtractEx)
-	intern("subtract__", procSubtract)
-	intern("max__", procMax)
-	intern("min__", procMin)
-	intern("pos__", procIsPos)
-	intern("neg__", procIsNeg)
-	intern("quot__", procQuot)
-	intern("rem__", procRem)
-	intern("bit-not__", procBitNot)
-	intern("bit-and__", procBitAnd)
-	intern("bit-or__", procBitOr)
-	intern("bit-xor_", procBitXor)
-	intern("bit-and-not__", procBitAndNot)
-	intern("bit-clear__", procBitClear)
-	intern("bit-set__", procBitSet)
-	intern("bit-flip__", procBitFlip)
-	intern("bit-test__", procBitTest)
-	intern("bit-shift-left__", procBitShiftLeft)
-	intern("bit-shift-right__", procBitShiftRight)
-	intern("unsigned-bit-shift-right__", procUnsignedBitShiftRight)
-	intern("peek__", procPeek)
-	intern("pop__", procPop)
-	intern("contains?__", procContains)
-	intern("get__", procGet)
-	intern("dissoc__", procDissoc)
-	intern("disj__", procDisj)
-	intern("find__", procFind)
-	intern("keys__", procKeys)
-	intern("vals__", procVals)
-	intern("rseq__", procRseq)
-	intern("name__", procName)
-	intern("namespace__", procNamespace)
-	intern("find-var__", procFindVar)
-	intern("sort__", procSort)
-	intern("eval__", procEval)
-	intern("type__", procType)
-	intern("num__", procNumber)
-	intern("double__", procDouble)
-	intern("char__", procChar)
-	intern("boolean__", procBoolean)
-	intern("numerator__", procNumerator)
-	intern("denominator__", procDenominator)
-	intern("bigint__", procBigInt)
-	intern("bigfloat__", procBigFloat)
-	intern("pr__", procPr)
-	intern("pprint__", procPprint)
-	intern("newline__", procNewline)
-	intern("flush__", procFlush)
-	intern("read__", procRead)
-	intern("read-line__", procReadLine)
-	intern("reader-read-line__", procReaderReadLine)
-	intern("read-string__", procReadString)
-	intern("nano-time__", procNanoTime)
-	intern("macroexpand-1__", procMacroexpand1)
-	intern("load-string__", procLoadString)
-	intern("find-ns__", procFindNamespace)
-	intern("create-ns__", procCreateNamespace)
-	intern("inject-ns__", procInjectNamespace)
-	intern("remove-ns__", procRemoveNamespace)
-	intern("all-ns__", procAllNamespaces)
-	intern("ns-name__", procNamespaceName)
-	intern("ns-map__", procNamespaceMap)
-	intern("ns-unmap__", procNamespaceUnmap)
-	intern("var-ns__", procVarNamespace)
-	intern("refer__", procRefer)
-	intern("alias__", procAlias)
-	intern("ns-aliases__", procNamespaceAliases)
-	intern("ns-unalias__", procNamespaceUnalias)
-	intern("var-get__", procVarGet)
-	intern("var-set__", procVarSet)
-	intern("ns-resolve__", procNsResolve)
-	intern("array-map__", procArrayMap)
-	intern("buffer__", procBuffer)
-	intern("buffered-reader__", procBufferedReader)
-	intern("ex-info__", procExInfo)
-	intern("ex-data__", procExData)
-	intern("ex-cause__", procExCause)
-	intern("ex-message__", procExMessage)
-	intern("regex__", procRegex)
-	intern("re-seq__", procReSeq)
-	intern("re-find__", procReFind)
-	intern("rand__", procRand)
-	intern("special-symbol?__", procIsSpecialSymbol)
-	intern("subs__", procSubs)
-	intern("intern__", procIntern)
-	intern("set-meta__", procSetMeta)
-	intern("atom__", procAtom)
-	intern("deref__", procDeref)
-	intern("swap__", procSwap)
-	intern("swap-vals__", procSwapVals)
-	intern("reset__", procReset)
-	intern("reset-vals__", procResetVals)
-	intern("alter-meta__", procAlterMeta)
-	intern("reset-meta__", procResetMeta)
-	intern("empty__", procEmpty)
-	intern("bound?__", procIsBound)
-	intern("format__", procFormat)
-	intern("load-file__", procLoadFile)
-	intern("load-lib-from-path__", procLoadLibFromPath)
-	intern("reduce-kv__", procReduceKv)
-	intern("slurp__", procSlurp)
-	intern("spit__", procSpit)
-	intern("shuffle__", procShuffle)
-	intern("realized?__", procIsRealized)
-	intern("derive-info__", procDeriveInfo)
-	intern("joker-version__", procJokerVersion)
+	intern("list__", procList, "procList")
+	intern("cons__", procCons, "procCons")
+	intern("first__", procFirst, "procFirst")
+	intern("next__", procNext, "procNext")
+	intern("rest__", procRest, "procRest")
+	intern("conj__", procConj, "procConj")
+	intern("seq__", procSeq, "procSeq")
+	intern("instance?__", procIsInstance, "procIsInstance")
+	intern("assoc__", procAssoc, "procAssoc")
+	intern("meta__", procMeta, "procMeta")
+	intern("with-meta__", procWithMeta, "procWithMeta")
+	intern("=__", procEquals, "procEquals")
+	intern("count__", procCount, "procCount")
+	intern("subvec__", procSubvec, "procSubvec")
+	intern("cast__", procCast, "procCast")
+	intern("vec__", procVec, "procVec")
+	intern("hash-map__", procHashMap, "procHashMap")
+	intern("hash-set__", procHashSet, "procHashSet")
+	intern("str__", procStr, "procStr")
+	intern("symbol__", procSymbol, "procSymbol")
+	intern("gensym__", procGensym, "procGensym")
+	intern("keyword__", procKeyword, "procKeyword")
+	intern("apply__", procApply, "procApply")
+	intern("lazy-seq__", procLazySeq, "procLazySeq")
+	intern("delay__", procDelay, "procDelay")
+	intern("force__", procForce, "procForce")
+	intern("identical__", procIdentical, "procIdentical")
+	intern("compare__", procCompare, "procCompare")
+	intern("zero?__", procIsZero, "procIsZero")
+	intern("int__", procInt, "procInt")
+	intern("nth__", procNth, "procNth")
+	intern("<__", procLt, "procLt")
+	intern("<=__", procLte, "procLte")
+	intern(">__", procGt, "procGt")
+	intern(">=__", procGte, "procGte")
+	intern("==__", procEq, "procEq")
+	intern("inc'__", procIncEx, "procIncEx")
+	intern("inc__", procInc, "procInc")
+	intern("dec'__", procDecEx, "procDecEx")
+	intern("dec__", procDec, "procDec")
+	intern("add'__", procAddEx, "procAddEx")
+	intern("add__", procAdd, "procAdd")
+	intern("multiply'__", procMultiplyEx, "procMultiplyEx")
+	intern("multiply__", procMultiply, "procMultiply")
+	intern("divide__", procDivide, "procDivide")
+	intern("subtract'__", procSubtractEx, "procSubtractEx")
+	intern("subtract__", procSubtract, "procSubtract")
+	intern("max__", procMax, "procMax")
+	intern("min__", procMin, "procMin")
+	intern("pos__", procIsPos, "procIsPos")
+	intern("neg__", procIsNeg, "procIsNeg")
+	intern("quot__", procQuot, "procQuot")
+	intern("rem__", procRem, "procRem")
+	intern("bit-not__", procBitNot, "procBitNot")
+	intern("bit-and__", procBitAnd, "procBitAnd")
+	intern("bit-or__", procBitOr, "procBitOr")
+	intern("bit-xor_", procBitXor, "procBitXor")
+	intern("bit-and-not__", procBitAndNot, "procBitAndNot")
+	intern("bit-clear__", procBitClear, "procBitClear")
+	intern("bit-set__", procBitSet, "procBitSet")
+	intern("bit-flip__", procBitFlip, "procBitFlip")
+	intern("bit-test__", procBitTest, "procBitTest")
+	intern("bit-shift-left__", procBitShiftLeft, "procBitShiftLeft")
+	intern("bit-shift-right__", procBitShiftRight, "procBitShiftRight")
+	intern("unsigned-bit-shift-right__", procUnsignedBitShiftRight, "procUnsignedBitShiftRight")
+	intern("peek__", procPeek, "procPeek")
+	intern("pop__", procPop, "procPop")
+	intern("contains?__", procContains, "procContains")
+	intern("get__", procGet, "procGet")
+	intern("dissoc__", procDissoc, "procDissoc")
+	intern("disj__", procDisj, "procDisj")
+	intern("find__", procFind, "procFind")
+	intern("keys__", procKeys, "procKeys")
+	intern("vals__", procVals, "procVals")
+	intern("rseq__", procRseq, "procRseq")
+	intern("name__", procName, "procName")
+	intern("namespace__", procNamespace, "procNamespace")
+	intern("find-var__", procFindVar, "procFindVar")
+	intern("sort__", procSort, "procSort")
+	intern("eval__", procEval, "procEval")
+	intern("type__", procType, "procType")
+	intern("num__", procNumber, "procNumber")
+	intern("double__", procDouble, "procDouble")
+	intern("char__", procChar, "procChar")
+	intern("boolean__", procBoolean, "procBoolean")
+	intern("numerator__", procNumerator, "procNumerator")
+	intern("denominator__", procDenominator, "procDenominator")
+	intern("bigint__", procBigInt, "procBigInt")
+	intern("bigfloat__", procBigFloat, "procBigFloat")
+	intern("pr__", procPr, "procPr")
+	intern("pprint__", procPprint, "procPprint")
+	intern("newline__", procNewline, "procNewline")
+	intern("flush__", procFlush, "procFlush")
+	intern("read__", procRead, "procRead")
+	intern("read-line__", procReadLine, "procReadLine")
+	intern("reader-read-line__", procReaderReadLine, "procReaderReadLine")
+	intern("read-string__", procReadString, "procReadString")
+	intern("nano-time__", procNanoTime, "procNanoTime")
+	intern("macroexpand-1__", procMacroexpand1, "procMacroexpand1")
+	intern("load-string__", procLoadString, "procLoadString")
+	intern("find-ns__", procFindNamespace, "procFindNamespace")
+	intern("create-ns__", procCreateNamespace, "procCreateNamespace")
+	intern("inject-ns__", procInjectNamespace, "procInjectNamespace")
+	intern("remove-ns__", procRemoveNamespace, "procRemoveNamespace")
+	intern("all-ns__", procAllNamespaces, "procAllNamespaces")
+	intern("ns-name__", procNamespaceName, "procNamespaceName")
+	intern("ns-map__", procNamespaceMap, "procNamespaceMap")
+	intern("ns-unmap__", procNamespaceUnmap, "procNamespaceUnmap")
+	intern("var-ns__", procVarNamespace, "procVarNamespace")
+	intern("refer__", procRefer, "procRefer")
+	intern("alias__", procAlias, "procAlias")
+	intern("ns-aliases__", procNamespaceAliases, "procNamespaceAliases")
+	intern("ns-unalias__", procNamespaceUnalias, "procNamespaceUnalias")
+	intern("var-get__", procVarGet, "procVarGet")
+	intern("var-set__", procVarSet, "procVarSet")
+	intern("ns-resolve__", procNsResolve, "procNsResolve")
+	intern("array-map__", procArrayMap, "procArrayMap")
+	intern("buffer__", procBuffer, "procBuffer")
+	intern("buffered-reader__", procBufferedReader, "procBufferedReader")
+	intern("ex-info__", procExInfo, "procExInfo")
+	intern("ex-data__", procExData, "procExData")
+	intern("ex-cause__", procExCause, "procExCause")
+	intern("ex-message__", procExMessage, "procExMessage")
+	intern("regex__", procRegex, "procRegex")
+	intern("re-seq__", procReSeq, "procReSeq")
+	intern("re-find__", procReFind, "procReFind")
+	intern("rand__", procRand, "procRand")
+	intern("special-symbol?__", procIsSpecialSymbol, "procIsSpecialSymbol")
+	intern("subs__", procSubs, "procSubs")
+	intern("intern__", procIntern, "procIntern")
+	intern("set-meta__", procSetMeta, "procSetMeta")
+	intern("atom__", procAtom, "procAtom")
+	intern("deref__", procDeref, "procDeref")
+	intern("swap__", procSwap, "procSwap")
+	intern("swap-vals__", procSwapVals, "procSwapVals")
+	intern("reset__", procReset, "procReset")
+	intern("reset-vals__", procResetVals, "procResetVals")
+	intern("alter-meta__", procAlterMeta, "procAlterMeta")
+	intern("reset-meta__", procResetMeta, "procResetMeta")
+	intern("empty__", procEmpty, "procEmpty")
+	intern("bound?__", procIsBound, "procIsBound")
+	intern("format__", procFormat, "procFormat")
+	intern("load-file__", procLoadFile, "procLoadFile")
+	intern("load-lib-from-path__", procLoadLibFromPath, "procLoadLibFromPath")
+	intern("reduce-kv__", procReduceKv, "procReduceKv")
+	intern("slurp__", procSlurp, "procSlurp")
+	intern("spit__", procSpit, "procSpit")
+	intern("shuffle__", procShuffle, "procShuffle")
+	intern("realized?__", procIsRealized, "procIsRealized")
+	intern("derive-info__", procDeriveInfo, "procDeriveInfo")
+	intern("joker-version__", procJokerVersion, "procJokerVersion")
 
-	intern("hash__", procHash)
+	intern("hash__", procHash, "procHash")
 
-	intern("index-of__", procIndexOf)
-	intern("lib-path__", procLibPath)
-	intern("intern-fake-var__", procInternFakeVar)
-	intern("parse__", procParse)
-	intern("inc-problem-count__", procIncProblemCount)
-	intern("types__", procTypes)
-	intern("go__", procGo)
-	intern("<!__", procReceive)
-	intern(">!__", procSend)
-	intern("chan__", procCreateChan)
-	intern("close!__", procCloseChan)
+	intern("index-of__", procIndexOf, "procIndexOf")
+	intern("lib-path__", procLibPath, "procLibPath")
+	intern("intern-fake-var__", procInternFakeVar, "procInternFakeVar")
+	intern("parse__", procParse, "procParse")
+	intern("inc-problem-count__", procIncProblemCount, "procIncProblemCount")
+	intern("types__", procTypes, "procTypes")
+	intern("go__", procGo, "procGo")
+	intern("<!__", procReceive, "procReceive")
+	intern(">!__", procSend, "procSend")
+	intern("chan__", procCreateChan, "procCreateChan")
+	intern("close!__", procCloseChan, "procCloseChan")
 
-	intern("go-spew__", procGoSpew)
-	intern("verbosity-level__", procVerbosityLevel)
+	intern("go-spew__", procGoSpew, "procGoSpew")
+	intern("verbosity-level__", procVerbosityLevel, "procVerbosityLevel")
 }

--- a/core/spew_disabled.go
+++ b/core/spew_disabled.go
@@ -2,6 +2,6 @@
 
 package core
 
-var procGoSpew Proc = func(args []Object) (res Object) {
+var procGoSpew = func(args []Object) (res Object) {
 	return MakeBoolean(false)
 }

--- a/core/spew_enabled.go
+++ b/core/spew_enabled.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jcburley/go-spew/spew"
 )
 
-var procGoSpew Proc = func(args []Object) (res Object) {
+var procGoSpew = func(args []Object) (res Object) {
 	res = MakeBoolean(false)
 	CheckArity(args, 1, 2)
 	defer func() {

--- a/std/base64/a_base64.go
+++ b/std/base64/a_base64.go
@@ -11,7 +11,7 @@ var base64Namespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.base64"))
 
 
 var __decode_string__P ProcFn = __decode_string_
-var decode_string_ Proc = Proc{Fn: __decode_string__P, Name: "decode_string_"}
+var decode_string_ Proc = Proc{Fn: __decode_string__P, Name: "decode_string_", Package: "std/base64"}
 
 func __decode_string_(_args []Object) Object {
 	_c := len(_args)
@@ -28,7 +28,7 @@ func __decode_string_(_args []Object) Object {
 }
 
 var __encode_string__P ProcFn = __encode_string_
-var encode_string_ Proc = Proc{Fn: __encode_string__P, Name: "encode_string_"}
+var encode_string_ Proc = Proc{Fn: __encode_string__P, Name: "encode_string_", Package: "std/base64"}
 
 func __encode_string_(_args []Object) Object {
 	_c := len(_args)

--- a/std/base64/a_base64.go
+++ b/std/base64/a_base64.go
@@ -47,7 +47,6 @@ func __encode_string_(_args []Object) Object {
 func Init() {
 
 
-
 	base64Namespace.ResetMeta(MakeMeta(nil, `Implements base64 encoding as specified by RFC 4648.`, "1.0"))
 
 	

--- a/std/base64/a_base64.go
+++ b/std/base64/a_base64.go
@@ -10,7 +10,8 @@ var base64Namespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.base64"))
 
 
 
-var decode_string_ Proc
+var __decode_string__P ProcFn = __decode_string_
+var decode_string_ Proc = Proc{Fn: __decode_string__P, Name: "decode_string_"}
 
 func __decode_string_(_args []Object) Object {
 	_c := len(_args)
@@ -26,7 +27,8 @@ func __decode_string_(_args []Object) Object {
 	return NIL
 }
 
-var encode_string_ Proc
+var __encode_string__P ProcFn = __encode_string_
+var encode_string_ Proc = Proc{Fn: __encode_string__P, Name: "encode_string_"}
 
 func __encode_string_(_args []Object) Object {
 	_c := len(_args)
@@ -44,8 +46,7 @@ func __encode_string_(_args []Object) Object {
 
 func Init() {
 
-	decode_string_ = __decode_string_
-	encode_string_ = __encode_string_
+
 
 	base64Namespace.ResetMeta(MakeMeta(nil, `Implements base64 encoding as specified by RFC 4648.`, "1.0"))
 

--- a/std/crypto/a_crypto.go
+++ b/std/crypto/a_crypto.go
@@ -180,7 +180,6 @@ func __sha512_256_(_args []Object) Object {
 func Init() {
 
 
-
 	cryptoNamespace.ResetMeta(MakeMeta(nil, `Implements common cryptographic and hash functions.`, "1.0"))
 
 	

--- a/std/crypto/a_crypto.go
+++ b/std/crypto/a_crypto.go
@@ -15,7 +15,7 @@ var cryptoNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.crypto"))
 
 
 var __hmac__P ProcFn = __hmac_
-var hmac_ Proc = Proc{Fn: __hmac__P, Name: "hmac_"}
+var hmac_ Proc = Proc{Fn: __hmac__P, Name: "hmac_", Package: "std/crypto"}
 
 func __hmac_(_args []Object) Object {
 	_c := len(_args)
@@ -34,7 +34,7 @@ func __hmac_(_args []Object) Object {
 }
 
 var __md5__P ProcFn = __md5_
-var md5_ Proc = Proc{Fn: __md5__P, Name: "md5_"}
+var md5_ Proc = Proc{Fn: __md5__P, Name: "md5_", Package: "std/crypto"}
 
 func __md5_(_args []Object) Object {
 	_c := len(_args)
@@ -52,7 +52,7 @@ func __md5_(_args []Object) Object {
 }
 
 var __sha1__P ProcFn = __sha1_
-var sha1_ Proc = Proc{Fn: __sha1__P, Name: "sha1_"}
+var sha1_ Proc = Proc{Fn: __sha1__P, Name: "sha1_", Package: "std/crypto"}
 
 func __sha1_(_args []Object) Object {
 	_c := len(_args)
@@ -70,7 +70,7 @@ func __sha1_(_args []Object) Object {
 }
 
 var __sha224__P ProcFn = __sha224_
-var sha224_ Proc = Proc{Fn: __sha224__P, Name: "sha224_"}
+var sha224_ Proc = Proc{Fn: __sha224__P, Name: "sha224_", Package: "std/crypto"}
 
 func __sha224_(_args []Object) Object {
 	_c := len(_args)
@@ -88,7 +88,7 @@ func __sha224_(_args []Object) Object {
 }
 
 var __sha256__P ProcFn = __sha256_
-var sha256_ Proc = Proc{Fn: __sha256__P, Name: "sha256_"}
+var sha256_ Proc = Proc{Fn: __sha256__P, Name: "sha256_", Package: "std/crypto"}
 
 func __sha256_(_args []Object) Object {
 	_c := len(_args)
@@ -106,7 +106,7 @@ func __sha256_(_args []Object) Object {
 }
 
 var __sha384__P ProcFn = __sha384_
-var sha384_ Proc = Proc{Fn: __sha384__P, Name: "sha384_"}
+var sha384_ Proc = Proc{Fn: __sha384__P, Name: "sha384_", Package: "std/crypto"}
 
 func __sha384_(_args []Object) Object {
 	_c := len(_args)
@@ -124,7 +124,7 @@ func __sha384_(_args []Object) Object {
 }
 
 var __sha512__P ProcFn = __sha512_
-var sha512_ Proc = Proc{Fn: __sha512__P, Name: "sha512_"}
+var sha512_ Proc = Proc{Fn: __sha512__P, Name: "sha512_", Package: "std/crypto"}
 
 func __sha512_(_args []Object) Object {
 	_c := len(_args)
@@ -142,7 +142,7 @@ func __sha512_(_args []Object) Object {
 }
 
 var __sha512_224__P ProcFn = __sha512_224_
-var sha512_224_ Proc = Proc{Fn: __sha512_224__P, Name: "sha512_224_"}
+var sha512_224_ Proc = Proc{Fn: __sha512_224__P, Name: "sha512_224_", Package: "std/crypto"}
 
 func __sha512_224_(_args []Object) Object {
 	_c := len(_args)
@@ -160,7 +160,7 @@ func __sha512_224_(_args []Object) Object {
 }
 
 var __sha512_256__P ProcFn = __sha512_256_
-var sha512_256_ Proc = Proc{Fn: __sha512_256__P, Name: "sha512_256_"}
+var sha512_256_ Proc = Proc{Fn: __sha512_256__P, Name: "sha512_256_", Package: "std/crypto"}
 
 func __sha512_256_(_args []Object) Object {
 	_c := len(_args)

--- a/std/crypto/a_crypto.go
+++ b/std/crypto/a_crypto.go
@@ -14,7 +14,8 @@ var cryptoNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.crypto"))
 
 
 
-var hmac_ Proc
+var __hmac__P ProcFn = __hmac_
+var hmac_ Proc = Proc{Fn: __hmac__P, Name: "hmac_"}
 
 func __hmac_(_args []Object) Object {
 	_c := len(_args)
@@ -32,7 +33,8 @@ func __hmac_(_args []Object) Object {
 	return NIL
 }
 
-var md5_ Proc
+var __md5__P ProcFn = __md5_
+var md5_ Proc = Proc{Fn: __md5__P, Name: "md5_"}
 
 func __md5_(_args []Object) Object {
 	_c := len(_args)
@@ -49,7 +51,8 @@ func __md5_(_args []Object) Object {
 	return NIL
 }
 
-var sha1_ Proc
+var __sha1__P ProcFn = __sha1_
+var sha1_ Proc = Proc{Fn: __sha1__P, Name: "sha1_"}
 
 func __sha1_(_args []Object) Object {
 	_c := len(_args)
@@ -66,7 +69,8 @@ func __sha1_(_args []Object) Object {
 	return NIL
 }
 
-var sha224_ Proc
+var __sha224__P ProcFn = __sha224_
+var sha224_ Proc = Proc{Fn: __sha224__P, Name: "sha224_"}
 
 func __sha224_(_args []Object) Object {
 	_c := len(_args)
@@ -83,7 +87,8 @@ func __sha224_(_args []Object) Object {
 	return NIL
 }
 
-var sha256_ Proc
+var __sha256__P ProcFn = __sha256_
+var sha256_ Proc = Proc{Fn: __sha256__P, Name: "sha256_"}
 
 func __sha256_(_args []Object) Object {
 	_c := len(_args)
@@ -100,7 +105,8 @@ func __sha256_(_args []Object) Object {
 	return NIL
 }
 
-var sha384_ Proc
+var __sha384__P ProcFn = __sha384_
+var sha384_ Proc = Proc{Fn: __sha384__P, Name: "sha384_"}
 
 func __sha384_(_args []Object) Object {
 	_c := len(_args)
@@ -117,7 +123,8 @@ func __sha384_(_args []Object) Object {
 	return NIL
 }
 
-var sha512_ Proc
+var __sha512__P ProcFn = __sha512_
+var sha512_ Proc = Proc{Fn: __sha512__P, Name: "sha512_"}
 
 func __sha512_(_args []Object) Object {
 	_c := len(_args)
@@ -134,7 +141,8 @@ func __sha512_(_args []Object) Object {
 	return NIL
 }
 
-var sha512_224_ Proc
+var __sha512_224__P ProcFn = __sha512_224_
+var sha512_224_ Proc = Proc{Fn: __sha512_224__P, Name: "sha512_224_"}
 
 func __sha512_224_(_args []Object) Object {
 	_c := len(_args)
@@ -151,7 +159,8 @@ func __sha512_224_(_args []Object) Object {
 	return NIL
 }
 
-var sha512_256_ Proc
+var __sha512_256__P ProcFn = __sha512_256_
+var sha512_256_ Proc = Proc{Fn: __sha512_256__P, Name: "sha512_256_"}
 
 func __sha512_256_(_args []Object) Object {
 	_c := len(_args)
@@ -170,15 +179,7 @@ func __sha512_256_(_args []Object) Object {
 
 func Init() {
 
-	hmac_ = __hmac_
-	md5_ = __md5_
-	sha1_ = __sha1_
-	sha224_ = __sha224_
-	sha256_ = __sha256_
-	sha384_ = __sha384_
-	sha512_ = __sha512_
-	sha512_224_ = __sha512_224_
-	sha512_256_ = __sha512_256_
+
 
 	cryptoNamespace.ResetMeta(MakeMeta(nil, `Implements common cryptographic and hash functions.`, "1.0"))
 

--- a/std/csv/a_csv.go
+++ b/std/csv/a_csv.go
@@ -84,7 +84,6 @@ func __write_string_(_args []Object) Object {
 func Init() {
 
 
-
 	csvNamespace.ResetMeta(MakeMeta(nil, `Reads and writes comma-separated values (CSV) files as defined in RFC 4180.`, "1.0"))
 
 	

--- a/std/csv/a_csv.go
+++ b/std/csv/a_csv.go
@@ -11,7 +11,7 @@ var csvNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.csv"))
 
 
 var __csv_seq__P ProcFn = __csv_seq_
-var csv_seq_ Proc = Proc{Fn: __csv_seq__P, Name: "csv_seq_"}
+var csv_seq_ Proc = Proc{Fn: __csv_seq__P, Name: "csv_seq_", Package: "std/csv"}
 
 func __csv_seq_(_args []Object) Object {
 	_c := len(_args)
@@ -34,7 +34,7 @@ func __csv_seq_(_args []Object) Object {
 }
 
 var __write__P ProcFn = __write_
-var write_ Proc = Proc{Fn: __write__P, Name: "write_"}
+var write_ Proc = Proc{Fn: __write__P, Name: "write_", Package: "std/csv"}
 
 func __write_(_args []Object) Object {
 	_c := len(_args)
@@ -59,7 +59,7 @@ func __write_(_args []Object) Object {
 }
 
 var __write_string__P ProcFn = __write_string_
-var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_"}
+var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_", Package: "std/csv"}
 
 func __write_string_(_args []Object) Object {
 	_c := len(_args)

--- a/std/csv/a_csv.go
+++ b/std/csv/a_csv.go
@@ -10,7 +10,8 @@ var csvNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.csv"))
 
 
 
-var csv_seq_ Proc
+var __csv_seq__P ProcFn = __csv_seq_
+var csv_seq_ Proc = Proc{Fn: __csv_seq__P, Name: "csv_seq_"}
 
 func __csv_seq_(_args []Object) Object {
 	_c := len(_args)
@@ -32,7 +33,8 @@ func __csv_seq_(_args []Object) Object {
 	return NIL
 }
 
-var write_ Proc
+var __write__P ProcFn = __write_
+var write_ Proc = Proc{Fn: __write__P, Name: "write_"}
 
 func __write_(_args []Object) Object {
 	_c := len(_args)
@@ -56,7 +58,8 @@ func __write_(_args []Object) Object {
 	return NIL
 }
 
-var write_string_ Proc
+var __write_string__P ProcFn = __write_string_
+var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_"}
 
 func __write_string_(_args []Object) Object {
 	_c := len(_args)
@@ -80,9 +83,7 @@ func __write_string_(_args []Object) Object {
 
 func Init() {
 
-	csv_seq_ = __csv_seq_
-	write_ = __write_
-	write_string_ = __write_string_
+
 
 	csvNamespace.ResetMeta(MakeMeta(nil, `Reads and writes comma-separated values (CSV) files as defined in RFC 4180.`, "1.0"))
 

--- a/std/csv/csv_native.go
+++ b/std/csv/csv_native.go
@@ -9,7 +9,7 @@ import (
 )
 
 func csvLazySeq(rdr *csv.Reader) *LazySeq {
-	var c Proc = func(args []Object) Object {
+	var c ProcFn = func(args []Object) Object {
 		t, err := rdr.Read()
 		if err == io.EOF {
 			return EmptyList

--- a/std/csv/csv_native.go
+++ b/std/csv/csv_native.go
@@ -9,7 +9,7 @@ import (
 )
 
 func csvLazySeq(rdr *csv.Reader) *LazySeq {
-	var c ProcFn = func(args []Object) Object {
+	var c = func(args []Object) Object {
 		t, err := rdr.Read()
 		if err == io.EOF {
 			return EmptyList
@@ -17,7 +17,7 @@ func csvLazySeq(rdr *csv.Reader) *LazySeq {
 		PanicOnErr(err)
 		return NewConsSeq(MakeStringVector(t), csvLazySeq(rdr))
 	}
-	return NewLazySeq(c)
+	return NewLazySeq(Proc{Fn: c})
 }
 
 func csvSeqOpts(src Object, opts Map) Object {

--- a/std/filepath/a_filepath.go
+++ b/std/filepath/a_filepath.go
@@ -314,7 +314,6 @@ func Init() {
 	list_separator_ = MakeString(string(filepath.ListSeparator))
 	separator_ = MakeString(string(filepath.Separator))
 
-
 	filepathNamespace.ResetMeta(MakeMeta(nil, `Implements utility routines for manipulating filename paths.`, "1.0"))
 
 	filepathNamespace.InternVar("list-separator", list_separator_,

--- a/std/filepath/a_filepath.go
+++ b/std/filepath/a_filepath.go
@@ -12,7 +12,8 @@ var filepathNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.filepath"))
 var list_separator_ String
 var separator_ String
 
-var abs_ Proc
+var __abs__P ProcFn = __abs_
+var abs_ Proc = Proc{Fn: __abs__P, Name: "abs_"}
 
 func __abs_(_args []Object) Object {
 	_c := len(_args)
@@ -29,7 +30,8 @@ func __abs_(_args []Object) Object {
 	return NIL
 }
 
-var isabs_ Proc
+var __isabs__P ProcFn = __isabs_
+var isabs_ Proc = Proc{Fn: __isabs__P, Name: "isabs_"}
 
 func __isabs_(_args []Object) Object {
 	_c := len(_args)
@@ -45,7 +47,8 @@ func __isabs_(_args []Object) Object {
 	return NIL
 }
 
-var base_ Proc
+var __base__P ProcFn = __base_
+var base_ Proc = Proc{Fn: __base__P, Name: "base_"}
 
 func __base_(_args []Object) Object {
 	_c := len(_args)
@@ -61,7 +64,8 @@ func __base_(_args []Object) Object {
 	return NIL
 }
 
-var clean_ Proc
+var __clean__P ProcFn = __clean_
+var clean_ Proc = Proc{Fn: __clean__P, Name: "clean_"}
 
 func __clean_(_args []Object) Object {
 	_c := len(_args)
@@ -77,7 +81,8 @@ func __clean_(_args []Object) Object {
 	return NIL
 }
 
-var dir_ Proc
+var __dir__P ProcFn = __dir_
+var dir_ Proc = Proc{Fn: __dir__P, Name: "dir_"}
 
 func __dir_(_args []Object) Object {
 	_c := len(_args)
@@ -93,7 +98,8 @@ func __dir_(_args []Object) Object {
 	return NIL
 }
 
-var eval_symlinks_ Proc
+var __eval_symlinks__P ProcFn = __eval_symlinks_
+var eval_symlinks_ Proc = Proc{Fn: __eval_symlinks__P, Name: "eval_symlinks_"}
 
 func __eval_symlinks_(_args []Object) Object {
 	_c := len(_args)
@@ -110,7 +116,8 @@ func __eval_symlinks_(_args []Object) Object {
 	return NIL
 }
 
-var ext_ Proc
+var __ext__P ProcFn = __ext_
+var ext_ Proc = Proc{Fn: __ext__P, Name: "ext_"}
 
 func __ext_(_args []Object) Object {
 	_c := len(_args)
@@ -126,7 +133,8 @@ func __ext_(_args []Object) Object {
 	return NIL
 }
 
-var file_seq_ Proc
+var __file_seq__P ProcFn = __file_seq_
+var file_seq_ Proc = Proc{Fn: __file_seq__P, Name: "file_seq_"}
 
 func __file_seq_(_args []Object) Object {
 	_c := len(_args)
@@ -142,7 +150,8 @@ func __file_seq_(_args []Object) Object {
 	return NIL
 }
 
-var from_slash_ Proc
+var __from_slash__P ProcFn = __from_slash_
+var from_slash_ Proc = Proc{Fn: __from_slash__P, Name: "from_slash_"}
 
 func __from_slash_(_args []Object) Object {
 	_c := len(_args)
@@ -158,7 +167,8 @@ func __from_slash_(_args []Object) Object {
 	return NIL
 }
 
-var glob_ Proc
+var __glob__P ProcFn = __glob_
+var glob_ Proc = Proc{Fn: __glob__P, Name: "glob_"}
 
 func __glob_(_args []Object) Object {
 	_c := len(_args)
@@ -175,7 +185,8 @@ func __glob_(_args []Object) Object {
 	return NIL
 }
 
-var join_ Proc
+var __join__P ProcFn = __join_
+var join_ Proc = Proc{Fn: __join__P, Name: "join_"}
 
 func __join_(_args []Object) Object {
 	_c := len(_args)
@@ -192,7 +203,8 @@ func __join_(_args []Object) Object {
 	return NIL
 }
 
-var ismatches_ Proc
+var __ismatches__P ProcFn = __ismatches_
+var ismatches_ Proc = Proc{Fn: __ismatches__P, Name: "ismatches_"}
 
 func __ismatches_(_args []Object) Object {
 	_c := len(_args)
@@ -210,7 +222,8 @@ func __ismatches_(_args []Object) Object {
 	return NIL
 }
 
-var rel_ Proc
+var __rel__P ProcFn = __rel_
+var rel_ Proc = Proc{Fn: __rel__P, Name: "rel_"}
 
 func __rel_(_args []Object) Object {
 	_c := len(_args)
@@ -228,7 +241,8 @@ func __rel_(_args []Object) Object {
 	return NIL
 }
 
-var split_ Proc
+var __split__P ProcFn = __split_
+var split_ Proc = Proc{Fn: __split__P, Name: "split_"}
 
 func __split_(_args []Object) Object {
 	_c := len(_args)
@@ -245,7 +259,8 @@ func __split_(_args []Object) Object {
 	return NIL
 }
 
-var split_list_ Proc
+var __split_list__P ProcFn = __split_list_
+var split_list_ Proc = Proc{Fn: __split_list__P, Name: "split_list_"}
 
 func __split_list_(_args []Object) Object {
 	_c := len(_args)
@@ -261,7 +276,8 @@ func __split_list_(_args []Object) Object {
 	return NIL
 }
 
-var to_slash_ Proc
+var __to_slash__P ProcFn = __to_slash_
+var to_slash_ Proc = Proc{Fn: __to_slash__P, Name: "to_slash_"}
 
 func __to_slash_(_args []Object) Object {
 	_c := len(_args)
@@ -277,7 +293,8 @@ func __to_slash_(_args []Object) Object {
 	return NIL
 }
 
-var volume_name_ Proc
+var __volume_name__P ProcFn = __volume_name_
+var volume_name_ Proc = Proc{Fn: __volume_name__P, Name: "volume_name_"}
 
 func __volume_name_(_args []Object) Object {
 	_c := len(_args)
@@ -296,23 +313,7 @@ func __volume_name_(_args []Object) Object {
 func Init() {
 	list_separator_ = MakeString(string(filepath.ListSeparator))
 	separator_ = MakeString(string(filepath.Separator))
-	abs_ = __abs_
-	isabs_ = __isabs_
-	base_ = __base_
-	clean_ = __clean_
-	dir_ = __dir_
-	eval_symlinks_ = __eval_symlinks_
-	ext_ = __ext_
-	file_seq_ = __file_seq_
-	from_slash_ = __from_slash_
-	glob_ = __glob_
-	join_ = __join_
-	ismatches_ = __ismatches_
-	rel_ = __rel_
-	split_ = __split_
-	split_list_ = __split_list_
-	to_slash_ = __to_slash_
-	volume_name_ = __volume_name_
+
 
 	filepathNamespace.ResetMeta(MakeMeta(nil, `Implements utility routines for manipulating filename paths.`, "1.0"))
 

--- a/std/filepath/a_filepath.go
+++ b/std/filepath/a_filepath.go
@@ -13,7 +13,7 @@ var list_separator_ String
 var separator_ String
 
 var __abs__P ProcFn = __abs_
-var abs_ Proc = Proc{Fn: __abs__P, Name: "abs_"}
+var abs_ Proc = Proc{Fn: __abs__P, Name: "abs_", Package: "std/filepath"}
 
 func __abs_(_args []Object) Object {
 	_c := len(_args)
@@ -31,7 +31,7 @@ func __abs_(_args []Object) Object {
 }
 
 var __isabs__P ProcFn = __isabs_
-var isabs_ Proc = Proc{Fn: __isabs__P, Name: "isabs_"}
+var isabs_ Proc = Proc{Fn: __isabs__P, Name: "isabs_", Package: "std/filepath"}
 
 func __isabs_(_args []Object) Object {
 	_c := len(_args)
@@ -48,7 +48,7 @@ func __isabs_(_args []Object) Object {
 }
 
 var __base__P ProcFn = __base_
-var base_ Proc = Proc{Fn: __base__P, Name: "base_"}
+var base_ Proc = Proc{Fn: __base__P, Name: "base_", Package: "std/filepath"}
 
 func __base_(_args []Object) Object {
 	_c := len(_args)
@@ -65,7 +65,7 @@ func __base_(_args []Object) Object {
 }
 
 var __clean__P ProcFn = __clean_
-var clean_ Proc = Proc{Fn: __clean__P, Name: "clean_"}
+var clean_ Proc = Proc{Fn: __clean__P, Name: "clean_", Package: "std/filepath"}
 
 func __clean_(_args []Object) Object {
 	_c := len(_args)
@@ -82,7 +82,7 @@ func __clean_(_args []Object) Object {
 }
 
 var __dir__P ProcFn = __dir_
-var dir_ Proc = Proc{Fn: __dir__P, Name: "dir_"}
+var dir_ Proc = Proc{Fn: __dir__P, Name: "dir_", Package: "std/filepath"}
 
 func __dir_(_args []Object) Object {
 	_c := len(_args)
@@ -99,7 +99,7 @@ func __dir_(_args []Object) Object {
 }
 
 var __eval_symlinks__P ProcFn = __eval_symlinks_
-var eval_symlinks_ Proc = Proc{Fn: __eval_symlinks__P, Name: "eval_symlinks_"}
+var eval_symlinks_ Proc = Proc{Fn: __eval_symlinks__P, Name: "eval_symlinks_", Package: "std/filepath"}
 
 func __eval_symlinks_(_args []Object) Object {
 	_c := len(_args)
@@ -117,7 +117,7 @@ func __eval_symlinks_(_args []Object) Object {
 }
 
 var __ext__P ProcFn = __ext_
-var ext_ Proc = Proc{Fn: __ext__P, Name: "ext_"}
+var ext_ Proc = Proc{Fn: __ext__P, Name: "ext_", Package: "std/filepath"}
 
 func __ext_(_args []Object) Object {
 	_c := len(_args)
@@ -134,7 +134,7 @@ func __ext_(_args []Object) Object {
 }
 
 var __file_seq__P ProcFn = __file_seq_
-var file_seq_ Proc = Proc{Fn: __file_seq__P, Name: "file_seq_"}
+var file_seq_ Proc = Proc{Fn: __file_seq__P, Name: "file_seq_", Package: "std/filepath"}
 
 func __file_seq_(_args []Object) Object {
 	_c := len(_args)
@@ -151,7 +151,7 @@ func __file_seq_(_args []Object) Object {
 }
 
 var __from_slash__P ProcFn = __from_slash_
-var from_slash_ Proc = Proc{Fn: __from_slash__P, Name: "from_slash_"}
+var from_slash_ Proc = Proc{Fn: __from_slash__P, Name: "from_slash_", Package: "std/filepath"}
 
 func __from_slash_(_args []Object) Object {
 	_c := len(_args)
@@ -168,7 +168,7 @@ func __from_slash_(_args []Object) Object {
 }
 
 var __glob__P ProcFn = __glob_
-var glob_ Proc = Proc{Fn: __glob__P, Name: "glob_"}
+var glob_ Proc = Proc{Fn: __glob__P, Name: "glob_", Package: "std/filepath"}
 
 func __glob_(_args []Object) Object {
 	_c := len(_args)
@@ -186,7 +186,7 @@ func __glob_(_args []Object) Object {
 }
 
 var __join__P ProcFn = __join_
-var join_ Proc = Proc{Fn: __join__P, Name: "join_"}
+var join_ Proc = Proc{Fn: __join__P, Name: "join_", Package: "std/filepath"}
 
 func __join_(_args []Object) Object {
 	_c := len(_args)
@@ -204,7 +204,7 @@ func __join_(_args []Object) Object {
 }
 
 var __ismatches__P ProcFn = __ismatches_
-var ismatches_ Proc = Proc{Fn: __ismatches__P, Name: "ismatches_"}
+var ismatches_ Proc = Proc{Fn: __ismatches__P, Name: "ismatches_", Package: "std/filepath"}
 
 func __ismatches_(_args []Object) Object {
 	_c := len(_args)
@@ -223,7 +223,7 @@ func __ismatches_(_args []Object) Object {
 }
 
 var __rel__P ProcFn = __rel_
-var rel_ Proc = Proc{Fn: __rel__P, Name: "rel_"}
+var rel_ Proc = Proc{Fn: __rel__P, Name: "rel_", Package: "std/filepath"}
 
 func __rel_(_args []Object) Object {
 	_c := len(_args)
@@ -242,7 +242,7 @@ func __rel_(_args []Object) Object {
 }
 
 var __split__P ProcFn = __split_
-var split_ Proc = Proc{Fn: __split__P, Name: "split_"}
+var split_ Proc = Proc{Fn: __split__P, Name: "split_", Package: "std/filepath"}
 
 func __split_(_args []Object) Object {
 	_c := len(_args)
@@ -260,7 +260,7 @@ func __split_(_args []Object) Object {
 }
 
 var __split_list__P ProcFn = __split_list_
-var split_list_ Proc = Proc{Fn: __split_list__P, Name: "split_list_"}
+var split_list_ Proc = Proc{Fn: __split_list__P, Name: "split_list_", Package: "std/filepath"}
 
 func __split_list_(_args []Object) Object {
 	_c := len(_args)
@@ -277,7 +277,7 @@ func __split_list_(_args []Object) Object {
 }
 
 var __to_slash__P ProcFn = __to_slash_
-var to_slash_ Proc = Proc{Fn: __to_slash__P, Name: "to_slash_"}
+var to_slash_ Proc = Proc{Fn: __to_slash__P, Name: "to_slash_", Package: "std/filepath"}
 
 func __to_slash_(_args []Object) Object {
 	_c := len(_args)
@@ -294,7 +294,7 @@ func __to_slash_(_args []Object) Object {
 }
 
 var __volume_name__P ProcFn = __volume_name_
-var volume_name_ Proc = Proc{Fn: __volume_name__P, Name: "volume_name_"}
+var volume_name_ Proc = Proc{Fn: __volume_name__P, Name: "volume_name_", Package: "std/filepath"}
 
 func __volume_name_(_args []Object) Object {
 	_c := len(_args)

--- a/std/fn.tmpl
+++ b/std/fn.tmpl
@@ -1,6 +1,7 @@
-var {fnName} Proc
+var __{goName}_P ProcFn = __{goName}
+var {goName} Proc = Proc{Fn: __{goName}_P, Name: "{goName}"}
 
-func __{fnName}(_args []Object) Object {
+func __{goName}(_args []Object) Object {
 	_c := len(_args)
 	switch {
 	{arities}

--- a/std/fn.tmpl
+++ b/std/fn.tmpl
@@ -1,5 +1,5 @@
 var __{goName}_P ProcFn = __{goName}
-var {goName} Proc = Proc{Fn: __{goName}_P, Name: "{goName}"}
+var {goName} Proc = Proc{Fn: __{goName}_P, Name: "{goName}", Package: "std/{pkg}"}
 
 func __{goName}(_args []Object) Object {
 	_c := len(_args)

--- a/std/generate-std.joke
+++ b/std/generate-std.joke
@@ -126,7 +126,8 @@
         go-fn-name (go-name (str k))
         arities (s/join "\n\t" (map #(generate-arity % (:go m) (:tag m)) arglists))
         fn-str (-> fn-template
-                   (rpl "{fnName}" go-fn-name)
+                   (rpl "{goName}" go-fn-name)
+                   (rpl "{fnName}" (str k))
                    (rpl "{arities}" arities))
         intern-str (-> intern-template
                        (rpl "{nsFullName}" ns-name)
@@ -252,8 +253,9 @@
         go-fns (sort-by first (ns-public-go-fns ns))
         fn-decls (for [[k v] go-fns]
               (generate-fn-decl ns-name ns-name-final k v))
-        fn-inits (for [[k _] go-fns]
-                    (generate-fn-init k))
+        fn-inits ""
+        ;; (for [[k _] go-fns]
+        ;;   (generate-fn-init k))
         non-fn-decls (for [[k v] go-non-fns]
                        (generate-non-fn-decl ns-name ns-name-final k v))
         non-fn-inits (for [[k v] go-non-fns]

--- a/std/generate-std.joke
+++ b/std/generate-std.joke
@@ -127,6 +127,7 @@
         arities (s/join "\n\t" (map #(generate-arity % (:go m) (:tag m)) arglists))
         fn-str (-> fn-template
                    (rpl "{goName}" go-fn-name)
+                   (rpl "{pkg}" ns-name)
                    (rpl "{fnName}" (str k))
                    (rpl "{arities}" arities))
         intern-str (-> intern-template

--- a/std/generate-std.joke
+++ b/std/generate-std.joke
@@ -145,11 +145,6 @@
                                  ")")))]
     [fn-str intern-str]))
 
-(defn generate-fn-init
-  [v]
-  (let [g (go-name (str v))]
-    (format "\t%s = __%s" g g)))
-
 (defn go-return-type
   "Returns the return type of the Make<t>() function. Would be unnecessary if Go code could declare a var as having 'the type returned by <func>'."
   [t]
@@ -254,9 +249,6 @@
         go-fns (sort-by first (ns-public-go-fns ns))
         fn-decls (for [[k v] go-fns]
               (generate-fn-decl ns-name ns-name-final k v))
-        fn-inits ""
-        ;; (for [[k _] go-fns]
-        ;;   (generate-fn-init k))
         non-fn-decls (for [[k v] go-non-fns]
                        (generate-non-fn-decl ns-name ns-name-final k v))
         non-fn-inits (for [[k v] go-non-fns]
@@ -271,7 +263,6 @@
                 (rpl "{non-fn-decls}" (s/join "\n" (map first non-fn-decls)))
                 (rpl "{non-fn-inits}" (s/join "\n" non-fn-inits))
                 (rpl "{fn-decls}" (s/join "\n" (map first fn-decls)))
-                (rpl "{fn-inits}" (s/join "\n" fn-inits))
                 (rpl "{nsDocstring}" (raw-quoted-string (:doc m)))
                 (rpl "{non-fn-interns}" (s/join "\n\t" (map second non-fn-decls)))
                 (rpl "{fn-interns}" (s/join "\n\t" (map second fn-decls))))

--- a/std/hex/a_hex.go
+++ b/std/hex/a_hex.go
@@ -11,7 +11,8 @@ var hexNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.hex"))
 
 
 
-var decode_string_ Proc
+var __decode_string__P ProcFn = __decode_string_
+var decode_string_ Proc = Proc{Fn: __decode_string__P, Name: "decode_string_"}
 
 func __decode_string_(_args []Object) Object {
 	_c := len(_args)
@@ -29,7 +30,8 @@ func __decode_string_(_args []Object) Object {
 	return NIL
 }
 
-var encode_string_ Proc
+var __encode_string__P ProcFn = __encode_string_
+var encode_string_ Proc = Proc{Fn: __encode_string__P, Name: "encode_string_"}
 
 func __encode_string_(_args []Object) Object {
 	_c := len(_args)
@@ -47,8 +49,7 @@ func __encode_string_(_args []Object) Object {
 
 func Init() {
 
-	decode_string_ = __decode_string_
-	encode_string_ = __encode_string_
+
 
 	hexNamespace.ResetMeta(MakeMeta(nil, `Implements hexadecimal encoding and decoding.`, "1.0"))
 

--- a/std/hex/a_hex.go
+++ b/std/hex/a_hex.go
@@ -50,7 +50,6 @@ func __encode_string_(_args []Object) Object {
 func Init() {
 
 
-
 	hexNamespace.ResetMeta(MakeMeta(nil, `Implements hexadecimal encoding and decoding.`, "1.0"))
 
 	

--- a/std/hex/a_hex.go
+++ b/std/hex/a_hex.go
@@ -12,7 +12,7 @@ var hexNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.hex"))
 
 
 var __decode_string__P ProcFn = __decode_string_
-var decode_string_ Proc = Proc{Fn: __decode_string__P, Name: "decode_string_"}
+var decode_string_ Proc = Proc{Fn: __decode_string__P, Name: "decode_string_", Package: "std/hex"}
 
 func __decode_string_(_args []Object) Object {
 	_c := len(_args)
@@ -31,7 +31,7 @@ func __decode_string_(_args []Object) Object {
 }
 
 var __encode_string__P ProcFn = __encode_string_
-var encode_string_ Proc = Proc{Fn: __encode_string__P, Name: "encode_string_"}
+var encode_string_ Proc = Proc{Fn: __encode_string__P, Name: "encode_string_", Package: "std/hex"}
 
 func __encode_string_(_args []Object) Object {
 	_c := len(_args)

--- a/std/html/a_html.go
+++ b/std/html/a_html.go
@@ -48,7 +48,6 @@ func __unescape_(_args []Object) Object {
 func Init() {
 
 
-
 	htmlNamespace.ResetMeta(MakeMeta(nil, `Provides functions for escaping and unescaping HTML text.`, "1.0"))
 
 	

--- a/std/html/a_html.go
+++ b/std/html/a_html.go
@@ -11,7 +11,8 @@ var htmlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.html"))
 
 
 
-var escape_ Proc
+var __escape__P ProcFn = __escape_
+var escape_ Proc = Proc{Fn: __escape__P, Name: "escape_"}
 
 func __escape_(_args []Object) Object {
 	_c := len(_args)
@@ -27,7 +28,8 @@ func __escape_(_args []Object) Object {
 	return NIL
 }
 
-var unescape_ Proc
+var __unescape__P ProcFn = __unescape_
+var unescape_ Proc = Proc{Fn: __unescape__P, Name: "unescape_"}
 
 func __unescape_(_args []Object) Object {
 	_c := len(_args)
@@ -45,8 +47,7 @@ func __unescape_(_args []Object) Object {
 
 func Init() {
 
-	escape_ = __escape_
-	unescape_ = __unescape_
+
 
 	htmlNamespace.ResetMeta(MakeMeta(nil, `Provides functions for escaping and unescaping HTML text.`, "1.0"))
 

--- a/std/html/a_html.go
+++ b/std/html/a_html.go
@@ -12,7 +12,7 @@ var htmlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.html"))
 
 
 var __escape__P ProcFn = __escape_
-var escape_ Proc = Proc{Fn: __escape__P, Name: "escape_"}
+var escape_ Proc = Proc{Fn: __escape__P, Name: "escape_", Package: "std/html"}
 
 func __escape_(_args []Object) Object {
 	_c := len(_args)
@@ -29,7 +29,7 @@ func __escape_(_args []Object) Object {
 }
 
 var __unescape__P ProcFn = __unescape_
-var unescape_ Proc = Proc{Fn: __unescape__P, Name: "unescape_"}
+var unescape_ Proc = Proc{Fn: __unescape__P, Name: "unescape_", Package: "std/html"}
 
 func __unescape_(_args []Object) Object {
 	_c := len(_args)

--- a/std/http/a_http.go
+++ b/std/http/a_http.go
@@ -11,7 +11,7 @@ var httpNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.http"))
 
 
 var __send__P ProcFn = __send_
-var send_ Proc = Proc{Fn: __send__P, Name: "send_"}
+var send_ Proc = Proc{Fn: __send__P, Name: "send_", Package: "std/http"}
 
 func __send_(_args []Object) Object {
 	_c := len(_args)
@@ -28,7 +28,7 @@ func __send_(_args []Object) Object {
 }
 
 var __start_file_server__P ProcFn = __start_file_server_
-var start_file_server_ Proc = Proc{Fn: __start_file_server__P, Name: "start_file_server_"}
+var start_file_server_ Proc = Proc{Fn: __start_file_server__P, Name: "start_file_server_", Package: "std/http"}
 
 func __start_file_server_(_args []Object) Object {
 	_c := len(_args)
@@ -46,7 +46,7 @@ func __start_file_server_(_args []Object) Object {
 }
 
 var __start_server__P ProcFn = __start_server_
-var start_server_ Proc = Proc{Fn: __start_server__P, Name: "start_server_"}
+var start_server_ Proc = Proc{Fn: __start_server__P, Name: "start_server_", Package: "std/http"}
 
 func __start_server_(_args []Object) Object {
 	_c := len(_args)

--- a/std/http/a_http.go
+++ b/std/http/a_http.go
@@ -66,7 +66,6 @@ func __start_server_(_args []Object) Object {
 func Init() {
 
 
-
 	httpNamespace.ResetMeta(MakeMeta(nil, `Provides HTTP client and server implementations.`, "1.0"))
 
 	

--- a/std/http/a_http.go
+++ b/std/http/a_http.go
@@ -10,7 +10,8 @@ var httpNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.http"))
 
 
 
-var send_ Proc
+var __send__P ProcFn = __send_
+var send_ Proc = Proc{Fn: __send__P, Name: "send_"}
 
 func __send_(_args []Object) Object {
 	_c := len(_args)
@@ -26,7 +27,8 @@ func __send_(_args []Object) Object {
 	return NIL
 }
 
-var start_file_server_ Proc
+var __start_file_server__P ProcFn = __start_file_server_
+var start_file_server_ Proc = Proc{Fn: __start_file_server__P, Name: "start_file_server_"}
 
 func __start_file_server_(_args []Object) Object {
 	_c := len(_args)
@@ -43,7 +45,8 @@ func __start_file_server_(_args []Object) Object {
 	return NIL
 }
 
-var start_server_ Proc
+var __start_server__P ProcFn = __start_server_
+var start_server_ Proc = Proc{Fn: __start_server__P, Name: "start_server_"}
 
 func __start_server_(_args []Object) Object {
 	_c := len(_args)
@@ -62,9 +65,7 @@ func __start_server_(_args []Object) Object {
 
 func Init() {
 
-	send_ = __send_
-	start_file_server_ = __start_file_server_
-	start_server_ = __start_server_
+
 
 	httpNamespace.ResetMeta(MakeMeta(nil, `Provides HTTP client and server implementations.`, "1.0"))
 

--- a/std/io/a_io.go
+++ b/std/io/a_io.go
@@ -11,7 +11,8 @@ var ioNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.io"))
 
 
 
-var copy_ Proc
+var __copy__P ProcFn = __copy_
+var copy_ Proc = Proc{Fn: __copy__P, Name: "copy_"}
 
 func __copy_(_args []Object) Object {
 	_c := len(_args)
@@ -32,7 +33,7 @@ func __copy_(_args []Object) Object {
 
 func Init() {
 
-	copy_ = __copy_
+
 
 	ioNamespace.ResetMeta(MakeMeta(nil, `Provides basic interfaces to I/O primitives.`, "1.0"))
 

--- a/std/io/a_io.go
+++ b/std/io/a_io.go
@@ -34,7 +34,6 @@ func __copy_(_args []Object) Object {
 func Init() {
 
 
-
 	ioNamespace.ResetMeta(MakeMeta(nil, `Provides basic interfaces to I/O primitives.`, "1.0"))
 
 	

--- a/std/io/a_io.go
+++ b/std/io/a_io.go
@@ -12,7 +12,7 @@ var ioNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.io"))
 
 
 var __copy__P ProcFn = __copy_
-var copy_ Proc = Proc{Fn: __copy__P, Name: "copy_"}
+var copy_ Proc = Proc{Fn: __copy__P, Name: "copy_", Package: "std/io"}
 
 func __copy_(_args []Object) Object {
 	_c := len(_args)

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -11,7 +11,7 @@ var jsonNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.json"))
 
 
 var __read_string__P ProcFn = __read_string_
-var read_string_ Proc = Proc{Fn: __read_string__P, Name: "read_string_"}
+var read_string_ Proc = Proc{Fn: __read_string__P, Name: "read_string_", Package: "std/json"}
 
 func __read_string_(_args []Object) Object {
 	_c := len(_args)
@@ -34,7 +34,7 @@ func __read_string_(_args []Object) Object {
 }
 
 var __write_string__P ProcFn = __write_string_
-var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_"}
+var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_", Package: "std/json"}
 
 func __write_string_(_args []Object) Object {
 	_c := len(_args)

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -53,7 +53,6 @@ func __write_string_(_args []Object) Object {
 func Init() {
 
 
-
 	jsonNamespace.ResetMeta(MakeMeta(nil, `Implements encoding and decoding of JSON as defined in RFC 4627.`, "1.0"))
 
 	

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -10,7 +10,8 @@ var jsonNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.json"))
 
 
 
-var read_string_ Proc
+var __read_string__P ProcFn = __read_string_
+var read_string_ Proc = Proc{Fn: __read_string__P, Name: "read_string_"}
 
 func __read_string_(_args []Object) Object {
 	_c := len(_args)
@@ -32,7 +33,8 @@ func __read_string_(_args []Object) Object {
 	return NIL
 }
 
-var write_string_ Proc
+var __write_string__P ProcFn = __write_string_
+var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_"}
 
 func __write_string_(_args []Object) Object {
 	_c := len(_args)
@@ -50,8 +52,7 @@ func __write_string_(_args []Object) Object {
 
 func Init() {
 
-	read_string_ = __read_string_
-	write_string_ = __write_string_
+
 
 	jsonNamespace.ResetMeta(MakeMeta(nil, `Implements encoding and decoding of JSON as defined in RFC 4627.`, "1.0"))
 

--- a/std/math/a_math.go
+++ b/std/math/a_math.go
@@ -23,7 +23,8 @@ var sqrt_of_e_ Double
 var sqrt_of_phi_ Double
 var sqrt_of_pi_ Double
 
-var abs_ Proc
+var __abs__P ProcFn = __abs_
+var abs_ Proc = Proc{Fn: __abs__P, Name: "abs_"}
 
 func __abs_(_args []Object) Object {
 	_c := len(_args)
@@ -39,7 +40,8 @@ func __abs_(_args []Object) Object {
 	return NIL
 }
 
-var ceil_ Proc
+var __ceil__P ProcFn = __ceil_
+var ceil_ Proc = Proc{Fn: __ceil__P, Name: "ceil_"}
 
 func __ceil_(_args []Object) Object {
 	_c := len(_args)
@@ -55,7 +57,8 @@ func __ceil_(_args []Object) Object {
 	return NIL
 }
 
-var copy_sign_ Proc
+var __copy_sign__P ProcFn = __copy_sign_
+var copy_sign_ Proc = Proc{Fn: __copy_sign__P, Name: "copy_sign_"}
 
 func __copy_sign_(_args []Object) Object {
 	_c := len(_args)
@@ -72,7 +75,8 @@ func __copy_sign_(_args []Object) Object {
 	return NIL
 }
 
-var cos_ Proc
+var __cos__P ProcFn = __cos_
+var cos_ Proc = Proc{Fn: __cos__P, Name: "cos_"}
 
 func __cos_(_args []Object) Object {
 	_c := len(_args)
@@ -88,7 +92,8 @@ func __cos_(_args []Object) Object {
 	return NIL
 }
 
-var cube_root_ Proc
+var __cube_root__P ProcFn = __cube_root_
+var cube_root_ Proc = Proc{Fn: __cube_root__P, Name: "cube_root_"}
 
 func __cube_root_(_args []Object) Object {
 	_c := len(_args)
@@ -104,7 +109,8 @@ func __cube_root_(_args []Object) Object {
 	return NIL
 }
 
-var dim_ Proc
+var __dim__P ProcFn = __dim_
+var dim_ Proc = Proc{Fn: __dim__P, Name: "dim_"}
 
 func __dim_(_args []Object) Object {
 	_c := len(_args)
@@ -121,7 +127,8 @@ func __dim_(_args []Object) Object {
 	return NIL
 }
 
-var exp_ Proc
+var __exp__P ProcFn = __exp_
+var exp_ Proc = Proc{Fn: __exp__P, Name: "exp_"}
 
 func __exp_(_args []Object) Object {
 	_c := len(_args)
@@ -137,7 +144,8 @@ func __exp_(_args []Object) Object {
 	return NIL
 }
 
-var exp_2_ Proc
+var __exp_2__P ProcFn = __exp_2_
+var exp_2_ Proc = Proc{Fn: __exp_2__P, Name: "exp_2_"}
 
 func __exp_2_(_args []Object) Object {
 	_c := len(_args)
@@ -153,7 +161,8 @@ func __exp_2_(_args []Object) Object {
 	return NIL
 }
 
-var exp_minus_1_ Proc
+var __exp_minus_1__P ProcFn = __exp_minus_1_
+var exp_minus_1_ Proc = Proc{Fn: __exp_minus_1__P, Name: "exp_minus_1_"}
 
 func __exp_minus_1_(_args []Object) Object {
 	_c := len(_args)
@@ -169,7 +178,8 @@ func __exp_minus_1_(_args []Object) Object {
 	return NIL
 }
 
-var floor_ Proc
+var __floor__P ProcFn = __floor_
+var floor_ Proc = Proc{Fn: __floor__P, Name: "floor_"}
 
 func __floor_(_args []Object) Object {
 	_c := len(_args)
@@ -185,7 +195,8 @@ func __floor_(_args []Object) Object {
 	return NIL
 }
 
-var hypot_ Proc
+var __hypot__P ProcFn = __hypot_
+var hypot_ Proc = Proc{Fn: __hypot__P, Name: "hypot_"}
 
 func __hypot_(_args []Object) Object {
 	_c := len(_args)
@@ -202,7 +213,8 @@ func __hypot_(_args []Object) Object {
 	return NIL
 }
 
-var inf_ Proc
+var __inf__P ProcFn = __inf_
+var inf_ Proc = Proc{Fn: __inf__P, Name: "inf_"}
 
 func __inf_(_args []Object) Object {
 	_c := len(_args)
@@ -218,7 +230,8 @@ func __inf_(_args []Object) Object {
 	return NIL
 }
 
-var isinf_ Proc
+var __isinf__P ProcFn = __isinf_
+var isinf_ Proc = Proc{Fn: __isinf__P, Name: "isinf_"}
 
 func __isinf_(_args []Object) Object {
 	_c := len(_args)
@@ -235,7 +248,8 @@ func __isinf_(_args []Object) Object {
 	return NIL
 }
 
-var log_ Proc
+var __log__P ProcFn = __log_
+var log_ Proc = Proc{Fn: __log__P, Name: "log_"}
 
 func __log_(_args []Object) Object {
 	_c := len(_args)
@@ -251,7 +265,8 @@ func __log_(_args []Object) Object {
 	return NIL
 }
 
-var log_10_ Proc
+var __log_10__P ProcFn = __log_10_
+var log_10_ Proc = Proc{Fn: __log_10__P, Name: "log_10_"}
 
 func __log_10_(_args []Object) Object {
 	_c := len(_args)
@@ -267,7 +282,8 @@ func __log_10_(_args []Object) Object {
 	return NIL
 }
 
-var log_2_ Proc
+var __log_2__P ProcFn = __log_2_
+var log_2_ Proc = Proc{Fn: __log_2__P, Name: "log_2_"}
 
 func __log_2_(_args []Object) Object {
 	_c := len(_args)
@@ -283,7 +299,8 @@ func __log_2_(_args []Object) Object {
 	return NIL
 }
 
-var log_binary_ Proc
+var __log_binary__P ProcFn = __log_binary_
+var log_binary_ Proc = Proc{Fn: __log_binary__P, Name: "log_binary_"}
 
 func __log_binary_(_args []Object) Object {
 	_c := len(_args)
@@ -299,7 +316,8 @@ func __log_binary_(_args []Object) Object {
 	return NIL
 }
 
-var log_plus_1_ Proc
+var __log_plus_1__P ProcFn = __log_plus_1_
+var log_plus_1_ Proc = Proc{Fn: __log_plus_1__P, Name: "log_plus_1_"}
 
 func __log_plus_1_(_args []Object) Object {
 	_c := len(_args)
@@ -315,7 +333,8 @@ func __log_plus_1_(_args []Object) Object {
 	return NIL
 }
 
-var modf_ Proc
+var __modf__P ProcFn = __modf_
+var modf_ Proc = Proc{Fn: __modf__P, Name: "modf_"}
 
 func __modf_(_args []Object) Object {
 	_c := len(_args)
@@ -331,7 +350,8 @@ func __modf_(_args []Object) Object {
 	return NIL
 }
 
-var nan_ Proc
+var __nan__P ProcFn = __nan_
+var nan_ Proc = Proc{Fn: __nan__P, Name: "nan_"}
 
 func __nan_(_args []Object) Object {
 	_c := len(_args)
@@ -346,7 +366,8 @@ func __nan_(_args []Object) Object {
 	return NIL
 }
 
-var isnan_ Proc
+var __isnan__P ProcFn = __isnan_
+var isnan_ Proc = Proc{Fn: __isnan__P, Name: "isnan_"}
 
 func __isnan_(_args []Object) Object {
 	_c := len(_args)
@@ -362,7 +383,8 @@ func __isnan_(_args []Object) Object {
 	return NIL
 }
 
-var next_after_ Proc
+var __next_after__P ProcFn = __next_after_
+var next_after_ Proc = Proc{Fn: __next_after__P, Name: "next_after_"}
 
 func __next_after_(_args []Object) Object {
 	_c := len(_args)
@@ -379,7 +401,8 @@ func __next_after_(_args []Object) Object {
 	return NIL
 }
 
-var pow_ Proc
+var __pow__P ProcFn = __pow_
+var pow_ Proc = Proc{Fn: __pow__P, Name: "pow_"}
 
 func __pow_(_args []Object) Object {
 	_c := len(_args)
@@ -396,7 +419,8 @@ func __pow_(_args []Object) Object {
 	return NIL
 }
 
-var pow_10_ Proc
+var __pow_10__P ProcFn = __pow_10_
+var pow_10_ Proc = Proc{Fn: __pow_10__P, Name: "pow_10_"}
 
 func __pow_10_(_args []Object) Object {
 	_c := len(_args)
@@ -412,7 +436,8 @@ func __pow_10_(_args []Object) Object {
 	return NIL
 }
 
-var round_ Proc
+var __round__P ProcFn = __round_
+var round_ Proc = Proc{Fn: __round__P, Name: "round_"}
 
 func __round_(_args []Object) Object {
 	_c := len(_args)
@@ -428,7 +453,8 @@ func __round_(_args []Object) Object {
 	return NIL
 }
 
-var round_to_even_ Proc
+var __round_to_even__P ProcFn = __round_to_even_
+var round_to_even_ Proc = Proc{Fn: __round_to_even__P, Name: "round_to_even_"}
 
 func __round_to_even_(_args []Object) Object {
 	_c := len(_args)
@@ -444,7 +470,8 @@ func __round_to_even_(_args []Object) Object {
 	return NIL
 }
 
-var sign_bit_ Proc
+var __sign_bit__P ProcFn = __sign_bit_
+var sign_bit_ Proc = Proc{Fn: __sign_bit__P, Name: "sign_bit_"}
 
 func __sign_bit_(_args []Object) Object {
 	_c := len(_args)
@@ -460,7 +487,8 @@ func __sign_bit_(_args []Object) Object {
 	return NIL
 }
 
-var sin_ Proc
+var __sin__P ProcFn = __sin_
+var sin_ Proc = Proc{Fn: __sin__P, Name: "sin_"}
 
 func __sin_(_args []Object) Object {
 	_c := len(_args)
@@ -476,7 +504,8 @@ func __sin_(_args []Object) Object {
 	return NIL
 }
 
-var sqrt_ Proc
+var __sqrt__P ProcFn = __sqrt_
+var sqrt_ Proc = Proc{Fn: __sqrt__P, Name: "sqrt_"}
 
 func __sqrt_(_args []Object) Object {
 	_c := len(_args)
@@ -492,7 +521,8 @@ func __sqrt_(_args []Object) Object {
 	return NIL
 }
 
-var trunc_ Proc
+var __trunc__P ProcFn = __trunc_
+var trunc_ Proc = Proc{Fn: __trunc__P, Name: "trunc_"}
 
 func __trunc_(_args []Object) Object {
 	_c := len(_args)
@@ -522,36 +552,7 @@ func Init() {
 	sqrt_of_e_ = MakeDouble(math.SqrtE)
 	sqrt_of_phi_ = MakeDouble(math.SqrtPhi)
 	sqrt_of_pi_ = MakeDouble(math.SqrtPi)
-	abs_ = __abs_
-	ceil_ = __ceil_
-	copy_sign_ = __copy_sign_
-	cos_ = __cos_
-	cube_root_ = __cube_root_
-	dim_ = __dim_
-	exp_ = __exp_
-	exp_2_ = __exp_2_
-	exp_minus_1_ = __exp_minus_1_
-	floor_ = __floor_
-	hypot_ = __hypot_
-	inf_ = __inf_
-	isinf_ = __isinf_
-	log_ = __log_
-	log_10_ = __log_10_
-	log_2_ = __log_2_
-	log_binary_ = __log_binary_
-	log_plus_1_ = __log_plus_1_
-	modf_ = __modf_
-	nan_ = __nan_
-	isnan_ = __isnan_
-	next_after_ = __next_after_
-	pow_ = __pow_
-	pow_10_ = __pow_10_
-	round_ = __round_
-	round_to_even_ = __round_to_even_
-	sign_bit_ = __sign_bit_
-	sin_ = __sin_
-	sqrt_ = __sqrt_
-	trunc_ = __trunc_
+
 
 	mathNamespace.ResetMeta(MakeMeta(nil, `Provides basic constants and mathematical functions.`, "1.0"))
 

--- a/std/math/a_math.go
+++ b/std/math/a_math.go
@@ -24,7 +24,7 @@ var sqrt_of_phi_ Double
 var sqrt_of_pi_ Double
 
 var __abs__P ProcFn = __abs_
-var abs_ Proc = Proc{Fn: __abs__P, Name: "abs_"}
+var abs_ Proc = Proc{Fn: __abs__P, Name: "abs_", Package: "std/math"}
 
 func __abs_(_args []Object) Object {
 	_c := len(_args)
@@ -41,7 +41,7 @@ func __abs_(_args []Object) Object {
 }
 
 var __ceil__P ProcFn = __ceil_
-var ceil_ Proc = Proc{Fn: __ceil__P, Name: "ceil_"}
+var ceil_ Proc = Proc{Fn: __ceil__P, Name: "ceil_", Package: "std/math"}
 
 func __ceil_(_args []Object) Object {
 	_c := len(_args)
@@ -58,7 +58,7 @@ func __ceil_(_args []Object) Object {
 }
 
 var __copy_sign__P ProcFn = __copy_sign_
-var copy_sign_ Proc = Proc{Fn: __copy_sign__P, Name: "copy_sign_"}
+var copy_sign_ Proc = Proc{Fn: __copy_sign__P, Name: "copy_sign_", Package: "std/math"}
 
 func __copy_sign_(_args []Object) Object {
 	_c := len(_args)
@@ -76,7 +76,7 @@ func __copy_sign_(_args []Object) Object {
 }
 
 var __cos__P ProcFn = __cos_
-var cos_ Proc = Proc{Fn: __cos__P, Name: "cos_"}
+var cos_ Proc = Proc{Fn: __cos__P, Name: "cos_", Package: "std/math"}
 
 func __cos_(_args []Object) Object {
 	_c := len(_args)
@@ -93,7 +93,7 @@ func __cos_(_args []Object) Object {
 }
 
 var __cube_root__P ProcFn = __cube_root_
-var cube_root_ Proc = Proc{Fn: __cube_root__P, Name: "cube_root_"}
+var cube_root_ Proc = Proc{Fn: __cube_root__P, Name: "cube_root_", Package: "std/math"}
 
 func __cube_root_(_args []Object) Object {
 	_c := len(_args)
@@ -110,7 +110,7 @@ func __cube_root_(_args []Object) Object {
 }
 
 var __dim__P ProcFn = __dim_
-var dim_ Proc = Proc{Fn: __dim__P, Name: "dim_"}
+var dim_ Proc = Proc{Fn: __dim__P, Name: "dim_", Package: "std/math"}
 
 func __dim_(_args []Object) Object {
 	_c := len(_args)
@@ -128,7 +128,7 @@ func __dim_(_args []Object) Object {
 }
 
 var __exp__P ProcFn = __exp_
-var exp_ Proc = Proc{Fn: __exp__P, Name: "exp_"}
+var exp_ Proc = Proc{Fn: __exp__P, Name: "exp_", Package: "std/math"}
 
 func __exp_(_args []Object) Object {
 	_c := len(_args)
@@ -145,7 +145,7 @@ func __exp_(_args []Object) Object {
 }
 
 var __exp_2__P ProcFn = __exp_2_
-var exp_2_ Proc = Proc{Fn: __exp_2__P, Name: "exp_2_"}
+var exp_2_ Proc = Proc{Fn: __exp_2__P, Name: "exp_2_", Package: "std/math"}
 
 func __exp_2_(_args []Object) Object {
 	_c := len(_args)
@@ -162,7 +162,7 @@ func __exp_2_(_args []Object) Object {
 }
 
 var __exp_minus_1__P ProcFn = __exp_minus_1_
-var exp_minus_1_ Proc = Proc{Fn: __exp_minus_1__P, Name: "exp_minus_1_"}
+var exp_minus_1_ Proc = Proc{Fn: __exp_minus_1__P, Name: "exp_minus_1_", Package: "std/math"}
 
 func __exp_minus_1_(_args []Object) Object {
 	_c := len(_args)
@@ -179,7 +179,7 @@ func __exp_minus_1_(_args []Object) Object {
 }
 
 var __floor__P ProcFn = __floor_
-var floor_ Proc = Proc{Fn: __floor__P, Name: "floor_"}
+var floor_ Proc = Proc{Fn: __floor__P, Name: "floor_", Package: "std/math"}
 
 func __floor_(_args []Object) Object {
 	_c := len(_args)
@@ -196,7 +196,7 @@ func __floor_(_args []Object) Object {
 }
 
 var __hypot__P ProcFn = __hypot_
-var hypot_ Proc = Proc{Fn: __hypot__P, Name: "hypot_"}
+var hypot_ Proc = Proc{Fn: __hypot__P, Name: "hypot_", Package: "std/math"}
 
 func __hypot_(_args []Object) Object {
 	_c := len(_args)
@@ -214,7 +214,7 @@ func __hypot_(_args []Object) Object {
 }
 
 var __inf__P ProcFn = __inf_
-var inf_ Proc = Proc{Fn: __inf__P, Name: "inf_"}
+var inf_ Proc = Proc{Fn: __inf__P, Name: "inf_", Package: "std/math"}
 
 func __inf_(_args []Object) Object {
 	_c := len(_args)
@@ -231,7 +231,7 @@ func __inf_(_args []Object) Object {
 }
 
 var __isinf__P ProcFn = __isinf_
-var isinf_ Proc = Proc{Fn: __isinf__P, Name: "isinf_"}
+var isinf_ Proc = Proc{Fn: __isinf__P, Name: "isinf_", Package: "std/math"}
 
 func __isinf_(_args []Object) Object {
 	_c := len(_args)
@@ -249,7 +249,7 @@ func __isinf_(_args []Object) Object {
 }
 
 var __log__P ProcFn = __log_
-var log_ Proc = Proc{Fn: __log__P, Name: "log_"}
+var log_ Proc = Proc{Fn: __log__P, Name: "log_", Package: "std/math"}
 
 func __log_(_args []Object) Object {
 	_c := len(_args)
@@ -266,7 +266,7 @@ func __log_(_args []Object) Object {
 }
 
 var __log_10__P ProcFn = __log_10_
-var log_10_ Proc = Proc{Fn: __log_10__P, Name: "log_10_"}
+var log_10_ Proc = Proc{Fn: __log_10__P, Name: "log_10_", Package: "std/math"}
 
 func __log_10_(_args []Object) Object {
 	_c := len(_args)
@@ -283,7 +283,7 @@ func __log_10_(_args []Object) Object {
 }
 
 var __log_2__P ProcFn = __log_2_
-var log_2_ Proc = Proc{Fn: __log_2__P, Name: "log_2_"}
+var log_2_ Proc = Proc{Fn: __log_2__P, Name: "log_2_", Package: "std/math"}
 
 func __log_2_(_args []Object) Object {
 	_c := len(_args)
@@ -300,7 +300,7 @@ func __log_2_(_args []Object) Object {
 }
 
 var __log_binary__P ProcFn = __log_binary_
-var log_binary_ Proc = Proc{Fn: __log_binary__P, Name: "log_binary_"}
+var log_binary_ Proc = Proc{Fn: __log_binary__P, Name: "log_binary_", Package: "std/math"}
 
 func __log_binary_(_args []Object) Object {
 	_c := len(_args)
@@ -317,7 +317,7 @@ func __log_binary_(_args []Object) Object {
 }
 
 var __log_plus_1__P ProcFn = __log_plus_1_
-var log_plus_1_ Proc = Proc{Fn: __log_plus_1__P, Name: "log_plus_1_"}
+var log_plus_1_ Proc = Proc{Fn: __log_plus_1__P, Name: "log_plus_1_", Package: "std/math"}
 
 func __log_plus_1_(_args []Object) Object {
 	_c := len(_args)
@@ -334,7 +334,7 @@ func __log_plus_1_(_args []Object) Object {
 }
 
 var __modf__P ProcFn = __modf_
-var modf_ Proc = Proc{Fn: __modf__P, Name: "modf_"}
+var modf_ Proc = Proc{Fn: __modf__P, Name: "modf_", Package: "std/math"}
 
 func __modf_(_args []Object) Object {
 	_c := len(_args)
@@ -351,7 +351,7 @@ func __modf_(_args []Object) Object {
 }
 
 var __nan__P ProcFn = __nan_
-var nan_ Proc = Proc{Fn: __nan__P, Name: "nan_"}
+var nan_ Proc = Proc{Fn: __nan__P, Name: "nan_", Package: "std/math"}
 
 func __nan_(_args []Object) Object {
 	_c := len(_args)
@@ -367,7 +367,7 @@ func __nan_(_args []Object) Object {
 }
 
 var __isnan__P ProcFn = __isnan_
-var isnan_ Proc = Proc{Fn: __isnan__P, Name: "isnan_"}
+var isnan_ Proc = Proc{Fn: __isnan__P, Name: "isnan_", Package: "std/math"}
 
 func __isnan_(_args []Object) Object {
 	_c := len(_args)
@@ -384,7 +384,7 @@ func __isnan_(_args []Object) Object {
 }
 
 var __next_after__P ProcFn = __next_after_
-var next_after_ Proc = Proc{Fn: __next_after__P, Name: "next_after_"}
+var next_after_ Proc = Proc{Fn: __next_after__P, Name: "next_after_", Package: "std/math"}
 
 func __next_after_(_args []Object) Object {
 	_c := len(_args)
@@ -402,7 +402,7 @@ func __next_after_(_args []Object) Object {
 }
 
 var __pow__P ProcFn = __pow_
-var pow_ Proc = Proc{Fn: __pow__P, Name: "pow_"}
+var pow_ Proc = Proc{Fn: __pow__P, Name: "pow_", Package: "std/math"}
 
 func __pow_(_args []Object) Object {
 	_c := len(_args)
@@ -420,7 +420,7 @@ func __pow_(_args []Object) Object {
 }
 
 var __pow_10__P ProcFn = __pow_10_
-var pow_10_ Proc = Proc{Fn: __pow_10__P, Name: "pow_10_"}
+var pow_10_ Proc = Proc{Fn: __pow_10__P, Name: "pow_10_", Package: "std/math"}
 
 func __pow_10_(_args []Object) Object {
 	_c := len(_args)
@@ -437,7 +437,7 @@ func __pow_10_(_args []Object) Object {
 }
 
 var __round__P ProcFn = __round_
-var round_ Proc = Proc{Fn: __round__P, Name: "round_"}
+var round_ Proc = Proc{Fn: __round__P, Name: "round_", Package: "std/math"}
 
 func __round_(_args []Object) Object {
 	_c := len(_args)
@@ -454,7 +454,7 @@ func __round_(_args []Object) Object {
 }
 
 var __round_to_even__P ProcFn = __round_to_even_
-var round_to_even_ Proc = Proc{Fn: __round_to_even__P, Name: "round_to_even_"}
+var round_to_even_ Proc = Proc{Fn: __round_to_even__P, Name: "round_to_even_", Package: "std/math"}
 
 func __round_to_even_(_args []Object) Object {
 	_c := len(_args)
@@ -471,7 +471,7 @@ func __round_to_even_(_args []Object) Object {
 }
 
 var __sign_bit__P ProcFn = __sign_bit_
-var sign_bit_ Proc = Proc{Fn: __sign_bit__P, Name: "sign_bit_"}
+var sign_bit_ Proc = Proc{Fn: __sign_bit__P, Name: "sign_bit_", Package: "std/math"}
 
 func __sign_bit_(_args []Object) Object {
 	_c := len(_args)
@@ -488,7 +488,7 @@ func __sign_bit_(_args []Object) Object {
 }
 
 var __sin__P ProcFn = __sin_
-var sin_ Proc = Proc{Fn: __sin__P, Name: "sin_"}
+var sin_ Proc = Proc{Fn: __sin__P, Name: "sin_", Package: "std/math"}
 
 func __sin_(_args []Object) Object {
 	_c := len(_args)
@@ -505,7 +505,7 @@ func __sin_(_args []Object) Object {
 }
 
 var __sqrt__P ProcFn = __sqrt_
-var sqrt_ Proc = Proc{Fn: __sqrt__P, Name: "sqrt_"}
+var sqrt_ Proc = Proc{Fn: __sqrt__P, Name: "sqrt_", Package: "std/math"}
 
 func __sqrt_(_args []Object) Object {
 	_c := len(_args)
@@ -522,7 +522,7 @@ func __sqrt_(_args []Object) Object {
 }
 
 var __trunc__P ProcFn = __trunc_
-var trunc_ Proc = Proc{Fn: __trunc__P, Name: "trunc_"}
+var trunc_ Proc = Proc{Fn: __trunc__P, Name: "trunc_", Package: "std/math"}
 
 func __trunc_(_args []Object) Object {
 	_c := len(_args)

--- a/std/math/a_math.go
+++ b/std/math/a_math.go
@@ -553,7 +553,6 @@ func Init() {
 	sqrt_of_phi_ = MakeDouble(math.SqrtPhi)
 	sqrt_of_pi_ = MakeDouble(math.SqrtPi)
 
-
 	mathNamespace.ResetMeta(MakeMeta(nil, `Provides basic constants and mathematical functions.`, "1.0"))
 
 	mathNamespace.InternVar("e", e_,

--- a/std/os/a_os.go
+++ b/std/os/a_os.go
@@ -11,7 +11,8 @@ var osNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.os"))
 
 
 
-var args_ Proc
+var __args__P ProcFn = __args_
+var args_ Proc = Proc{Fn: __args__P, Name: "args_"}
 
 func __args_(_args []Object) Object {
 	_c := len(_args)
@@ -26,7 +27,8 @@ func __args_(_args []Object) Object {
 	return NIL
 }
 
-var chdir_ Proc
+var __chdir__P ProcFn = __chdir_
+var chdir_ Proc = Proc{Fn: __chdir__P, Name: "chdir_"}
 
 func __chdir_(_args []Object) Object {
 	_c := len(_args)
@@ -42,7 +44,8 @@ func __chdir_(_args []Object) Object {
 	return NIL
 }
 
-var close_ Proc
+var __close__P ProcFn = __close_
+var close_ Proc = Proc{Fn: __close__P, Name: "close_"}
 
 func __close_(_args []Object) Object {
 	_c := len(_args)
@@ -60,7 +63,8 @@ func __close_(_args []Object) Object {
 	return NIL
 }
 
-var create_ Proc
+var __create__P ProcFn = __create_
+var create_ Proc = Proc{Fn: __create__P, Name: "create_"}
 
 func __create_(_args []Object) Object {
 	_c := len(_args)
@@ -77,7 +81,8 @@ func __create_(_args []Object) Object {
 	return NIL
 }
 
-var cwd_ Proc
+var __cwd__P ProcFn = __cwd_
+var cwd_ Proc = Proc{Fn: __cwd__P, Name: "cwd_"}
 
 func __cwd_(_args []Object) Object {
 	_c := len(_args)
@@ -92,7 +97,8 @@ func __cwd_(_args []Object) Object {
 	return NIL
 }
 
-var env_ Proc
+var __env__P ProcFn = __env_
+var env_ Proc = Proc{Fn: __env__P, Name: "env_"}
 
 func __env_(_args []Object) Object {
 	_c := len(_args)
@@ -107,7 +113,8 @@ func __env_(_args []Object) Object {
 	return NIL
 }
 
-var exec_ Proc
+var __exec__P ProcFn = __exec_
+var exec_ Proc = Proc{Fn: __exec__P, Name: "exec_"}
 
 func __exec_(_args []Object) Object {
 	_c := len(_args)
@@ -124,7 +131,8 @@ func __exec_(_args []Object) Object {
 	return NIL
 }
 
-var isexists_ Proc
+var __isexists__P ProcFn = __isexists_
+var isexists_ Proc = Proc{Fn: __isexists__P, Name: "isexists_"}
 
 func __isexists_(_args []Object) Object {
 	_c := len(_args)
@@ -140,7 +148,8 @@ func __isexists_(_args []Object) Object {
 	return NIL
 }
 
-var exit_ Proc
+var __exit__P ProcFn = __exit_
+var exit_ Proc = Proc{Fn: __exit__P, Name: "exit_"}
 
 func __exit_(_args []Object) Object {
 	_c := len(_args)
@@ -157,7 +166,8 @@ func __exit_(_args []Object) Object {
 	return NIL
 }
 
-var get_env_ Proc
+var __get_env__P ProcFn = __get_env_
+var get_env_ Proc = Proc{Fn: __get_env__P, Name: "get_env_"}
 
 func __get_env_(_args []Object) Object {
 	_c := len(_args)
@@ -173,7 +183,8 @@ func __get_env_(_args []Object) Object {
 	return NIL
 }
 
-var ls_ Proc
+var __ls__P ProcFn = __ls_
+var ls_ Proc = Proc{Fn: __ls__P, Name: "ls_"}
 
 func __ls_(_args []Object) Object {
 	_c := len(_args)
@@ -189,7 +200,8 @@ func __ls_(_args []Object) Object {
 	return NIL
 }
 
-var mkdir_ Proc
+var __mkdir__P ProcFn = __mkdir_
+var mkdir_ Proc = Proc{Fn: __mkdir__P, Name: "mkdir_"}
 
 func __mkdir_(_args []Object) Object {
 	_c := len(_args)
@@ -206,7 +218,8 @@ func __mkdir_(_args []Object) Object {
 	return NIL
 }
 
-var open_ Proc
+var __open__P ProcFn = __open_
+var open_ Proc = Proc{Fn: __open__P, Name: "open_"}
 
 func __open_(_args []Object) Object {
 	_c := len(_args)
@@ -223,7 +236,8 @@ func __open_(_args []Object) Object {
 	return NIL
 }
 
-var remove_ Proc
+var __remove__P ProcFn = __remove_
+var remove_ Proc = Proc{Fn: __remove__P, Name: "remove_"}
 
 func __remove_(_args []Object) Object {
 	_c := len(_args)
@@ -241,7 +255,8 @@ func __remove_(_args []Object) Object {
 	return NIL
 }
 
-var remove_all_ Proc
+var __remove_all__P ProcFn = __remove_all_
+var remove_all_ Proc = Proc{Fn: __remove_all__P, Name: "remove_all_"}
 
 func __remove_all_(_args []Object) Object {
 	_c := len(_args)
@@ -259,7 +274,8 @@ func __remove_all_(_args []Object) Object {
 	return NIL
 }
 
-var set_env_ Proc
+var __set_env__P ProcFn = __set_env_
+var set_env_ Proc = Proc{Fn: __set_env__P, Name: "set_env_"}
 
 func __set_env_(_args []Object) Object {
 	_c := len(_args)
@@ -276,7 +292,8 @@ func __set_env_(_args []Object) Object {
 	return NIL
 }
 
-var sh_ Proc
+var __sh__P ProcFn = __sh_
+var sh_ Proc = Proc{Fn: __sh__P, Name: "sh_"}
 
 func __sh_(_args []Object) Object {
 	_c := len(_args)
@@ -294,7 +311,8 @@ func __sh_(_args []Object) Object {
 	return NIL
 }
 
-var sh_from_ Proc
+var __sh_from__P ProcFn = __sh_from_
+var sh_from_ Proc = Proc{Fn: __sh_from__P, Name: "sh_from_"}
 
 func __sh_from_(_args []Object) Object {
 	_c := len(_args)
@@ -313,7 +331,8 @@ func __sh_from_(_args []Object) Object {
 	return NIL
 }
 
-var stat_ Proc
+var __stat__P ProcFn = __stat_
+var stat_ Proc = Proc{Fn: __stat__P, Name: "stat_"}
 
 func __stat_(_args []Object) Object {
 	_c := len(_args)
@@ -331,25 +350,7 @@ func __stat_(_args []Object) Object {
 
 func Init() {
 
-	args_ = __args_
-	chdir_ = __chdir_
-	close_ = __close_
-	create_ = __create_
-	cwd_ = __cwd_
-	env_ = __env_
-	exec_ = __exec_
-	isexists_ = __isexists_
-	exit_ = __exit_
-	get_env_ = __get_env_
-	ls_ = __ls_
-	mkdir_ = __mkdir_
-	open_ = __open_
-	remove_ = __remove_
-	remove_all_ = __remove_all_
-	set_env_ = __set_env_
-	sh_ = __sh_
-	sh_from_ = __sh_from_
-	stat_ = __stat_
+
 
 	osNamespace.ResetMeta(MakeMeta(nil, `Provides a platform-independent interface to operating system functionality.`, "1.0"))
 

--- a/std/os/a_os.go
+++ b/std/os/a_os.go
@@ -12,7 +12,7 @@ var osNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.os"))
 
 
 var __args__P ProcFn = __args_
-var args_ Proc = Proc{Fn: __args__P, Name: "args_"}
+var args_ Proc = Proc{Fn: __args__P, Name: "args_", Package: "std/os"}
 
 func __args_(_args []Object) Object {
 	_c := len(_args)
@@ -28,7 +28,7 @@ func __args_(_args []Object) Object {
 }
 
 var __chdir__P ProcFn = __chdir_
-var chdir_ Proc = Proc{Fn: __chdir__P, Name: "chdir_"}
+var chdir_ Proc = Proc{Fn: __chdir__P, Name: "chdir_", Package: "std/os"}
 
 func __chdir_(_args []Object) Object {
 	_c := len(_args)
@@ -45,7 +45,7 @@ func __chdir_(_args []Object) Object {
 }
 
 var __close__P ProcFn = __close_
-var close_ Proc = Proc{Fn: __close__P, Name: "close_"}
+var close_ Proc = Proc{Fn: __close__P, Name: "close_", Package: "std/os"}
 
 func __close_(_args []Object) Object {
 	_c := len(_args)
@@ -64,7 +64,7 @@ func __close_(_args []Object) Object {
 }
 
 var __create__P ProcFn = __create_
-var create_ Proc = Proc{Fn: __create__P, Name: "create_"}
+var create_ Proc = Proc{Fn: __create__P, Name: "create_", Package: "std/os"}
 
 func __create_(_args []Object) Object {
 	_c := len(_args)
@@ -82,7 +82,7 @@ func __create_(_args []Object) Object {
 }
 
 var __cwd__P ProcFn = __cwd_
-var cwd_ Proc = Proc{Fn: __cwd__P, Name: "cwd_"}
+var cwd_ Proc = Proc{Fn: __cwd__P, Name: "cwd_", Package: "std/os"}
 
 func __cwd_(_args []Object) Object {
 	_c := len(_args)
@@ -98,7 +98,7 @@ func __cwd_(_args []Object) Object {
 }
 
 var __env__P ProcFn = __env_
-var env_ Proc = Proc{Fn: __env__P, Name: "env_"}
+var env_ Proc = Proc{Fn: __env__P, Name: "env_", Package: "std/os"}
 
 func __env_(_args []Object) Object {
 	_c := len(_args)
@@ -114,7 +114,7 @@ func __env_(_args []Object) Object {
 }
 
 var __exec__P ProcFn = __exec_
-var exec_ Proc = Proc{Fn: __exec__P, Name: "exec_"}
+var exec_ Proc = Proc{Fn: __exec__P, Name: "exec_", Package: "std/os"}
 
 func __exec_(_args []Object) Object {
 	_c := len(_args)
@@ -132,7 +132,7 @@ func __exec_(_args []Object) Object {
 }
 
 var __isexists__P ProcFn = __isexists_
-var isexists_ Proc = Proc{Fn: __isexists__P, Name: "isexists_"}
+var isexists_ Proc = Proc{Fn: __isexists__P, Name: "isexists_", Package: "std/os"}
 
 func __isexists_(_args []Object) Object {
 	_c := len(_args)
@@ -149,7 +149,7 @@ func __isexists_(_args []Object) Object {
 }
 
 var __exit__P ProcFn = __exit_
-var exit_ Proc = Proc{Fn: __exit__P, Name: "exit_"}
+var exit_ Proc = Proc{Fn: __exit__P, Name: "exit_", Package: "std/os"}
 
 func __exit_(_args []Object) Object {
 	_c := len(_args)
@@ -167,7 +167,7 @@ func __exit_(_args []Object) Object {
 }
 
 var __get_env__P ProcFn = __get_env_
-var get_env_ Proc = Proc{Fn: __get_env__P, Name: "get_env_"}
+var get_env_ Proc = Proc{Fn: __get_env__P, Name: "get_env_", Package: "std/os"}
 
 func __get_env_(_args []Object) Object {
 	_c := len(_args)
@@ -184,7 +184,7 @@ func __get_env_(_args []Object) Object {
 }
 
 var __ls__P ProcFn = __ls_
-var ls_ Proc = Proc{Fn: __ls__P, Name: "ls_"}
+var ls_ Proc = Proc{Fn: __ls__P, Name: "ls_", Package: "std/os"}
 
 func __ls_(_args []Object) Object {
 	_c := len(_args)
@@ -201,7 +201,7 @@ func __ls_(_args []Object) Object {
 }
 
 var __mkdir__P ProcFn = __mkdir_
-var mkdir_ Proc = Proc{Fn: __mkdir__P, Name: "mkdir_"}
+var mkdir_ Proc = Proc{Fn: __mkdir__P, Name: "mkdir_", Package: "std/os"}
 
 func __mkdir_(_args []Object) Object {
 	_c := len(_args)
@@ -219,7 +219,7 @@ func __mkdir_(_args []Object) Object {
 }
 
 var __open__P ProcFn = __open_
-var open_ Proc = Proc{Fn: __open__P, Name: "open_"}
+var open_ Proc = Proc{Fn: __open__P, Name: "open_", Package: "std/os"}
 
 func __open_(_args []Object) Object {
 	_c := len(_args)
@@ -237,7 +237,7 @@ func __open_(_args []Object) Object {
 }
 
 var __remove__P ProcFn = __remove_
-var remove_ Proc = Proc{Fn: __remove__P, Name: "remove_"}
+var remove_ Proc = Proc{Fn: __remove__P, Name: "remove_", Package: "std/os"}
 
 func __remove_(_args []Object) Object {
 	_c := len(_args)
@@ -256,7 +256,7 @@ func __remove_(_args []Object) Object {
 }
 
 var __remove_all__P ProcFn = __remove_all_
-var remove_all_ Proc = Proc{Fn: __remove_all__P, Name: "remove_all_"}
+var remove_all_ Proc = Proc{Fn: __remove_all__P, Name: "remove_all_", Package: "std/os"}
 
 func __remove_all_(_args []Object) Object {
 	_c := len(_args)
@@ -275,7 +275,7 @@ func __remove_all_(_args []Object) Object {
 }
 
 var __set_env__P ProcFn = __set_env_
-var set_env_ Proc = Proc{Fn: __set_env__P, Name: "set_env_"}
+var set_env_ Proc = Proc{Fn: __set_env__P, Name: "set_env_", Package: "std/os"}
 
 func __set_env_(_args []Object) Object {
 	_c := len(_args)
@@ -293,7 +293,7 @@ func __set_env_(_args []Object) Object {
 }
 
 var __sh__P ProcFn = __sh_
-var sh_ Proc = Proc{Fn: __sh__P, Name: "sh_"}
+var sh_ Proc = Proc{Fn: __sh__P, Name: "sh_", Package: "std/os"}
 
 func __sh_(_args []Object) Object {
 	_c := len(_args)
@@ -312,7 +312,7 @@ func __sh_(_args []Object) Object {
 }
 
 var __sh_from__P ProcFn = __sh_from_
-var sh_from_ Proc = Proc{Fn: __sh_from__P, Name: "sh_from_"}
+var sh_from_ Proc = Proc{Fn: __sh_from__P, Name: "sh_from_", Package: "std/os"}
 
 func __sh_from_(_args []Object) Object {
 	_c := len(_args)
@@ -332,7 +332,7 @@ func __sh_from_(_args []Object) Object {
 }
 
 var __stat__P ProcFn = __stat_
-var stat_ Proc = Proc{Fn: __stat__P, Name: "stat_"}
+var stat_ Proc = Proc{Fn: __stat__P, Name: "stat_", Package: "std/os"}
 
 func __stat_(_args []Object) Object {
 	_c := len(_args)

--- a/std/os/a_os.go
+++ b/std/os/a_os.go
@@ -351,7 +351,6 @@ func __stat_(_args []Object) Object {
 func Init() {
 
 
-
 	osNamespace.ResetMeta(MakeMeta(nil, `Provides a platform-independent interface to operating system functionality.`, "1.0"))
 
 	

--- a/std/package.tmpl
+++ b/std/package.tmpl
@@ -13,7 +13,6 @@ var {nsName}Namespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.{nsFullName
 {fn-decls}
 func Init() {
 {non-fn-inits}
-{fn-inits}
 
 	{nsName}Namespace.ResetMeta(MakeMeta(nil, {nsDocstring}, "1.0"))
 

--- a/std/strconv/a_strconv.go
+++ b/std/strconv/a_strconv.go
@@ -12,7 +12,7 @@ var strconvNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.strconv"))
 
 
 var __atoi__P ProcFn = __atoi_
-var atoi_ Proc = Proc{Fn: __atoi__P, Name: "atoi_"}
+var atoi_ Proc = Proc{Fn: __atoi__P, Name: "atoi_", Package: "std/strconv"}
 
 func __atoi_(_args []Object) Object {
 	_c := len(_args)
@@ -30,7 +30,7 @@ func __atoi_(_args []Object) Object {
 }
 
 var __iscan_backquote__P ProcFn = __iscan_backquote_
-var iscan_backquote_ Proc = Proc{Fn: __iscan_backquote__P, Name: "iscan_backquote_"}
+var iscan_backquote_ Proc = Proc{Fn: __iscan_backquote__P, Name: "iscan_backquote_", Package: "std/strconv"}
 
 func __iscan_backquote_(_args []Object) Object {
 	_c := len(_args)
@@ -47,7 +47,7 @@ func __iscan_backquote_(_args []Object) Object {
 }
 
 var __format_bool__P ProcFn = __format_bool_
-var format_bool_ Proc = Proc{Fn: __format_bool__P, Name: "format_bool_"}
+var format_bool_ Proc = Proc{Fn: __format_bool__P, Name: "format_bool_", Package: "std/strconv"}
 
 func __format_bool_(_args []Object) Object {
 	_c := len(_args)
@@ -64,7 +64,7 @@ func __format_bool_(_args []Object) Object {
 }
 
 var __format_double__P ProcFn = __format_double_
-var format_double_ Proc = Proc{Fn: __format_double__P, Name: "format_double_"}
+var format_double_ Proc = Proc{Fn: __format_double__P, Name: "format_double_", Package: "std/strconv"}
 
 func __format_double_(_args []Object) Object {
 	_c := len(_args)
@@ -84,7 +84,7 @@ func __format_double_(_args []Object) Object {
 }
 
 var __format_int__P ProcFn = __format_int_
-var format_int_ Proc = Proc{Fn: __format_int__P, Name: "format_int_"}
+var format_int_ Proc = Proc{Fn: __format_int__P, Name: "format_int_", Package: "std/strconv"}
 
 func __format_int_(_args []Object) Object {
 	_c := len(_args)
@@ -102,7 +102,7 @@ func __format_int_(_args []Object) Object {
 }
 
 var __isgraphic__P ProcFn = __isgraphic_
-var isgraphic_ Proc = Proc{Fn: __isgraphic__P, Name: "isgraphic_"}
+var isgraphic_ Proc = Proc{Fn: __isgraphic__P, Name: "isgraphic_", Package: "std/strconv"}
 
 func __isgraphic_(_args []Object) Object {
 	_c := len(_args)
@@ -119,7 +119,7 @@ func __isgraphic_(_args []Object) Object {
 }
 
 var __itoa__P ProcFn = __itoa_
-var itoa_ Proc = Proc{Fn: __itoa__P, Name: "itoa_"}
+var itoa_ Proc = Proc{Fn: __itoa__P, Name: "itoa_", Package: "std/strconv"}
 
 func __itoa_(_args []Object) Object {
 	_c := len(_args)
@@ -136,7 +136,7 @@ func __itoa_(_args []Object) Object {
 }
 
 var __parse_bool__P ProcFn = __parse_bool_
-var parse_bool_ Proc = Proc{Fn: __parse_bool__P, Name: "parse_bool_"}
+var parse_bool_ Proc = Proc{Fn: __parse_bool__P, Name: "parse_bool_", Package: "std/strconv"}
 
 func __parse_bool_(_args []Object) Object {
 	_c := len(_args)
@@ -154,7 +154,7 @@ func __parse_bool_(_args []Object) Object {
 }
 
 var __parse_double__P ProcFn = __parse_double_
-var parse_double_ Proc = Proc{Fn: __parse_double__P, Name: "parse_double_"}
+var parse_double_ Proc = Proc{Fn: __parse_double__P, Name: "parse_double_", Package: "std/strconv"}
 
 func __parse_double_(_args []Object) Object {
 	_c := len(_args)
@@ -172,7 +172,7 @@ func __parse_double_(_args []Object) Object {
 }
 
 var __parse_int__P ProcFn = __parse_int_
-var parse_int_ Proc = Proc{Fn: __parse_int__P, Name: "parse_int_"}
+var parse_int_ Proc = Proc{Fn: __parse_int__P, Name: "parse_int_", Package: "std/strconv"}
 
 func __parse_int_(_args []Object) Object {
 	_c := len(_args)
@@ -193,7 +193,7 @@ func __parse_int_(_args []Object) Object {
 }
 
 var __isprintable__P ProcFn = __isprintable_
-var isprintable_ Proc = Proc{Fn: __isprintable__P, Name: "isprintable_"}
+var isprintable_ Proc = Proc{Fn: __isprintable__P, Name: "isprintable_", Package: "std/strconv"}
 
 func __isprintable_(_args []Object) Object {
 	_c := len(_args)
@@ -210,7 +210,7 @@ func __isprintable_(_args []Object) Object {
 }
 
 var __quote__P ProcFn = __quote_
-var quote_ Proc = Proc{Fn: __quote__P, Name: "quote_"}
+var quote_ Proc = Proc{Fn: __quote__P, Name: "quote_", Package: "std/strconv"}
 
 func __quote_(_args []Object) Object {
 	_c := len(_args)
@@ -227,7 +227,7 @@ func __quote_(_args []Object) Object {
 }
 
 var __quote_char__P ProcFn = __quote_char_
-var quote_char_ Proc = Proc{Fn: __quote_char__P, Name: "quote_char_"}
+var quote_char_ Proc = Proc{Fn: __quote_char__P, Name: "quote_char_", Package: "std/strconv"}
 
 func __quote_char_(_args []Object) Object {
 	_c := len(_args)
@@ -244,7 +244,7 @@ func __quote_char_(_args []Object) Object {
 }
 
 var __quote_char_to_ascii__P ProcFn = __quote_char_to_ascii_
-var quote_char_to_ascii_ Proc = Proc{Fn: __quote_char_to_ascii__P, Name: "quote_char_to_ascii_"}
+var quote_char_to_ascii_ Proc = Proc{Fn: __quote_char_to_ascii__P, Name: "quote_char_to_ascii_", Package: "std/strconv"}
 
 func __quote_char_to_ascii_(_args []Object) Object {
 	_c := len(_args)
@@ -261,7 +261,7 @@ func __quote_char_to_ascii_(_args []Object) Object {
 }
 
 var __quote_char_to_graphic__P ProcFn = __quote_char_to_graphic_
-var quote_char_to_graphic_ Proc = Proc{Fn: __quote_char_to_graphic__P, Name: "quote_char_to_graphic_"}
+var quote_char_to_graphic_ Proc = Proc{Fn: __quote_char_to_graphic__P, Name: "quote_char_to_graphic_", Package: "std/strconv"}
 
 func __quote_char_to_graphic_(_args []Object) Object {
 	_c := len(_args)
@@ -278,7 +278,7 @@ func __quote_char_to_graphic_(_args []Object) Object {
 }
 
 var __quote_to_ascii__P ProcFn = __quote_to_ascii_
-var quote_to_ascii_ Proc = Proc{Fn: __quote_to_ascii__P, Name: "quote_to_ascii_"}
+var quote_to_ascii_ Proc = Proc{Fn: __quote_to_ascii__P, Name: "quote_to_ascii_", Package: "std/strconv"}
 
 func __quote_to_ascii_(_args []Object) Object {
 	_c := len(_args)
@@ -295,7 +295,7 @@ func __quote_to_ascii_(_args []Object) Object {
 }
 
 var __quote_to_graphic__P ProcFn = __quote_to_graphic_
-var quote_to_graphic_ Proc = Proc{Fn: __quote_to_graphic__P, Name: "quote_to_graphic_"}
+var quote_to_graphic_ Proc = Proc{Fn: __quote_to_graphic__P, Name: "quote_to_graphic_", Package: "std/strconv"}
 
 func __quote_to_graphic_(_args []Object) Object {
 	_c := len(_args)
@@ -312,7 +312,7 @@ func __quote_to_graphic_(_args []Object) Object {
 }
 
 var __unquote__P ProcFn = __unquote_
-var unquote_ Proc = Proc{Fn: __unquote__P, Name: "unquote_"}
+var unquote_ Proc = Proc{Fn: __unquote__P, Name: "unquote_", Package: "std/strconv"}
 
 func __unquote_(_args []Object) Object {
 	_c := len(_args)

--- a/std/strconv/a_strconv.go
+++ b/std/strconv/a_strconv.go
@@ -11,7 +11,8 @@ var strconvNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.strconv"))
 
 
 
-var atoi_ Proc
+var __atoi__P ProcFn = __atoi_
+var atoi_ Proc = Proc{Fn: __atoi__P, Name: "atoi_"}
 
 func __atoi_(_args []Object) Object {
 	_c := len(_args)
@@ -28,7 +29,8 @@ func __atoi_(_args []Object) Object {
 	return NIL
 }
 
-var iscan_backquote_ Proc
+var __iscan_backquote__P ProcFn = __iscan_backquote_
+var iscan_backquote_ Proc = Proc{Fn: __iscan_backquote__P, Name: "iscan_backquote_"}
 
 func __iscan_backquote_(_args []Object) Object {
 	_c := len(_args)
@@ -44,7 +46,8 @@ func __iscan_backquote_(_args []Object) Object {
 	return NIL
 }
 
-var format_bool_ Proc
+var __format_bool__P ProcFn = __format_bool_
+var format_bool_ Proc = Proc{Fn: __format_bool__P, Name: "format_bool_"}
 
 func __format_bool_(_args []Object) Object {
 	_c := len(_args)
@@ -60,7 +63,8 @@ func __format_bool_(_args []Object) Object {
 	return NIL
 }
 
-var format_double_ Proc
+var __format_double__P ProcFn = __format_double_
+var format_double_ Proc = Proc{Fn: __format_double__P, Name: "format_double_"}
 
 func __format_double_(_args []Object) Object {
 	_c := len(_args)
@@ -79,7 +83,8 @@ func __format_double_(_args []Object) Object {
 	return NIL
 }
 
-var format_int_ Proc
+var __format_int__P ProcFn = __format_int_
+var format_int_ Proc = Proc{Fn: __format_int__P, Name: "format_int_"}
 
 func __format_int_(_args []Object) Object {
 	_c := len(_args)
@@ -96,7 +101,8 @@ func __format_int_(_args []Object) Object {
 	return NIL
 }
 
-var isgraphic_ Proc
+var __isgraphic__P ProcFn = __isgraphic_
+var isgraphic_ Proc = Proc{Fn: __isgraphic__P, Name: "isgraphic_"}
 
 func __isgraphic_(_args []Object) Object {
 	_c := len(_args)
@@ -112,7 +118,8 @@ func __isgraphic_(_args []Object) Object {
 	return NIL
 }
 
-var itoa_ Proc
+var __itoa__P ProcFn = __itoa_
+var itoa_ Proc = Proc{Fn: __itoa__P, Name: "itoa_"}
 
 func __itoa_(_args []Object) Object {
 	_c := len(_args)
@@ -128,7 +135,8 @@ func __itoa_(_args []Object) Object {
 	return NIL
 }
 
-var parse_bool_ Proc
+var __parse_bool__P ProcFn = __parse_bool_
+var parse_bool_ Proc = Proc{Fn: __parse_bool__P, Name: "parse_bool_"}
 
 func __parse_bool_(_args []Object) Object {
 	_c := len(_args)
@@ -145,7 +153,8 @@ func __parse_bool_(_args []Object) Object {
 	return NIL
 }
 
-var parse_double_ Proc
+var __parse_double__P ProcFn = __parse_double_
+var parse_double_ Proc = Proc{Fn: __parse_double__P, Name: "parse_double_"}
 
 func __parse_double_(_args []Object) Object {
 	_c := len(_args)
@@ -162,7 +171,8 @@ func __parse_double_(_args []Object) Object {
 	return NIL
 }
 
-var parse_int_ Proc
+var __parse_int__P ProcFn = __parse_int_
+var parse_int_ Proc = Proc{Fn: __parse_int__P, Name: "parse_int_"}
 
 func __parse_int_(_args []Object) Object {
 	_c := len(_args)
@@ -182,7 +192,8 @@ func __parse_int_(_args []Object) Object {
 	return NIL
 }
 
-var isprintable_ Proc
+var __isprintable__P ProcFn = __isprintable_
+var isprintable_ Proc = Proc{Fn: __isprintable__P, Name: "isprintable_"}
 
 func __isprintable_(_args []Object) Object {
 	_c := len(_args)
@@ -198,7 +209,8 @@ func __isprintable_(_args []Object) Object {
 	return NIL
 }
 
-var quote_ Proc
+var __quote__P ProcFn = __quote_
+var quote_ Proc = Proc{Fn: __quote__P, Name: "quote_"}
 
 func __quote_(_args []Object) Object {
 	_c := len(_args)
@@ -214,7 +226,8 @@ func __quote_(_args []Object) Object {
 	return NIL
 }
 
-var quote_char_ Proc
+var __quote_char__P ProcFn = __quote_char_
+var quote_char_ Proc = Proc{Fn: __quote_char__P, Name: "quote_char_"}
 
 func __quote_char_(_args []Object) Object {
 	_c := len(_args)
@@ -230,7 +243,8 @@ func __quote_char_(_args []Object) Object {
 	return NIL
 }
 
-var quote_char_to_ascii_ Proc
+var __quote_char_to_ascii__P ProcFn = __quote_char_to_ascii_
+var quote_char_to_ascii_ Proc = Proc{Fn: __quote_char_to_ascii__P, Name: "quote_char_to_ascii_"}
 
 func __quote_char_to_ascii_(_args []Object) Object {
 	_c := len(_args)
@@ -246,7 +260,8 @@ func __quote_char_to_ascii_(_args []Object) Object {
 	return NIL
 }
 
-var quote_char_to_graphic_ Proc
+var __quote_char_to_graphic__P ProcFn = __quote_char_to_graphic_
+var quote_char_to_graphic_ Proc = Proc{Fn: __quote_char_to_graphic__P, Name: "quote_char_to_graphic_"}
 
 func __quote_char_to_graphic_(_args []Object) Object {
 	_c := len(_args)
@@ -262,7 +277,8 @@ func __quote_char_to_graphic_(_args []Object) Object {
 	return NIL
 }
 
-var quote_to_ascii_ Proc
+var __quote_to_ascii__P ProcFn = __quote_to_ascii_
+var quote_to_ascii_ Proc = Proc{Fn: __quote_to_ascii__P, Name: "quote_to_ascii_"}
 
 func __quote_to_ascii_(_args []Object) Object {
 	_c := len(_args)
@@ -278,7 +294,8 @@ func __quote_to_ascii_(_args []Object) Object {
 	return NIL
 }
 
-var quote_to_graphic_ Proc
+var __quote_to_graphic__P ProcFn = __quote_to_graphic_
+var quote_to_graphic_ Proc = Proc{Fn: __quote_to_graphic__P, Name: "quote_to_graphic_"}
 
 func __quote_to_graphic_(_args []Object) Object {
 	_c := len(_args)
@@ -294,7 +311,8 @@ func __quote_to_graphic_(_args []Object) Object {
 	return NIL
 }
 
-var unquote_ Proc
+var __unquote__P ProcFn = __unquote_
+var unquote_ Proc = Proc{Fn: __unquote__P, Name: "unquote_"}
 
 func __unquote_(_args []Object) Object {
 	_c := len(_args)
@@ -313,24 +331,7 @@ func __unquote_(_args []Object) Object {
 
 func Init() {
 
-	atoi_ = __atoi_
-	iscan_backquote_ = __iscan_backquote_
-	format_bool_ = __format_bool_
-	format_double_ = __format_double_
-	format_int_ = __format_int_
-	isgraphic_ = __isgraphic_
-	itoa_ = __itoa_
-	parse_bool_ = __parse_bool_
-	parse_double_ = __parse_double_
-	parse_int_ = __parse_int_
-	isprintable_ = __isprintable_
-	quote_ = __quote_
-	quote_char_ = __quote_char_
-	quote_char_to_ascii_ = __quote_char_to_ascii_
-	quote_char_to_graphic_ = __quote_char_to_graphic_
-	quote_to_ascii_ = __quote_to_ascii_
-	quote_to_graphic_ = __quote_to_graphic_
-	unquote_ = __unquote_
+
 
 	strconvNamespace.ResetMeta(MakeMeta(nil, `Implements conversions to and from string representations of basic data types.`, "1.0"))
 

--- a/std/strconv/a_strconv.go
+++ b/std/strconv/a_strconv.go
@@ -332,7 +332,6 @@ func __unquote_(_args []Object) Object {
 func Init() {
 
 
-
 	strconvNamespace.ResetMeta(MakeMeta(nil, `Implements conversions to and from string representations of basic data types.`, "1.0"))
 
 	

--- a/std/string/a_string.go
+++ b/std/string/a_string.go
@@ -13,7 +13,8 @@ var stringNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.string"))
 
 
 
-var isblank_ Proc
+var __isblank__P ProcFn = __isblank_
+var isblank_ Proc = Proc{Fn: __isblank__P, Name: "isblank_"}
 
 func __isblank_(_args []Object) Object {
 	_c := len(_args)
@@ -29,7 +30,8 @@ func __isblank_(_args []Object) Object {
 	return NIL
 }
 
-var capitalize_ Proc
+var __capitalize__P ProcFn = __capitalize_
+var capitalize_ Proc = Proc{Fn: __capitalize__P, Name: "capitalize_"}
 
 func __capitalize_(_args []Object) Object {
 	_c := len(_args)
@@ -45,7 +47,8 @@ func __capitalize_(_args []Object) Object {
 	return NIL
 }
 
-var isends_with_ Proc
+var __isends_with__P ProcFn = __isends_with_
+var isends_with_ Proc = Proc{Fn: __isends_with__P, Name: "isends_with_"}
 
 func __isends_with_(_args []Object) Object {
 	_c := len(_args)
@@ -62,7 +65,8 @@ func __isends_with_(_args []Object) Object {
 	return NIL
 }
 
-var escape_ Proc
+var __escape__P ProcFn = __escape_
+var escape_ Proc = Proc{Fn: __escape__P, Name: "escape_"}
 
 func __escape_(_args []Object) Object {
 	_c := len(_args)
@@ -79,7 +83,8 @@ func __escape_(_args []Object) Object {
 	return NIL
 }
 
-var isincludes_ Proc
+var __isincludes__P ProcFn = __isincludes_
+var isincludes_ Proc = Proc{Fn: __isincludes__P, Name: "isincludes_"}
 
 func __isincludes_(_args []Object) Object {
 	_c := len(_args)
@@ -96,7 +101,8 @@ func __isincludes_(_args []Object) Object {
 	return NIL
 }
 
-var index_of_ Proc
+var __index_of__P ProcFn = __index_of_
+var index_of_ Proc = Proc{Fn: __index_of__P, Name: "index_of_"}
 
 func __index_of_(_args []Object) Object {
 	_c := len(_args)
@@ -120,7 +126,8 @@ func __index_of_(_args []Object) Object {
 	return NIL
 }
 
-var join_ Proc
+var __join__P ProcFn = __join_
+var join_ Proc = Proc{Fn: __join__P, Name: "join_"}
 
 func __join_(_args []Object) Object {
 	_c := len(_args)
@@ -142,7 +149,8 @@ func __join_(_args []Object) Object {
 	return NIL
 }
 
-var last_index_of_ Proc
+var __last_index_of__P ProcFn = __last_index_of_
+var last_index_of_ Proc = Proc{Fn: __last_index_of__P, Name: "last_index_of_"}
 
 func __last_index_of_(_args []Object) Object {
 	_c := len(_args)
@@ -166,7 +174,8 @@ func __last_index_of_(_args []Object) Object {
 	return NIL
 }
 
-var lower_case_ Proc
+var __lower_case__P ProcFn = __lower_case_
+var lower_case_ Proc = Proc{Fn: __lower_case__P, Name: "lower_case_"}
 
 func __lower_case_(_args []Object) Object {
 	_c := len(_args)
@@ -182,7 +191,8 @@ func __lower_case_(_args []Object) Object {
 	return NIL
 }
 
-var pad_left_ Proc
+var __pad_left__P ProcFn = __pad_left_
+var pad_left_ Proc = Proc{Fn: __pad_left__P, Name: "pad_left_"}
 
 func __pad_left_(_args []Object) Object {
 	_c := len(_args)
@@ -200,7 +210,8 @@ func __pad_left_(_args []Object) Object {
 	return NIL
 }
 
-var pad_right_ Proc
+var __pad_right__P ProcFn = __pad_right_
+var pad_right_ Proc = Proc{Fn: __pad_right__P, Name: "pad_right_"}
 
 func __pad_right_(_args []Object) Object {
 	_c := len(_args)
@@ -218,7 +229,8 @@ func __pad_right_(_args []Object) Object {
 	return NIL
 }
 
-var re_quote_ Proc
+var __re_quote__P ProcFn = __re_quote_
+var re_quote_ Proc = Proc{Fn: __re_quote__P, Name: "re_quote_"}
 
 func __re_quote_(_args []Object) Object {
 	_c := len(_args)
@@ -234,7 +246,8 @@ func __re_quote_(_args []Object) Object {
 	return NIL
 }
 
-var replace_ Proc
+var __replace__P ProcFn = __replace_
+var replace_ Proc = Proc{Fn: __replace__P, Name: "replace_"}
 
 func __replace_(_args []Object) Object {
 	_c := len(_args)
@@ -252,7 +265,8 @@ func __replace_(_args []Object) Object {
 	return NIL
 }
 
-var replace_first_ Proc
+var __replace_first__P ProcFn = __replace_first_
+var replace_first_ Proc = Proc{Fn: __replace_first__P, Name: "replace_first_"}
 
 func __replace_first_(_args []Object) Object {
 	_c := len(_args)
@@ -270,7 +284,8 @@ func __replace_first_(_args []Object) Object {
 	return NIL
 }
 
-var reverse_ Proc
+var __reverse__P ProcFn = __reverse_
+var reverse_ Proc = Proc{Fn: __reverse__P, Name: "reverse_"}
 
 func __reverse_(_args []Object) Object {
 	_c := len(_args)
@@ -286,7 +301,8 @@ func __reverse_(_args []Object) Object {
 	return NIL
 }
 
-var split_ Proc
+var __split__P ProcFn = __split_
+var split_ Proc = Proc{Fn: __split__P, Name: "split_"}
 
 func __split_(_args []Object) Object {
 	_c := len(_args)
@@ -310,7 +326,8 @@ func __split_(_args []Object) Object {
 	return NIL
 }
 
-var split_lines_ Proc
+var __split_lines__P ProcFn = __split_lines_
+var split_lines_ Proc = Proc{Fn: __split_lines__P, Name: "split_lines_"}
 
 func __split_lines_(_args []Object) Object {
 	_c := len(_args)
@@ -326,7 +343,8 @@ func __split_lines_(_args []Object) Object {
 	return NIL
 }
 
-var isstarts_with_ Proc
+var __isstarts_with__P ProcFn = __isstarts_with_
+var isstarts_with_ Proc = Proc{Fn: __isstarts_with__P, Name: "isstarts_with_"}
 
 func __isstarts_with_(_args []Object) Object {
 	_c := len(_args)
@@ -343,7 +361,8 @@ func __isstarts_with_(_args []Object) Object {
 	return NIL
 }
 
-var trim_ Proc
+var __trim__P ProcFn = __trim_
+var trim_ Proc = Proc{Fn: __trim__P, Name: "trim_"}
 
 func __trim_(_args []Object) Object {
 	_c := len(_args)
@@ -359,7 +378,8 @@ func __trim_(_args []Object) Object {
 	return NIL
 }
 
-var trim_left_ Proc
+var __trim_left__P ProcFn = __trim_left_
+var trim_left_ Proc = Proc{Fn: __trim_left__P, Name: "trim_left_"}
 
 func __trim_left_(_args []Object) Object {
 	_c := len(_args)
@@ -375,7 +395,8 @@ func __trim_left_(_args []Object) Object {
 	return NIL
 }
 
-var trim_newline_ Proc
+var __trim_newline__P ProcFn = __trim_newline_
+var trim_newline_ Proc = Proc{Fn: __trim_newline__P, Name: "trim_newline_"}
 
 func __trim_newline_(_args []Object) Object {
 	_c := len(_args)
@@ -391,7 +412,8 @@ func __trim_newline_(_args []Object) Object {
 	return NIL
 }
 
-var trim_right_ Proc
+var __trim_right__P ProcFn = __trim_right_
+var trim_right_ Proc = Proc{Fn: __trim_right__P, Name: "trim_right_"}
 
 func __trim_right_(_args []Object) Object {
 	_c := len(_args)
@@ -407,7 +429,8 @@ func __trim_right_(_args []Object) Object {
 	return NIL
 }
 
-var triml_ Proc
+var __triml__P ProcFn = __triml_
+var triml_ Proc = Proc{Fn: __triml__P, Name: "triml_"}
 
 func __triml_(_args []Object) Object {
 	_c := len(_args)
@@ -423,7 +446,8 @@ func __triml_(_args []Object) Object {
 	return NIL
 }
 
-var trimr_ Proc
+var __trimr__P ProcFn = __trimr_
+var trimr_ Proc = Proc{Fn: __trimr__P, Name: "trimr_"}
 
 func __trimr_(_args []Object) Object {
 	_c := len(_args)
@@ -439,7 +463,8 @@ func __trimr_(_args []Object) Object {
 	return NIL
 }
 
-var upper_case_ Proc
+var __upper_case__P ProcFn = __upper_case_
+var upper_case_ Proc = Proc{Fn: __upper_case__P, Name: "upper_case_"}
 
 func __upper_case_(_args []Object) Object {
 	_c := len(_args)
@@ -457,31 +482,7 @@ func __upper_case_(_args []Object) Object {
 
 func Init() {
 
-	isblank_ = __isblank_
-	capitalize_ = __capitalize_
-	isends_with_ = __isends_with_
-	escape_ = __escape_
-	isincludes_ = __isincludes_
-	index_of_ = __index_of_
-	join_ = __join_
-	last_index_of_ = __last_index_of_
-	lower_case_ = __lower_case_
-	pad_left_ = __pad_left_
-	pad_right_ = __pad_right_
-	re_quote_ = __re_quote_
-	replace_ = __replace_
-	replace_first_ = __replace_first_
-	reverse_ = __reverse_
-	split_ = __split_
-	split_lines_ = __split_lines_
-	isstarts_with_ = __isstarts_with_
-	trim_ = __trim_
-	trim_left_ = __trim_left_
-	trim_newline_ = __trim_newline_
-	trim_right_ = __trim_right_
-	triml_ = __triml_
-	trimr_ = __trimr_
-	upper_case_ = __upper_case_
+
 
 	stringNamespace.ResetMeta(MakeMeta(nil, `Implements simple functions to manipulate strings.`, "1.0"))
 

--- a/std/string/a_string.go
+++ b/std/string/a_string.go
@@ -14,7 +14,7 @@ var stringNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.string"))
 
 
 var __isblank__P ProcFn = __isblank_
-var isblank_ Proc = Proc{Fn: __isblank__P, Name: "isblank_"}
+var isblank_ Proc = Proc{Fn: __isblank__P, Name: "isblank_", Package: "std/string"}
 
 func __isblank_(_args []Object) Object {
 	_c := len(_args)
@@ -31,7 +31,7 @@ func __isblank_(_args []Object) Object {
 }
 
 var __capitalize__P ProcFn = __capitalize_
-var capitalize_ Proc = Proc{Fn: __capitalize__P, Name: "capitalize_"}
+var capitalize_ Proc = Proc{Fn: __capitalize__P, Name: "capitalize_", Package: "std/string"}
 
 func __capitalize_(_args []Object) Object {
 	_c := len(_args)
@@ -48,7 +48,7 @@ func __capitalize_(_args []Object) Object {
 }
 
 var __isends_with__P ProcFn = __isends_with_
-var isends_with_ Proc = Proc{Fn: __isends_with__P, Name: "isends_with_"}
+var isends_with_ Proc = Proc{Fn: __isends_with__P, Name: "isends_with_", Package: "std/string"}
 
 func __isends_with_(_args []Object) Object {
 	_c := len(_args)
@@ -66,7 +66,7 @@ func __isends_with_(_args []Object) Object {
 }
 
 var __escape__P ProcFn = __escape_
-var escape_ Proc = Proc{Fn: __escape__P, Name: "escape_"}
+var escape_ Proc = Proc{Fn: __escape__P, Name: "escape_", Package: "std/string"}
 
 func __escape_(_args []Object) Object {
 	_c := len(_args)
@@ -84,7 +84,7 @@ func __escape_(_args []Object) Object {
 }
 
 var __isincludes__P ProcFn = __isincludes_
-var isincludes_ Proc = Proc{Fn: __isincludes__P, Name: "isincludes_"}
+var isincludes_ Proc = Proc{Fn: __isincludes__P, Name: "isincludes_", Package: "std/string"}
 
 func __isincludes_(_args []Object) Object {
 	_c := len(_args)
@@ -102,7 +102,7 @@ func __isincludes_(_args []Object) Object {
 }
 
 var __index_of__P ProcFn = __index_of_
-var index_of_ Proc = Proc{Fn: __index_of__P, Name: "index_of_"}
+var index_of_ Proc = Proc{Fn: __index_of__P, Name: "index_of_", Package: "std/string"}
 
 func __index_of_(_args []Object) Object {
 	_c := len(_args)
@@ -127,7 +127,7 @@ func __index_of_(_args []Object) Object {
 }
 
 var __join__P ProcFn = __join_
-var join_ Proc = Proc{Fn: __join__P, Name: "join_"}
+var join_ Proc = Proc{Fn: __join__P, Name: "join_", Package: "std/string"}
 
 func __join_(_args []Object) Object {
 	_c := len(_args)
@@ -150,7 +150,7 @@ func __join_(_args []Object) Object {
 }
 
 var __last_index_of__P ProcFn = __last_index_of_
-var last_index_of_ Proc = Proc{Fn: __last_index_of__P, Name: "last_index_of_"}
+var last_index_of_ Proc = Proc{Fn: __last_index_of__P, Name: "last_index_of_", Package: "std/string"}
 
 func __last_index_of_(_args []Object) Object {
 	_c := len(_args)
@@ -175,7 +175,7 @@ func __last_index_of_(_args []Object) Object {
 }
 
 var __lower_case__P ProcFn = __lower_case_
-var lower_case_ Proc = Proc{Fn: __lower_case__P, Name: "lower_case_"}
+var lower_case_ Proc = Proc{Fn: __lower_case__P, Name: "lower_case_", Package: "std/string"}
 
 func __lower_case_(_args []Object) Object {
 	_c := len(_args)
@@ -192,7 +192,7 @@ func __lower_case_(_args []Object) Object {
 }
 
 var __pad_left__P ProcFn = __pad_left_
-var pad_left_ Proc = Proc{Fn: __pad_left__P, Name: "pad_left_"}
+var pad_left_ Proc = Proc{Fn: __pad_left__P, Name: "pad_left_", Package: "std/string"}
 
 func __pad_left_(_args []Object) Object {
 	_c := len(_args)
@@ -211,7 +211,7 @@ func __pad_left_(_args []Object) Object {
 }
 
 var __pad_right__P ProcFn = __pad_right_
-var pad_right_ Proc = Proc{Fn: __pad_right__P, Name: "pad_right_"}
+var pad_right_ Proc = Proc{Fn: __pad_right__P, Name: "pad_right_", Package: "std/string"}
 
 func __pad_right_(_args []Object) Object {
 	_c := len(_args)
@@ -230,7 +230,7 @@ func __pad_right_(_args []Object) Object {
 }
 
 var __re_quote__P ProcFn = __re_quote_
-var re_quote_ Proc = Proc{Fn: __re_quote__P, Name: "re_quote_"}
+var re_quote_ Proc = Proc{Fn: __re_quote__P, Name: "re_quote_", Package: "std/string"}
 
 func __re_quote_(_args []Object) Object {
 	_c := len(_args)
@@ -247,7 +247,7 @@ func __re_quote_(_args []Object) Object {
 }
 
 var __replace__P ProcFn = __replace_
-var replace_ Proc = Proc{Fn: __replace__P, Name: "replace_"}
+var replace_ Proc = Proc{Fn: __replace__P, Name: "replace_", Package: "std/string"}
 
 func __replace_(_args []Object) Object {
 	_c := len(_args)
@@ -266,7 +266,7 @@ func __replace_(_args []Object) Object {
 }
 
 var __replace_first__P ProcFn = __replace_first_
-var replace_first_ Proc = Proc{Fn: __replace_first__P, Name: "replace_first_"}
+var replace_first_ Proc = Proc{Fn: __replace_first__P, Name: "replace_first_", Package: "std/string"}
 
 func __replace_first_(_args []Object) Object {
 	_c := len(_args)
@@ -285,7 +285,7 @@ func __replace_first_(_args []Object) Object {
 }
 
 var __reverse__P ProcFn = __reverse_
-var reverse_ Proc = Proc{Fn: __reverse__P, Name: "reverse_"}
+var reverse_ Proc = Proc{Fn: __reverse__P, Name: "reverse_", Package: "std/string"}
 
 func __reverse_(_args []Object) Object {
 	_c := len(_args)
@@ -302,7 +302,7 @@ func __reverse_(_args []Object) Object {
 }
 
 var __split__P ProcFn = __split_
-var split_ Proc = Proc{Fn: __split__P, Name: "split_"}
+var split_ Proc = Proc{Fn: __split__P, Name: "split_", Package: "std/string"}
 
 func __split_(_args []Object) Object {
 	_c := len(_args)
@@ -327,7 +327,7 @@ func __split_(_args []Object) Object {
 }
 
 var __split_lines__P ProcFn = __split_lines_
-var split_lines_ Proc = Proc{Fn: __split_lines__P, Name: "split_lines_"}
+var split_lines_ Proc = Proc{Fn: __split_lines__P, Name: "split_lines_", Package: "std/string"}
 
 func __split_lines_(_args []Object) Object {
 	_c := len(_args)
@@ -344,7 +344,7 @@ func __split_lines_(_args []Object) Object {
 }
 
 var __isstarts_with__P ProcFn = __isstarts_with_
-var isstarts_with_ Proc = Proc{Fn: __isstarts_with__P, Name: "isstarts_with_"}
+var isstarts_with_ Proc = Proc{Fn: __isstarts_with__P, Name: "isstarts_with_", Package: "std/string"}
 
 func __isstarts_with_(_args []Object) Object {
 	_c := len(_args)
@@ -362,7 +362,7 @@ func __isstarts_with_(_args []Object) Object {
 }
 
 var __trim__P ProcFn = __trim_
-var trim_ Proc = Proc{Fn: __trim__P, Name: "trim_"}
+var trim_ Proc = Proc{Fn: __trim__P, Name: "trim_", Package: "std/string"}
 
 func __trim_(_args []Object) Object {
 	_c := len(_args)
@@ -379,7 +379,7 @@ func __trim_(_args []Object) Object {
 }
 
 var __trim_left__P ProcFn = __trim_left_
-var trim_left_ Proc = Proc{Fn: __trim_left__P, Name: "trim_left_"}
+var trim_left_ Proc = Proc{Fn: __trim_left__P, Name: "trim_left_", Package: "std/string"}
 
 func __trim_left_(_args []Object) Object {
 	_c := len(_args)
@@ -396,7 +396,7 @@ func __trim_left_(_args []Object) Object {
 }
 
 var __trim_newline__P ProcFn = __trim_newline_
-var trim_newline_ Proc = Proc{Fn: __trim_newline__P, Name: "trim_newline_"}
+var trim_newline_ Proc = Proc{Fn: __trim_newline__P, Name: "trim_newline_", Package: "std/string"}
 
 func __trim_newline_(_args []Object) Object {
 	_c := len(_args)
@@ -413,7 +413,7 @@ func __trim_newline_(_args []Object) Object {
 }
 
 var __trim_right__P ProcFn = __trim_right_
-var trim_right_ Proc = Proc{Fn: __trim_right__P, Name: "trim_right_"}
+var trim_right_ Proc = Proc{Fn: __trim_right__P, Name: "trim_right_", Package: "std/string"}
 
 func __trim_right_(_args []Object) Object {
 	_c := len(_args)
@@ -430,7 +430,7 @@ func __trim_right_(_args []Object) Object {
 }
 
 var __triml__P ProcFn = __triml_
-var triml_ Proc = Proc{Fn: __triml__P, Name: "triml_"}
+var triml_ Proc = Proc{Fn: __triml__P, Name: "triml_", Package: "std/string"}
 
 func __triml_(_args []Object) Object {
 	_c := len(_args)
@@ -447,7 +447,7 @@ func __triml_(_args []Object) Object {
 }
 
 var __trimr__P ProcFn = __trimr_
-var trimr_ Proc = Proc{Fn: __trimr__P, Name: "trimr_"}
+var trimr_ Proc = Proc{Fn: __trimr__P, Name: "trimr_", Package: "std/string"}
 
 func __trimr_(_args []Object) Object {
 	_c := len(_args)
@@ -464,7 +464,7 @@ func __trimr_(_args []Object) Object {
 }
 
 var __upper_case__P ProcFn = __upper_case_
-var upper_case_ Proc = Proc{Fn: __upper_case__P, Name: "upper_case_"}
+var upper_case_ Proc = Proc{Fn: __upper_case__P, Name: "upper_case_", Package: "std/string"}
 
 func __upper_case_(_args []Object) Object {
 	_c := len(_args)

--- a/std/string/a_string.go
+++ b/std/string/a_string.go
@@ -483,7 +483,6 @@ func __upper_case_(_args []Object) Object {
 func Init() {
 
 
-
 	stringNamespace.ResetMeta(MakeMeta(nil, `Implements simple functions to manipulate strings.`, "1.0"))
 
 	

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -375,7 +375,6 @@ func Init() {
 	stamp_nano_ = MakeString(time.StampNano)
 	unix_date_ = MakeString(time.UnixDate)
 
-
 	timeNamespace.ResetMeta(MakeMeta(nil, `Provides functionality for measuring and displaying time.`, "1.0"))
 
 	timeNamespace.InternVar("ansi-c", ansi_c_,

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -31,7 +31,8 @@ var stamp_milli_ String
 var stamp_nano_ String
 var unix_date_ String
 
-var add_ Proc
+var __add__P ProcFn = __add_
+var add_ Proc = Proc{Fn: __add__P, Name: "add_"}
 
 func __add_(_args []Object) Object {
 	_c := len(_args)
@@ -48,7 +49,8 @@ func __add_(_args []Object) Object {
 	return NIL
 }
 
-var add_date_ Proc
+var __add_date__P ProcFn = __add_date_
+var add_date_ Proc = Proc{Fn: __add_date__P, Name: "add_date_"}
 
 func __add_date_(_args []Object) Object {
 	_c := len(_args)
@@ -67,7 +69,8 @@ func __add_date_(_args []Object) Object {
 	return NIL
 }
 
-var format_ Proc
+var __format__P ProcFn = __format_
+var format_ Proc = Proc{Fn: __format__P, Name: "format_"}
 
 func __format_(_args []Object) Object {
 	_c := len(_args)
@@ -84,7 +87,8 @@ func __format_(_args []Object) Object {
 	return NIL
 }
 
-var from_unix_ Proc
+var __from_unix__P ProcFn = __from_unix_
+var from_unix_ Proc = Proc{Fn: __from_unix__P, Name: "from_unix_"}
 
 func __from_unix_(_args []Object) Object {
 	_c := len(_args)
@@ -101,7 +105,8 @@ func __from_unix_(_args []Object) Object {
 	return NIL
 }
 
-var hours_ Proc
+var __hours__P ProcFn = __hours_
+var hours_ Proc = Proc{Fn: __hours__P, Name: "hours_"}
 
 func __hours_(_args []Object) Object {
 	_c := len(_args)
@@ -117,7 +122,8 @@ func __hours_(_args []Object) Object {
 	return NIL
 }
 
-var minutes_ Proc
+var __minutes__P ProcFn = __minutes_
+var minutes_ Proc = Proc{Fn: __minutes__P, Name: "minutes_"}
 
 func __minutes_(_args []Object) Object {
 	_c := len(_args)
@@ -133,7 +139,8 @@ func __minutes_(_args []Object) Object {
 	return NIL
 }
 
-var now_ Proc
+var __now__P ProcFn = __now_
+var now_ Proc = Proc{Fn: __now__P, Name: "now_"}
 
 func __now_(_args []Object) Object {
 	_c := len(_args)
@@ -148,7 +155,8 @@ func __now_(_args []Object) Object {
 	return NIL
 }
 
-var parse_ Proc
+var __parse__P ProcFn = __parse_
+var parse_ Proc = Proc{Fn: __parse__P, Name: "parse_"}
 
 func __parse_(_args []Object) Object {
 	_c := len(_args)
@@ -166,7 +174,8 @@ func __parse_(_args []Object) Object {
 	return NIL
 }
 
-var parse_duration_ Proc
+var __parse_duration__P ProcFn = __parse_duration_
+var parse_duration_ Proc = Proc{Fn: __parse_duration__P, Name: "parse_duration_"}
 
 func __parse_duration_(_args []Object) Object {
 	_c := len(_args)
@@ -184,7 +193,8 @@ func __parse_duration_(_args []Object) Object {
 	return NIL
 }
 
-var round_ Proc
+var __round__P ProcFn = __round_
+var round_ Proc = Proc{Fn: __round__P, Name: "round_"}
 
 func __round_(_args []Object) Object {
 	_c := len(_args)
@@ -201,7 +211,8 @@ func __round_(_args []Object) Object {
 	return NIL
 }
 
-var seconds_ Proc
+var __seconds__P ProcFn = __seconds_
+var seconds_ Proc = Proc{Fn: __seconds__P, Name: "seconds_"}
 
 func __seconds_(_args []Object) Object {
 	_c := len(_args)
@@ -217,7 +228,8 @@ func __seconds_(_args []Object) Object {
 	return NIL
 }
 
-var since_ Proc
+var __since__P ProcFn = __since_
+var since_ Proc = Proc{Fn: __since__P, Name: "since_"}
 
 func __since_(_args []Object) Object {
 	_c := len(_args)
@@ -233,7 +245,8 @@ func __since_(_args []Object) Object {
 	return NIL
 }
 
-var sleep_ Proc
+var __sleep__P ProcFn = __sleep_
+var sleep_ Proc = Proc{Fn: __sleep__P, Name: "sleep_"}
 
 func __sleep_(_args []Object) Object {
 	_c := len(_args)
@@ -252,7 +265,8 @@ func __sleep_(_args []Object) Object {
 	return NIL
 }
 
-var string_ Proc
+var __string__P ProcFn = __string_
+var string_ Proc = Proc{Fn: __string__P, Name: "string_"}
 
 func __string_(_args []Object) Object {
 	_c := len(_args)
@@ -268,7 +282,8 @@ func __string_(_args []Object) Object {
 	return NIL
 }
 
-var sub_ Proc
+var __sub__P ProcFn = __sub_
+var sub_ Proc = Proc{Fn: __sub__P, Name: "sub_"}
 
 func __sub_(_args []Object) Object {
 	_c := len(_args)
@@ -285,7 +300,8 @@ func __sub_(_args []Object) Object {
 	return NIL
 }
 
-var truncate_ Proc
+var __truncate__P ProcFn = __truncate_
+var truncate_ Proc = Proc{Fn: __truncate__P, Name: "truncate_"}
 
 func __truncate_(_args []Object) Object {
 	_c := len(_args)
@@ -302,7 +318,8 @@ func __truncate_(_args []Object) Object {
 	return NIL
 }
 
-var unix_ Proc
+var __unix__P ProcFn = __unix_
+var unix_ Proc = Proc{Fn: __unix__P, Name: "unix_"}
 
 func __unix_(_args []Object) Object {
 	_c := len(_args)
@@ -318,7 +335,8 @@ func __unix_(_args []Object) Object {
 	return NIL
 }
 
-var until_ Proc
+var __until__P ProcFn = __until_
+var until_ Proc = Proc{Fn: __until__P, Name: "until_"}
 
 func __until_(_args []Object) Object {
 	_c := len(_args)
@@ -356,24 +374,7 @@ func Init() {
 	stamp_milli_ = MakeString(time.StampMilli)
 	stamp_nano_ = MakeString(time.StampNano)
 	unix_date_ = MakeString(time.UnixDate)
-	add_ = __add_
-	add_date_ = __add_date_
-	format_ = __format_
-	from_unix_ = __from_unix_
-	hours_ = __hours_
-	minutes_ = __minutes_
-	now_ = __now_
-	parse_ = __parse_
-	parse_duration_ = __parse_duration_
-	round_ = __round_
-	seconds_ = __seconds_
-	since_ = __since_
-	sleep_ = __sleep_
-	string_ = __string_
-	sub_ = __sub_
-	truncate_ = __truncate_
-	unix_ = __unix_
-	until_ = __until_
+
 
 	timeNamespace.ResetMeta(MakeMeta(nil, `Provides functionality for measuring and displaying time.`, "1.0"))
 

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -32,7 +32,7 @@ var stamp_nano_ String
 var unix_date_ String
 
 var __add__P ProcFn = __add_
-var add_ Proc = Proc{Fn: __add__P, Name: "add_"}
+var add_ Proc = Proc{Fn: __add__P, Name: "add_", Package: "std/time"}
 
 func __add_(_args []Object) Object {
 	_c := len(_args)
@@ -50,7 +50,7 @@ func __add_(_args []Object) Object {
 }
 
 var __add_date__P ProcFn = __add_date_
-var add_date_ Proc = Proc{Fn: __add_date__P, Name: "add_date_"}
+var add_date_ Proc = Proc{Fn: __add_date__P, Name: "add_date_", Package: "std/time"}
 
 func __add_date_(_args []Object) Object {
 	_c := len(_args)
@@ -70,7 +70,7 @@ func __add_date_(_args []Object) Object {
 }
 
 var __format__P ProcFn = __format_
-var format_ Proc = Proc{Fn: __format__P, Name: "format_"}
+var format_ Proc = Proc{Fn: __format__P, Name: "format_", Package: "std/time"}
 
 func __format_(_args []Object) Object {
 	_c := len(_args)
@@ -88,7 +88,7 @@ func __format_(_args []Object) Object {
 }
 
 var __from_unix__P ProcFn = __from_unix_
-var from_unix_ Proc = Proc{Fn: __from_unix__P, Name: "from_unix_"}
+var from_unix_ Proc = Proc{Fn: __from_unix__P, Name: "from_unix_", Package: "std/time"}
 
 func __from_unix_(_args []Object) Object {
 	_c := len(_args)
@@ -106,7 +106,7 @@ func __from_unix_(_args []Object) Object {
 }
 
 var __hours__P ProcFn = __hours_
-var hours_ Proc = Proc{Fn: __hours__P, Name: "hours_"}
+var hours_ Proc = Proc{Fn: __hours__P, Name: "hours_", Package: "std/time"}
 
 func __hours_(_args []Object) Object {
 	_c := len(_args)
@@ -123,7 +123,7 @@ func __hours_(_args []Object) Object {
 }
 
 var __minutes__P ProcFn = __minutes_
-var minutes_ Proc = Proc{Fn: __minutes__P, Name: "minutes_"}
+var minutes_ Proc = Proc{Fn: __minutes__P, Name: "minutes_", Package: "std/time"}
 
 func __minutes_(_args []Object) Object {
 	_c := len(_args)
@@ -140,7 +140,7 @@ func __minutes_(_args []Object) Object {
 }
 
 var __now__P ProcFn = __now_
-var now_ Proc = Proc{Fn: __now__P, Name: "now_"}
+var now_ Proc = Proc{Fn: __now__P, Name: "now_", Package: "std/time"}
 
 func __now_(_args []Object) Object {
 	_c := len(_args)
@@ -156,7 +156,7 @@ func __now_(_args []Object) Object {
 }
 
 var __parse__P ProcFn = __parse_
-var parse_ Proc = Proc{Fn: __parse__P, Name: "parse_"}
+var parse_ Proc = Proc{Fn: __parse__P, Name: "parse_", Package: "std/time"}
 
 func __parse_(_args []Object) Object {
 	_c := len(_args)
@@ -175,7 +175,7 @@ func __parse_(_args []Object) Object {
 }
 
 var __parse_duration__P ProcFn = __parse_duration_
-var parse_duration_ Proc = Proc{Fn: __parse_duration__P, Name: "parse_duration_"}
+var parse_duration_ Proc = Proc{Fn: __parse_duration__P, Name: "parse_duration_", Package: "std/time"}
 
 func __parse_duration_(_args []Object) Object {
 	_c := len(_args)
@@ -194,7 +194,7 @@ func __parse_duration_(_args []Object) Object {
 }
 
 var __round__P ProcFn = __round_
-var round_ Proc = Proc{Fn: __round__P, Name: "round_"}
+var round_ Proc = Proc{Fn: __round__P, Name: "round_", Package: "std/time"}
 
 func __round_(_args []Object) Object {
 	_c := len(_args)
@@ -212,7 +212,7 @@ func __round_(_args []Object) Object {
 }
 
 var __seconds__P ProcFn = __seconds_
-var seconds_ Proc = Proc{Fn: __seconds__P, Name: "seconds_"}
+var seconds_ Proc = Proc{Fn: __seconds__P, Name: "seconds_", Package: "std/time"}
 
 func __seconds_(_args []Object) Object {
 	_c := len(_args)
@@ -229,7 +229,7 @@ func __seconds_(_args []Object) Object {
 }
 
 var __since__P ProcFn = __since_
-var since_ Proc = Proc{Fn: __since__P, Name: "since_"}
+var since_ Proc = Proc{Fn: __since__P, Name: "since_", Package: "std/time"}
 
 func __since_(_args []Object) Object {
 	_c := len(_args)
@@ -246,7 +246,7 @@ func __since_(_args []Object) Object {
 }
 
 var __sleep__P ProcFn = __sleep_
-var sleep_ Proc = Proc{Fn: __sleep__P, Name: "sleep_"}
+var sleep_ Proc = Proc{Fn: __sleep__P, Name: "sleep_", Package: "std/time"}
 
 func __sleep_(_args []Object) Object {
 	_c := len(_args)
@@ -266,7 +266,7 @@ func __sleep_(_args []Object) Object {
 }
 
 var __string__P ProcFn = __string_
-var string_ Proc = Proc{Fn: __string__P, Name: "string_"}
+var string_ Proc = Proc{Fn: __string__P, Name: "string_", Package: "std/time"}
 
 func __string_(_args []Object) Object {
 	_c := len(_args)
@@ -283,7 +283,7 @@ func __string_(_args []Object) Object {
 }
 
 var __sub__P ProcFn = __sub_
-var sub_ Proc = Proc{Fn: __sub__P, Name: "sub_"}
+var sub_ Proc = Proc{Fn: __sub__P, Name: "sub_", Package: "std/time"}
 
 func __sub_(_args []Object) Object {
 	_c := len(_args)
@@ -301,7 +301,7 @@ func __sub_(_args []Object) Object {
 }
 
 var __truncate__P ProcFn = __truncate_
-var truncate_ Proc = Proc{Fn: __truncate__P, Name: "truncate_"}
+var truncate_ Proc = Proc{Fn: __truncate__P, Name: "truncate_", Package: "std/time"}
 
 func __truncate_(_args []Object) Object {
 	_c := len(_args)
@@ -319,7 +319,7 @@ func __truncate_(_args []Object) Object {
 }
 
 var __unix__P ProcFn = __unix_
-var unix_ Proc = Proc{Fn: __unix__P, Name: "unix_"}
+var unix_ Proc = Proc{Fn: __unix__P, Name: "unix_", Package: "std/time"}
 
 func __unix_(_args []Object) Object {
 	_c := len(_args)
@@ -336,7 +336,7 @@ func __unix_(_args []Object) Object {
 }
 
 var __until__P ProcFn = __until_
-var until_ Proc = Proc{Fn: __until__P, Name: "until_"}
+var until_ Proc = Proc{Fn: __until__P, Name: "until_", Package: "std/time"}
 
 func __until_(_args []Object) Object {
 	_c := len(_args)

--- a/std/url/a_url.go
+++ b/std/url/a_url.go
@@ -12,7 +12,7 @@ var urlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.url"))
 
 
 var __path_escape__P ProcFn = __path_escape_
-var path_escape_ Proc = Proc{Fn: __path_escape__P, Name: "path_escape_"}
+var path_escape_ Proc = Proc{Fn: __path_escape__P, Name: "path_escape_", Package: "std/url"}
 
 func __path_escape_(_args []Object) Object {
 	_c := len(_args)
@@ -29,7 +29,7 @@ func __path_escape_(_args []Object) Object {
 }
 
 var __path_unescape__P ProcFn = __path_unescape_
-var path_unescape_ Proc = Proc{Fn: __path_unescape__P, Name: "path_unescape_"}
+var path_unescape_ Proc = Proc{Fn: __path_unescape__P, Name: "path_unescape_", Package: "std/url"}
 
 func __path_unescape_(_args []Object) Object {
 	_c := len(_args)
@@ -46,7 +46,7 @@ func __path_unescape_(_args []Object) Object {
 }
 
 var __query_escape__P ProcFn = __query_escape_
-var query_escape_ Proc = Proc{Fn: __query_escape__P, Name: "query_escape_"}
+var query_escape_ Proc = Proc{Fn: __query_escape__P, Name: "query_escape_", Package: "std/url"}
 
 func __query_escape_(_args []Object) Object {
 	_c := len(_args)
@@ -63,7 +63,7 @@ func __query_escape_(_args []Object) Object {
 }
 
 var __query_unescape__P ProcFn = __query_unescape_
-var query_unescape_ Proc = Proc{Fn: __query_unescape__P, Name: "query_unescape_"}
+var query_unescape_ Proc = Proc{Fn: __query_unescape__P, Name: "query_unescape_", Package: "std/url"}
 
 func __query_unescape_(_args []Object) Object {
 	_c := len(_args)

--- a/std/url/a_url.go
+++ b/std/url/a_url.go
@@ -82,7 +82,6 @@ func __query_unescape_(_args []Object) Object {
 func Init() {
 
 
-
 	urlNamespace.ResetMeta(MakeMeta(nil, `Parses URLs and implements query escaping.`, "1.0"))
 
 	

--- a/std/url/a_url.go
+++ b/std/url/a_url.go
@@ -11,7 +11,8 @@ var urlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.url"))
 
 
 
-var path_escape_ Proc
+var __path_escape__P ProcFn = __path_escape_
+var path_escape_ Proc = Proc{Fn: __path_escape__P, Name: "path_escape_"}
 
 func __path_escape_(_args []Object) Object {
 	_c := len(_args)
@@ -27,7 +28,8 @@ func __path_escape_(_args []Object) Object {
 	return NIL
 }
 
-var path_unescape_ Proc
+var __path_unescape__P ProcFn = __path_unescape_
+var path_unescape_ Proc = Proc{Fn: __path_unescape__P, Name: "path_unescape_"}
 
 func __path_unescape_(_args []Object) Object {
 	_c := len(_args)
@@ -43,7 +45,8 @@ func __path_unescape_(_args []Object) Object {
 	return NIL
 }
 
-var query_escape_ Proc
+var __query_escape__P ProcFn = __query_escape_
+var query_escape_ Proc = Proc{Fn: __query_escape__P, Name: "query_escape_"}
 
 func __query_escape_(_args []Object) Object {
 	_c := len(_args)
@@ -59,7 +62,8 @@ func __query_escape_(_args []Object) Object {
 	return NIL
 }
 
-var query_unescape_ Proc
+var __query_unescape__P ProcFn = __query_unescape_
+var query_unescape_ Proc = Proc{Fn: __query_unescape__P, Name: "query_unescape_"}
 
 func __query_unescape_(_args []Object) Object {
 	_c := len(_args)
@@ -77,10 +81,7 @@ func __query_unescape_(_args []Object) Object {
 
 func Init() {
 
-	path_escape_ = __path_escape_
-	path_unescape_ = __path_unescape_
-	query_escape_ = __query_escape_
-	query_unescape_ = __query_unescape_
+
 
 	urlNamespace.ResetMeta(MakeMeta(nil, `Parses URLs and implements query escaping.`, "1.0"))
 

--- a/std/yaml/a_yaml.go
+++ b/std/yaml/a_yaml.go
@@ -11,7 +11,7 @@ var yamlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.yaml"))
 
 
 var __read_string__P ProcFn = __read_string_
-var read_string_ Proc = Proc{Fn: __read_string__P, Name: "read_string_"}
+var read_string_ Proc = Proc{Fn: __read_string__P, Name: "read_string_", Package: "std/yaml"}
 
 func __read_string_(_args []Object) Object {
 	_c := len(_args)
@@ -28,7 +28,7 @@ func __read_string_(_args []Object) Object {
 }
 
 var __write_string__P ProcFn = __write_string_
-var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_"}
+var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_", Package: "std/yaml"}
 
 func __write_string_(_args []Object) Object {
 	_c := len(_args)

--- a/std/yaml/a_yaml.go
+++ b/std/yaml/a_yaml.go
@@ -47,7 +47,6 @@ func __write_string_(_args []Object) Object {
 func Init() {
 
 
-
 	yamlNamespace.ResetMeta(MakeMeta(nil, `Implements encoding and decoding of YAML.`, "1.0"))
 
 	

--- a/std/yaml/a_yaml.go
+++ b/std/yaml/a_yaml.go
@@ -10,7 +10,8 @@ var yamlNamespace = GLOBAL_ENV.EnsureNamespace(MakeSymbol("joker.yaml"))
 
 
 
-var read_string_ Proc
+var __read_string__P ProcFn = __read_string_
+var read_string_ Proc = Proc{Fn: __read_string__P, Name: "read_string_"}
 
 func __read_string_(_args []Object) Object {
 	_c := len(_args)
@@ -26,7 +27,8 @@ func __read_string_(_args []Object) Object {
 	return NIL
 }
 
-var write_string_ Proc
+var __write_string__P ProcFn = __write_string_
+var write_string_ Proc = Proc{Fn: __write_string__P, Name: "write_string_"}
 
 func __write_string_(_args []Object) Object {
 	_c := len(_args)
@@ -44,8 +46,7 @@ func __write_string_(_args []Object) Object {
 
 func Init() {
 
-	read_string_ = __read_string_
-	write_string_ = __write_string_
+
 
 	yamlNamespace.ResetMeta(MakeMeta(nil, `Implements encoding and decoding of YAML.`, "1.0"))
 

--- a/tests/eval/csv.joke
+++ b/tests/eval/csv.joke
@@ -1,0 +1,6 @@
+(ns joker.test-joker.csv
+  (:require [joker.csv :as csv]
+            [joker.test :refer [deftest is]]))
+
+(deftest test-csv-seq
+  (is (= (csv/csv-seq "a,b,c\nd,e,f") '(["a" "b" "c"] ["d" "e" "f"]))))


### PR DESCRIPTION
Needed by the `gen-code` branch (on my fork) to generate static Go code that instantiates a `Proc` given one that it finds while traversing Joker's data structures.

Also makes this work:

```
$ ./joker
Welcome to joker v0.14.1. Use EOF (Ctrl-D) or SIGINT (Ctrl-C) to exit.
user=> cons
#object[Proc:procCons]
user=> joker.string/blank?
#object[Proc:std/string.isblank_]
user=>
```

Previously, only `#object[Proc]` would be output, providing no information on which `Proc` was stringized.

(Note that the individual commit messages are missing the `#object` lines, presumably because they were treated as comment lines!)