### PR TITLE
Better bolt test fix

### DIFF
--- a/tests/eval/bolt.joke
+++ b/tests/eval/bolt.joke
@@ -9,8 +9,8 @@
   (testing "example in docstring"
     (let [f (create-temp "" "bolt-test-")
           db-name (name f)
-          db (open db-name 0600)
           _ (joker.os/close f) ; Windows requires the file itself to be closed for remove to work.
+          db (open db-name 0600)
           users "users"
           joe "Joe Black"]
       (try

--- a/tests/eval/bolt.joke
+++ b/tests/eval/bolt.joke
@@ -8,8 +8,9 @@
 (deftest example-1
   (testing "example in docstring"
     (let [f (create-temp "" "bolt-test-")
-          db (open (name f) 0600)
-          _ (joker.os/close f)  ; Windows requires the file itself to be closed for remove to work.
+          db-name (name f)
+          db (open db-name 0600)
+          f (joker.os/close f) ; Windows requires the file itself to be closed for remove to work.
           users "users"
           joe "Joe Black"]
       (try
@@ -21,4 +22,4 @@
               s (str (sort m))]
           (is (= s (format "([\"id\" %d] [\"name\" \"%s\"])" id joe))))
         (finally (close db)
-                 (remove (name f)))))))
+                 (remove db-name))))))

--- a/tests/eval/bolt.joke
+++ b/tests/eval/bolt.joke
@@ -9,7 +9,7 @@
   (testing "example in docstring"
     (let [f (create-temp "" "bolt-test-")
           db (open (name f) 0600)
-          _ (joker.os/close f)  ; Windows requires the file iself to be closed for remove to work.
+          _ (joker.os/close f)  ; Windows requires the file itself to be closed for remove to work.
           users "users"
           joe "Joe Black"]
       (try

--- a/tests/eval/bolt.joke
+++ b/tests/eval/bolt.joke
@@ -9,6 +9,7 @@
   (testing "example in docstring"
     (let [f (create-temp "" "bolt-test-")
           db (open (name f) 0600)
+          _ (joker.os/close f)  ; Windows requires the file iself to be closed for remove to work.
           users "users"
           joe "Joe Black"]
       (try
@@ -20,5 +21,4 @@
               s (str (sort m))]
           (is (= s (format "([\"id\" %d] [\"name\" \"%s\"])" id joe))))
         (finally (close db)
-                 (joker.os/close f)  ; Windows requires the file iself to be closed for remove to work.
                  (remove (name f)))))))

--- a/tests/eval/bolt.joke
+++ b/tests/eval/bolt.joke
@@ -10,7 +10,7 @@
     (let [f (create-temp "" "bolt-test-")
           db-name (name f)
           db (open db-name 0600)
-          f (joker.os/close f) ; Windows requires the file itself to be closed for remove to work.
+          _ (joker.os/close f) ; Windows requires the file itself to be closed for remove to work.
           users "users"
           joe "Joe Black"]
       (try


### PR DESCRIPTION
Close file ASAP (and nil out the var for it) while avoiding race conditions.

Before closing the file, capture its name, then use that when opening the db and, later, removing the file.

Tested on Windows (and Ubuntu).