### PR TITLE
Build only one executable via run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Below commands should get you up and running.
 ```
 go get -d github.com/candid82/joker
 cd $GOPATH/src/github.com/candid82/joker
-./run.sh --version && go install # -tags fast_init (if you want to install the fast-startup version)
+./run.sh --version && go install # -tags slow_init (if you want to install the original, slow-startup, version)
 ```
 
 ### Cross-platform Builds
@@ -265,7 +265,7 @@ cd $GOPATH/src/github.com/candid82/joker
 After building the native version (to autogenerate appropriate files, "vet" the source code, etc.), set the appropriate environment variables and invoke `go build`. E.g.:
 
 ```
-$ GOOS=linux GOARCH=arm GOARM=6 go build # -tags fast_init (if you want to build the fast-startup version)
+$ GOOS=linux GOARCH=arm GOARM=6 go build # -tags slow_init (if you want to build the original, slow-startup, version)
 ```
 
 (The `run.sh` script does not support cross-platform building.)

--- a/run.sh
+++ b/run.sh
@@ -8,13 +8,11 @@ build() {
   go generate ./...
   (cd core; go fmt a_*.go > /dev/null)
   go vet -tags gen_code ./...
-  go build -tags slow_init
   if $OPTIMIZE_STARTUP; then
-      mv -f joker joker.slow
       go build
       ln -f joker joker.fast
-      echo "...built both joker.slow and joker.fast (aka joker)."
   else
+      go build -tags slow_init
       ln -f joker joker.slow
   fi
 }


### PR DESCRIPTION
The next step towards https://github.com/candid82/joker/issues/362, this causes `run.sh` to (in the default case) no longer build a `joker.slow` executable. Or, an env var or flag file can be used to build that but not `joker.fast`.

`go build -tags slow_init` and such can still be used afterwards to build such an executable (as `joker`), so A/B testing is still supported. That is, all the relevant `*_data.go`, `*_code.go`, `*_slow_init.go`, and `*_fast_init.go` files are still generated.

Documentation updated accordingly, including fixing/clarifying a few things that predate this PR.