### PR TITLE
Refer core namespace to user namespace only when building slow version

### DIFF
--- a/core/environment_init.go
+++ b/core/environment_init.go
@@ -40,3 +40,7 @@ func NewEnv() *Env {
 		MakeMeta(nil, "Map of configuration key/value pairs for linter mode", "1.0"))
 	return res
 }
+
+func (env *Env) ReferCoreToUser() {
+	env.FindNamespace(MakeSymbol("user")).ReferAll(env.CoreNamespace)
+}

--- a/core/gen_data/gen_data.go
+++ b/core/gen_data/gen_data.go
@@ -30,7 +30,6 @@ const hextable = "0123456789abcdef"
 func main() {
 	namespaces := map[string]struct{}{}
 
-	GLOBAL_ENV.FindNamespace(MakeSymbol("user")).ReferAll(GLOBAL_ENV.CoreNamespace)
 	for _, f := range CoreSourceFiles {
 		GLOBAL_ENV.SetCurrentNamespace(GLOBAL_ENV.CoreNamespace)
 		content, err := ioutil.ReadFile("data/" + f.Filename)

--- a/main.go
+++ b/main.go
@@ -690,8 +690,7 @@ func main() {
 	RT.GIL.Lock()
 	ProcessCoreData()
 
-	GLOBAL_ENV.FindNamespace(MakeSymbol("user")).ReferAll(GLOBAL_ENV.CoreNamespace)
-
+	GLOBAL_ENV.ReferCoreToUser()
 	GLOBAL_ENV.SetEnvArgs(remainingArgs)
 	GLOBAL_ENV.SetClassPath(classPath)
 


### PR DESCRIPTION
This isn't needed for the fast version (forthcoming `gen-code` branch), nor by `gen_data.go` that I can see.