### PR TITLE
Fix panic when exhausting pathname components for namespace

### DIFF
--- a/core/procs.go
+++ b/core/procs.go
@@ -1492,6 +1492,9 @@ var procLibPath = func(args []Object) Object {
 		parts := strings.Split(ns.Name(), ".")
 		for _ = range parts {
 			file, _ = filepath.Split(file)
+			if len(file) == 0 {
+				break
+			}
 			file = file[:len(file)-1]
 		}
 		path = filepath.Join(append([]string{file}, strings.Split(sym.Name(), ".")...)...) + ".joke"


### PR DESCRIPTION
Fixes crash on this when in a "short" path such as `/tmp`:

```
(ns foo.barfizz.buzz.core (:require [clojure.string :as str]))
```

Fixes: https://github.com/candid82/joker/issues/357