### PR TITLE
Add :ns and :name to metadata via add-doc-and-meta

### DIFF
--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3786,7 +3786,7 @@
        ~(emit gpred gexpr clauses))))
 
 (defmacro add-doc-and-meta {:private true} [name docstring meta]
-  `(alter-meta! (var ~name) merge (assoc ~meta :doc ~docstring :ns *ns* :name (symbol '~name))))
+  `(alter-meta! (var ~name) merge (assoc ~meta :doc ~docstring :ns *ns* :name '~name)))
 
 (add-doc-and-meta *file*
   "The path of the file being evaluated, as a String.

--- a/core/data/core.joke
+++ b/core/data/core.joke
@@ -3786,7 +3786,7 @@
        ~(emit gpred gexpr clauses))))
 
 (defmacro add-doc-and-meta {:private true} [name docstring meta]
-  `(alter-meta! (var ~name) merge (assoc ~meta :doc ~docstring)))
+  `(alter-meta! (var ~name) merge (assoc ~meta :doc ~docstring :ns *ns* :name (symbol '~name))))
 
 (add-doc-and-meta *file*
   "The path of the file being evaluated, as a String.


### PR DESCRIPTION
Note the missing info in current Joker versus with this change:

```
$ joker -e '(joker.repl/doc *file*)'
-------------------------

  The path of the file being evaluated, as a String.

  When there is no file, e.g. in the REPL, the value is not defined.
$ ./joker -e '(joker.repl/doc *file*)'
-------------------------
joker.core/*file*
  The path of the file being evaluated, as a String.

  When there is no file, e.g. in the REPL, the value is not defined.
```