### PR TITLE
Fix broken doc links in DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,7 +8,7 @@ These notes are intended for developers working on the internals of Joker itself
 
 As with Clojure, Joker supports "libraries" of code organized into _namespaces_. It offers a number of namespaces that are built-in to the Joker executable itself, as well as the ability to dynamically (at run time and on-demand) extend these namespaces via external Joker source files typically organized into directory trees and deployed alongside the Joker executable. (Currently, Joker does not support dynamic extension via non-Joker code, such as Go plugins.)
 
-Whether built-in (as described below) or separately deployed via source files written in Joker (as described in [Organizing Libraries (Namespaces)](https://github.com/candid82/joker/LIBRARIES.md)), developers should be aware of the progression of any given namespace.
+Whether built-in (as described below) or separately deployed via source files written in Joker (as described in [Organizing Libraries (Namespaces)](LIBRARIES.md)), developers should be aware of the progression of any given namespace.
 
 ## Namespace States
 
@@ -121,7 +121,7 @@ These distinctions should be of little, if any, important to developers of Joker
 
 ## Built-in Namespaces
 
-As explained in [the `README.md file`](https://github.com/candid82/joker/README.md), Joker provides several built-in namespaces, such as `joker.core`, `joker.math`, `joker.string`, and so on.
+As explained in [the `README.md file`](README.md), Joker provides several built-in namespaces, such as `joker.core`, `joker.math`, `joker.string`, and so on.
 
 All necessary support for these namespaces is included in the Joker executable, so their source code needn't be distributed nor deployed along with Joker. This allows Joker to be deployed as a stand-alone executable.
 


### PR DESCRIPTION
New Joker fan here! Been having a great time migrating all my old bash junk to joker this week 😍 

The current links out of DEVELOPER to LIBRARIES and README 404 when reading the developer instructions from GitHub.

The new ones use relative links instead of absolute links; they now resolves to the actual hosted page at e.g. https://github.com/candid82/joker/blob/master/LIBRARIES.md and should also work within branches if browsing non-`master` branches.