### PR TITLE
Run go fmt on generated std/ files

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,7 @@ if [ -n "$OUT" ]; then
     echo >&2 "Unable to generate fresh library files; exiting."
     exit 2
 fi
+(cd std; go fmt ./... > /dev/null)
 NEW_SUM256="$(go run tools/sum256dir/main.go std)"
 
 if [ "$SUM256" != "$NEW_SUM256" ]; then


### PR DESCRIPTION
Recent changes to how these files are generated do not consistently conform to Go coding conventions.

Rather than try to keep up with those via changes to `generate-std.joke` and its `*.tmpl` files, just run `go fmt ./...` on the `std/` directory after generating those files.

That way, mere formatting differences won't force rebuilding Joker.