### PR TITLE
Separate environment.go init code from decl code

### DIFF
--- a/core/parse.go
+++ b/core/parse.go
@@ -253,7 +253,7 @@ type (
 )
 
 var (
-	GLOBAL_ENV                = NewEnv(MakeSymbol("user"), Stdin, Stdout, Stderr)
+	GLOBAL_ENV                = NewEnv()
 	LOCAL_BINDINGS  *Bindings = nil
 	SPECIAL_SYMBOLS           = make(map[*string]bool)
 	KNOWN_MACROS    *Var

--- a/core/procs.go
+++ b/core/procs.go
@@ -1656,11 +1656,11 @@ func PackReader(reader *Reader, filename string) ([]byte, error) {
 	if filename != "" {
 		currentFilename := parseContext.GlobalEnv.file.Value
 		defer func() {
-			parseContext.GlobalEnv.file.Value = currentFilename
+			parseContext.GlobalEnv.SetFilename(currentFilename)
 		}()
 		s, err := filepath.Abs(filename)
 		PanicOnErr(err)
-		parseContext.GlobalEnv.file.Value = String{S: s}
+		parseContext.GlobalEnv.SetFilename(MakeString(s))
 	}
 	for {
 		obj, err := TryRead(reader)
@@ -1697,11 +1697,11 @@ func ProcessReader(reader *Reader, filename string, phase Phase) error {
 	if filename != "" {
 		currentFilename := parseContext.GlobalEnv.file.Value
 		defer func() {
-			parseContext.GlobalEnv.file.Value = currentFilename
+			parseContext.GlobalEnv.SetFilename(currentFilename)
 		}()
 		s, err := filepath.Abs(filename)
 		PanicOnErr(err)
-		parseContext.GlobalEnv.file.Value = String{S: s}
+		parseContext.GlobalEnv.SetFilename(MakeString(s))
 	}
 	for {
 		obj, err := TryRead(reader)
@@ -1742,11 +1742,11 @@ func ProcessReaderFromEval(reader *Reader, filename string) {
 	if filename != "" {
 		currentFilename := parseContext.GlobalEnv.file.Value
 		defer func() {
-			parseContext.GlobalEnv.file.Value = currentFilename
+			parseContext.GlobalEnv.SetFilename(currentFilename)
 		}()
 		s, err := filepath.Abs(filename)
 		PanicOnErr(err)
-		parseContext.GlobalEnv.file.Value = String{S: s}
+		parseContext.GlobalEnv.SetFilename(MakeString(s))
 	}
 	for {
 		obj, err := TryRead(reader)

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func processFile(filename string, phase Phase) error {
 	if filename != "" {
 		f, err := filepath.Abs(filename)
 		PanicOnErr(err)
-		GLOBAL_ENV.MainFile.Value = MakeString(f)
+		GLOBAL_ENV.SetMainFilename(f)
 	}
 	if saveForRepl {
 		reader = NewReader(&replayable{reader}, "<replay>")
@@ -679,6 +679,8 @@ func main() {
 		finish()
 		os.Exit(code)
 	})
+
+	GLOBAL_ENV.InitEnv(Stdin, Stdout, Stderr, os.Args[1:])
 
 	parseArgs(os.Args) // Do this early enough so --verbose can show joker.core being processed.
 


### PR DESCRIPTION
This is a precursor to separating out the initialization code into a distinct source file, `environment_init.go`, that (like the other `*_init.go` files that will be split off) is built only when `!fast_init` (which is true when building the normal version of Joker).

The fast-startup version of Joker is built with `-tags fast_init`, so those `*_init.go` files will not be compiled in, but their effects will be in the form of `core/a_*code.go` files generated by `gen_code.go` (forthcoming).

(It seemed like a good idea to make this a separate PR from the PR to actually split out the files, which will make it hard to detect changes in the text of the code that is split out. The idea here is to have no such changes to that code, just the source-file splits, in a subsequent PR.)