### PR TITLE
Improve REPL Welcome Message

### DIFF
--- a/exiters.go
+++ b/exiters.go
@@ -1,0 +1,5 @@
+// +build linux darwin openbsd freebsd netbsd
+
+package main
+
+const EXITERS = "EOF (Ctrl-D), or SIGINT (Ctrl-C)"

--- a/exiters.go
+++ b/exiters.go
@@ -1,4 +1,5 @@
-// +build linux darwin openbsd freebsd netbsd
+// +build !windows
+// +build !plan9
 
 package main
 

--- a/exiters_plan9.go
+++ b/exiters_plan9.go
@@ -1,0 +1,3 @@
+package main
+
+const EXITERS = "EOF (Ctrl-D), or 'Interrupt' note (Ctrl-C)"

--- a/exiters_windows.go
+++ b/exiters_windows.go
@@ -1,0 +1,3 @@
+package main
+
+const EXITERS = "EOF (Ctrl-Z), or Ctrl-C"

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+replace github.com/candid82/liner => /Users/craig/go/src/github.com/candid82/liner

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,3 @@ require (
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-replace github.com/candid82/liner => /Users/craig/go/src/github.com/candid82/liner

--- a/repl.go
+++ b/repl.go
@@ -73,7 +73,7 @@ func saveReplHistory(rl *liner.State, filename string) {
 func repl(phase Phase) {
 	ProcessReplData()
 	GLOBAL_ENV.FindNamespace(MakeSymbol("user")).ReferAll(GLOBAL_ENV.FindNamespace(MakeSymbol("joker.repl")))
-	fmt.Printf("Welcome to joker %s. Use '(exit)', EOF (Ctrl-D) or SIGINT (Ctrl-C) to exit.\n", VERSION)
+	fmt.Printf("Welcome to joker %s. Use '(exit)', %s to exit.\n", VERSION, EXITERS)
 	parseContext := &ParseContext{GlobalEnv: GLOBAL_ENV}
 	replContext := NewReplContext(parseContext.GlobalEnv)
 

--- a/repl_plan9.go
+++ b/repl_plan9.go
@@ -11,7 +11,7 @@ import (
 func repl(phase Phase) {
 	ProcessReplData()
 	GLOBAL_ENV.FindNamespace(MakeSymbol("user")).ReferAll(GLOBAL_ENV.FindNamespace(MakeSymbol("joker.repl")))
-	fmt.Printf("Welcome to joker %s. Use '(exit)', EOF (Ctrl-D) or SIGINT (Ctrl-C) to exit.\n", VERSION)
+	fmt.Printf("Welcome to joker %s. Use '(exit)', %s to exit.\n", VERSION, EXITERS)
 	parseContext := &ParseContext{GlobalEnv: GLOBAL_ENV}
 	replContext := NewReplContext(parseContext.GlobalEnv)
 


### PR DESCRIPTION
As Joker doesn't seem to need any changes to support Ctrl-Z (or Ctrl-\) properly, either in the REPL or when calling `(joker.core/read-line)` from it, these changes seem to be all that's left to be done, and they have no important dependency on any particular version of `liner`.