### PR TITLE
Rename/refactor the Ensure/Assert functions

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -360,7 +360,7 @@ initialized to a global Clojure namespace with `NSFULLNAME`
 to the set `joker.core/*loaded-libs*`:
 
 ```Go
-var fooNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.foo"))
+var fooNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.foo"))
 ```
 
 `a_foo.go` finishes with:

--- a/core/channel.go
+++ b/core/channel.go
@@ -51,7 +51,7 @@ func MakeChannel(ch chan FutureResult) *Channel {
 }
 
 func ExtractChannel(args []Object, index int) *Channel {
-	return EnsureChannel(args, index)
+	return EnsureArgIsChannel(args, index)
 }
 
 func (ch *Channel) Close() {

--- a/core/environment.go
+++ b/core/environment.go
@@ -121,7 +121,7 @@ func (env *Env) SetCurrentNamespace(ns *Namespace) {
 	env.ns.Value = ns
 }
 
-func (env *Env) EnsureObjectIsNamespace(sym Symbol) *Namespace {
+func (env *Env) EnsureSymbolIsNamespace(sym Symbol) *Namespace {
 	if sym.ns != nil {
 		panic(RT.NewError("Namespace's name cannot be qualified: " + sym.ToString(false)))
 	}
@@ -132,7 +132,7 @@ func (env *Env) EnsureObjectIsNamespace(sym Symbol) *Namespace {
 }
 
 func (env *Env) EnsureLib(sym Symbol) *Namespace {
-	ns := env.EnsureObjectIsNamespace(sym)
+	ns := env.EnsureSymbolIsNamespace(sym)
 	env.libs.Value.(*MapSet).Add(sym)
 	return ns
 }
@@ -239,5 +239,5 @@ func (env *Env) ResolveSymbol(s Symbol) Symbol {
 }
 
 func init() {
-	GLOBAL_ENV.SetCurrentNamespace(GLOBAL_ENV.EnsureObjectIsNamespace(MakeSymbol("user")))
+	GLOBAL_ENV.SetCurrentNamespace(GLOBAL_ENV.EnsureSymbolIsNamespace(MakeSymbol("user")))
 }

--- a/core/environment.go
+++ b/core/environment.go
@@ -114,14 +114,14 @@ func (env *Env) IsStdIn(obj Object) bool {
 }
 
 func (env *Env) CurrentNamespace() *Namespace {
-	return AssertNamespace(env.ns.Value, "")
+	return EnsureObjectIsNamespace(env.ns.Value, "")
 }
 
 func (env *Env) SetCurrentNamespace(ns *Namespace) {
 	env.ns.Value = ns
 }
 
-func (env *Env) EnsureNamespace(sym Symbol) *Namespace {
+func (env *Env) EnsureObjectIsNamespace(sym Symbol) *Namespace {
 	if sym.ns != nil {
 		panic(RT.NewError("Namespace's name cannot be qualified: " + sym.ToString(false)))
 	}
@@ -132,7 +132,7 @@ func (env *Env) EnsureNamespace(sym Symbol) *Namespace {
 }
 
 func (env *Env) EnsureLib(sym Symbol) *Namespace {
-	ns := env.EnsureNamespace(sym)
+	ns := env.EnsureObjectIsNamespace(sym)
 	env.libs.Value.(*MapSet).Add(sym)
 	return ns
 }
@@ -239,5 +239,5 @@ func (env *Env) ResolveSymbol(s Symbol) Symbol {
 }
 
 func init() {
-	GLOBAL_ENV.SetCurrentNamespace(GLOBAL_ENV.EnsureNamespace(MakeSymbol("user")))
+	GLOBAL_ENV.SetCurrentNamespace(GLOBAL_ENV.EnsureObjectIsNamespace(MakeSymbol("user")))
 }

--- a/core/environment.go
+++ b/core/environment.go
@@ -131,7 +131,7 @@ func (env *Env) EnsureSymbolIsNamespace(sym Symbol) *Namespace {
 	return env.Namespaces[sym.name]
 }
 
-func (env *Env) EnsureLib(sym Symbol) *Namespace {
+func (env *Env) EnsureSymbolIsLib(sym Symbol) *Namespace {
 	ns := env.EnsureSymbolIsNamespace(sym)
 	env.libs.Value.(*MapSet).Add(sym)
 	return ns

--- a/core/environment_slow_init.go
+++ b/core/environment_slow_init.go
@@ -14,7 +14,7 @@ func NewEnv() *Env {
 		Namespaces: make(map[*string]*Namespace),
 		Features:   features,
 	}
-	res.CoreNamespace = res.EnsureObjectIsNamespace(SYMBOLS.joker_core)
+	res.CoreNamespace = res.EnsureSymbolIsNamespace(SYMBOLS.joker_core)
 	res.CoreNamespace.meta = MakeMeta(nil, "Core library of Joker.", "1.0")
 	res.NS_VAR = res.CoreNamespace.Intern(MakeSymbol("ns"))
 	res.IN_NS_VAR = res.CoreNamespace.Intern(MakeSymbol("in-ns"))

--- a/core/environment_slow_init.go
+++ b/core/environment_slow_init.go
@@ -14,7 +14,7 @@ func NewEnv() *Env {
 		Namespaces: make(map[*string]*Namespace),
 		Features:   features,
 	}
-	res.CoreNamespace = res.EnsureNamespace(SYMBOLS.joker_core)
+	res.CoreNamespace = res.EnsureObjectIsNamespace(SYMBOLS.joker_core)
 	res.CoreNamespace.meta = MakeMeta(nil, "Core library of Joker.", "1.0")
 	res.NS_VAR = res.CoreNamespace.Intern(MakeSymbol("ns"))
 	res.IN_NS_VAR = res.CoreNamespace.Intern(MakeSymbol("in-ns"))

--- a/core/file.go
+++ b/core/file.go
@@ -45,5 +45,5 @@ func MakeFile(f *os.File) *File {
 }
 
 func ExtractFile(args []Object, index int) *File {
-	return EnsureFile(args, index)
+	return EnsureArgIsFile(args, index)
 }

--- a/core/gen/gen_types.go
+++ b/core/gen/gen_types.go
@@ -27,22 +27,23 @@ import (
 )
 `
 
-var assertTemplate string = `
-func Assert{{.Name}}(obj Object, msg string) {{.TypeName}} {
+var ensureObjectIsTemplate string = `
+func EnsureObjectIs{{.Name}}(obj Object, pattern string) {{.TypeName}} {
 	switch c := obj.(type) {
 	case {{.TypeName}}:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "{{.ShowName}}", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "{{.ShowName}}", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 `
 
-var ensureTemplate string = `
-func Ensure{{.Name}}(args []Object, index int) {{.TypeName}} {
+var ensureArgIsTemplate string = `
+func EnsureArgIs{{.Name}}(args []Object, index int) {{.TypeName}} {
 	switch c := args[index].(type) {
 	case {{.TypeName}}:
 		return c
@@ -71,8 +72,8 @@ func generateAssertions(types []string) {
 	checkError(err)
 	defer f.Close()
 
-	var assert = template.Must(template.New("assert").Parse(assertTemplate))
-	var ensure = template.Must(template.New("ensure").Parse(ensureTemplate))
+	var ensureObjectIs = template.Must(template.New("assert").Parse(ensureObjectIsTemplate))
+	var ensureArgIs = template.Must(template.New("ensure").Parse(ensureArgIsTemplate))
 	f.WriteString(header)
 	f.WriteString(importFmt)
 	for _, t := range types {
@@ -87,8 +88,8 @@ func generateAssertions(types []string) {
 		} else if strings.ContainsRune(t, '.') {
 			typeInfo.Name = strings.ReplaceAll(t, ".", "_")
 		}
-		assert.Execute(f, typeInfo)
-		ensure.Execute(f, typeInfo)
+		ensureObjectIs.Execute(f, typeInfo)
+		ensureArgIs.Execute(f, typeInfo)
 	}
 }
 

--- a/core/object.go
+++ b/core/object.go
@@ -735,12 +735,12 @@ func compare(c Callable, a, b Object) int {
 		if r.B {
 			return -1
 		}
-		if AssertBoolean(c.Call([]Object{b, a}), "").B {
+		if EnsureObjectIsBoolean(c.Call([]Object{b, a}), "").B {
 			return 1
 		}
 		return 0
 	default:
-		return AssertNumber(r, "Function is not a comparator since it returned a non-integer value").Int().I
+		return EnsureObjectIsNumber(r, "Function is not a comparator since it returned a non-integer value%.s").Int().I
 	}
 }
 
@@ -802,7 +802,7 @@ func AlterMeta(m *MetaHolder, fn *Fn, args []Object) Map {
 		meta = NIL
 	}
 	fargs := append([]Object{meta}, args...)
-	m.meta = AssertMap(fn.Call(fargs), "")
+	m.meta = EnsureObjectIsMap(fn.Call(fargs), "")
 	return m.meta
 }
 
@@ -857,7 +857,7 @@ func (v *Var) Resolve() Object {
 
 func (v *Var) Call(args []Object) Object {
 	vl := v.Resolve()
-	return AssertCallable(
+	return EnsureObjectIsCallable(
 		vl,
 		"Var "+v.ToString(false)+" resolves to "+vl.ToString(false)+", which is not a Fn").Call(args)
 }
@@ -968,7 +968,7 @@ func (rat *Ratio) Hash() uint32 {
 }
 
 func (rat *Ratio) Compare(other Object) int {
-	return CompareNumbers(rat, AssertNumber(other, "Cannot compare Ratio and "+other.GetType().ToString(false)))
+	return CompareNumbers(rat, EnsureObjectIsNumber(other, "Cannot compare Ratio: %s"))
 }
 
 func MakeBigInt(bi int64) *BigInt {
@@ -992,7 +992,7 @@ func (bi *BigInt) Hash() uint32 {
 }
 
 func (bi *BigInt) Compare(other Object) int {
-	return CompareNumbers(bi, AssertNumber(other, "Cannot compare BigInt and "+other.GetType().ToString(false)))
+	return CompareNumbers(bi, EnsureObjectIsNumber(other, "Cannot compare BigInt: %s"))
 }
 
 func (bf *BigFloat) ToString(escape bool) string {
@@ -1019,7 +1019,7 @@ func (bf *BigFloat) Hash() uint32 {
 }
 
 func (bf *BigFloat) Compare(other Object) int {
-	return CompareNumbers(bf, AssertNumber(other, "Cannot compare BigFloat and "+other.GetType().ToString(false)))
+	return CompareNumbers(bf, EnsureObjectIsNumber(other, "Cannot compare BigFloat: %s"))
 }
 
 func (c Char) ToString(escape bool) string {
@@ -1053,7 +1053,7 @@ func (c Char) Hash() uint32 {
 }
 
 func (c Char) Compare(other Object) int {
-	c2 := AssertChar(other, "Cannot compare Char and "+other.GetType().ToString(false))
+	c2 := EnsureObjectIsChar(other, "Cannot compare Char: %s")
 	if c.Ch < c2.Ch {
 		return -1
 	}
@@ -1117,7 +1117,7 @@ func (d Double) Hash() uint32 {
 }
 
 func (d Double) Compare(other Object) int {
-	return CompareNumbers(d, AssertNumber(other, "Cannot compare Double and "+other.GetType().ToString(false)))
+	return CompareNumbers(d, EnsureObjectIsNumber(other, "Cannot compare Double: %s"))
 }
 
 func (i Int) ToString(escape bool) string {
@@ -1149,7 +1149,7 @@ func (i Int) Hash() uint32 {
 }
 
 func (i Int) Compare(other Object) int {
-	return CompareNumbers(i, AssertNumber(other, "Cannot compare Int and "+other.GetType().ToString(false)))
+	return CompareNumbers(i, EnsureObjectIsNumber(other, "Cannot compare Int: %s"))
 }
 
 func (b Boolean) ToString(escape bool) string {
@@ -1186,7 +1186,7 @@ func (b Boolean) Hash() uint32 {
 }
 
 func (b Boolean) Compare(other Object) int {
-	b2 := AssertBoolean(other, "Cannot compare Boolean and "+other.GetType().ToString(false))
+	b2 := EnsureObjectIsBoolean(other, "Cannot compare Boolean and "+other.GetType().ToString(false))
 	if b.B == b2.B {
 		return 0
 	}
@@ -1222,7 +1222,7 @@ func (t Time) Hash() uint32 {
 }
 
 func (t Time) Compare(other Object) int {
-	t2 := AssertTime(other, "Cannot compare Time and "+other.GetType().ToString(false))
+	t2 := EnsureObjectIsTime(other, "Cannot compare Time: %s")
 	if t.T.Equal(t2.T) {
 		return 0
 	}
@@ -1268,7 +1268,7 @@ func (k Keyword) Hash() uint32 {
 }
 
 func (k Keyword) Compare(other Object) int {
-	k2 := AssertKeyword(other, "Cannot compare Keyword and "+other.GetType().ToString(false))
+	k2 := EnsureObjectIsKeyword(other, "Cannot compare Keyword: %s")
 	return strings.Compare(k.ToString(false), k2.ToString(false))
 }
 
@@ -1344,7 +1344,7 @@ func (s Symbol) Hash() uint32 {
 }
 
 func (s Symbol) Compare(other Object) int {
-	s2 := AssertSymbol(other, "Cannot compare Symbol and "+other.GetType().ToString(false))
+	s2 := EnsureObjectIsSymbol(other, "Cannot compare Symbol: %s")
 	return strings.Compare(s.ToString(false), s2.ToString(false))
 }
 
@@ -1457,7 +1457,7 @@ func (s String) TryNth(i int, d Object) Object {
 }
 
 func (s String) Compare(other Object) int {
-	s2 := AssertString(other, "Cannot compare String and "+other.GetType().ToString(false))
+	s2 := EnsureObjectIsString(other, "Cannot compare String: %s")
 	return strings.Compare(s.S, s2.S)
 }
 

--- a/core/procs.go
+++ b/core/procs.go
@@ -49,7 +49,7 @@ const (
 )
 
 func ExtractCallable(args []Object, index int) Callable {
-	return EnsureCallable(args, index)
+	return EnsureArgIsCallable(args, index)
 }
 
 func ExtractObject(args []Object, index int) Object {
@@ -57,27 +57,27 @@ func ExtractObject(args []Object, index int) Object {
 }
 
 func ExtractString(args []Object, index int) string {
-	return EnsureString(args, index).S
+	return EnsureArgIsString(args, index).S
 }
 
 func ExtractKeyword(args []Object, index int) string {
-	return EnsureKeyword(args, index).ToString(false)
+	return EnsureArgIsKeyword(args, index).ToString(false)
 }
 
 func ExtractStringable(args []Object, index int) string {
-	return EnsureStringable(args, index).S
+	return EnsureArgIsStringable(args, index).S
 }
 
 func ExtractStrings(args []Object, index int) []string {
 	strs := make([]string, 0)
 	for i := index; i < len(args); i++ {
-		strs = append(strs, EnsureString(args, i).S)
+		strs = append(strs, EnsureArgIsString(args, i).S)
 	}
 	return strs
 }
 
 func ExtractInt(args []Object, index int) int {
-	return EnsureInt(args, index).I
+	return EnsureArgIsInt(args, index).I
 }
 
 func ExtractInteger(args []Object, index int) int {
@@ -90,43 +90,43 @@ func ExtractInteger(args []Object, index int) int {
 }
 
 func ExtractBoolean(args []Object, index int) bool {
-	return EnsureBoolean(args, index).B
+	return EnsureArgIsBoolean(args, index).B
 }
 
 func ExtractChar(args []Object, index int) rune {
-	return EnsureChar(args, index).Ch
+	return EnsureArgIsChar(args, index).Ch
 }
 
 func ExtractTime(args []Object, index int) time.Time {
-	return EnsureTime(args, index).T
+	return EnsureArgIsTime(args, index).T
 }
 
 func ExtractDouble(args []Object, index int) float64 {
-	return EnsureDouble(args, index).D
+	return EnsureArgIsDouble(args, index).D
 }
 
 func ExtractNumber(args []Object, index int) Number {
-	return EnsureNumber(args, index)
+	return EnsureArgIsNumber(args, index)
 }
 
 func ExtractRegex(args []Object, index int) *regexp.Regexp {
-	return EnsureRegex(args, index).R
+	return EnsureArgIsRegex(args, index).R
 }
 
 func ExtractSeqable(args []Object, index int) Seqable {
-	return EnsureSeqable(args, index)
+	return EnsureArgIsSeqable(args, index)
 }
 
 func ExtractMap(args []Object, index int) Map {
-	return EnsureMap(args, index)
+	return EnsureArgIsMap(args, index)
 }
 
 func ExtractIOReader(args []Object, index int) io.Reader {
-	return Ensureio_Reader(args, index)
+	return EnsureArgIsio_Reader(args, index)
 }
 
 func ExtractIOWriter(args []Object, index int) io.Writer {
-	return Ensureio_Writer(args, index)
+	return EnsureArgIsio_Writer(args, index)
 }
 
 var procMeta = func(args []Object) Object {
@@ -148,55 +148,55 @@ var procMeta = func(args []Object) Object {
 
 var procWithMeta = func(args []Object) Object {
 	CheckArity(args, 2, 2)
-	m := EnsureMeta(args, 0)
+	m := EnsureArgIsMeta(args, 0)
 	if args[1].Equals(NIL) {
 		return args[0]
 	}
-	return m.WithMeta(EnsureMap(args, 1))
+	return m.WithMeta(EnsureArgIsMap(args, 1))
 }
 
 var procIsZero = func(args []Object) Object {
-	n := EnsureNumber(args, 0)
+	n := EnsureArgIsNumber(args, 0)
 	ops := GetOps(n)
 	return Boolean{B: ops.IsZero(n)}
 }
 
 var procIsPos = func(args []Object) Object {
-	n := EnsureNumber(args, 0)
+	n := EnsureArgIsNumber(args, 0)
 	ops := GetOps(n)
 	return Boolean{B: ops.Gt(n, Int{I: 0})}
 }
 
 var procIsNeg = func(args []Object) Object {
-	n := EnsureNumber(args, 0)
+	n := EnsureArgIsNumber(args, 0)
 	ops := GetOps(n)
 	return Boolean{B: ops.Lt(n, Int{I: 0})}
 }
 
 var procAdd = func(args []Object) Object {
-	x := AssertNumber(args[0], "")
-	y := AssertNumber(args[1], "")
+	x := EnsureObjectIsNumber(args[0], "")
+	y := EnsureObjectIsNumber(args[1], "")
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Add(x, y)
 }
 
 var procAddEx = func(args []Object) Object {
-	x := AssertNumber(args[0], "")
-	y := AssertNumber(args[1], "")
+	x := EnsureObjectIsNumber(args[0], "")
+	y := EnsureObjectIsNumber(args[1], "")
 	ops := GetOps(x).Combine(GetOps(y)).Combine(BIGINT_OPS)
 	return ops.Add(x, y)
 }
 
 var procMultiply = func(args []Object) Object {
-	x := AssertNumber(args[0], "")
-	y := AssertNumber(args[1], "")
+	x := EnsureObjectIsNumber(args[0], "")
+	y := EnsureObjectIsNumber(args[1], "")
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Multiply(x, y)
 }
 
 var procMultiplyEx = func(args []Object) Object {
-	x := AssertNumber(args[0], "")
-	y := AssertNumber(args[1], "")
+	x := EnsureObjectIsNumber(args[0], "")
+	y := EnsureObjectIsNumber(args[1], "")
 	ops := GetOps(x).Combine(GetOps(y)).Combine(BIGINT_OPS)
 	return ops.Multiply(x, y)
 }
@@ -211,7 +211,7 @@ var procSubtract = func(args []Object) Object {
 		b = args[1]
 	}
 	ops := GetOps(a).Combine(GetOps(b))
-	return ops.Subtract(AssertNumber(a, ""), AssertNumber(b, ""))
+	return ops.Subtract(EnsureObjectIsNumber(a, ""), EnsureObjectIsNumber(b, ""))
 }
 
 var procSubtractEx = func(args []Object) Object {
@@ -224,93 +224,93 @@ var procSubtractEx = func(args []Object) Object {
 		b = args[1]
 	}
 	ops := GetOps(a).Combine(GetOps(b)).Combine(BIGINT_OPS)
-	return ops.Subtract(AssertNumber(a, ""), AssertNumber(b, ""))
+	return ops.Subtract(EnsureObjectIsNumber(a, ""), EnsureObjectIsNumber(b, ""))
 }
 
 var procDivide = func(args []Object) Object {
-	x := EnsureNumber(args, 0)
-	y := EnsureNumber(args, 1)
+	x := EnsureArgIsNumber(args, 0)
+	y := EnsureArgIsNumber(args, 1)
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Divide(x, y)
 }
 
 var procQuot = func(args []Object) Object {
-	x := EnsureNumber(args, 0)
-	y := EnsureNumber(args, 1)
+	x := EnsureArgIsNumber(args, 0)
+	y := EnsureArgIsNumber(args, 1)
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Quotient(x, y)
 }
 
 var procRem = func(args []Object) Object {
-	x := EnsureNumber(args, 0)
-	y := EnsureNumber(args, 1)
+	x := EnsureArgIsNumber(args, 0)
+	y := EnsureArgIsNumber(args, 1)
 	ops := GetOps(x).Combine(GetOps(y))
 	return ops.Rem(x, y)
 }
 
 var procBitNot = func(args []Object) Object {
-	x := AssertInt(args[0], "Bit operation not supported for "+args[0].GetType().ToString(false))
+	x := EnsureObjectIsInt(args[0], "Bit operation not supported for "+args[0].GetType().ToString(false))
 	return Int{I: ^x.I}
 }
 
-func AssertInts(args []Object) (Int, Int) {
-	x := AssertInt(args[0], "Bit operation not supported for "+args[0].GetType().ToString(false))
-	y := AssertInt(args[1], "Bit operation not supported for "+args[1].GetType().ToString(false))
+func EnsureObjectIsInts(args []Object) (Int, Int) {
+	x := EnsureObjectIsInt(args[0], "Bit operation not supported: %s")
+	y := EnsureObjectIsInt(args[1], "Bit operation not supported: %s")
 	return x, y
 }
 
 var procBitAnd = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I & y.I}
 }
 
 var procBitOr = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I | y.I}
 }
 
 var procBitXor = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I ^ y.I}
 }
 
 var procBitAndNot = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I &^ y.I}
 }
 
 var procBitClear = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I &^ (1 << uint(y.I))}
 }
 
 var procBitSet = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I | (1 << uint(y.I))}
 }
 
 var procBitFlip = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I ^ (1 << uint(y.I))}
 }
 
 var procBitTest = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Boolean{B: x.I&(1<<uint(y.I)) != 0}
 }
 
 var procBitShiftLeft = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I << uint(y.I)}
 }
 
 var procBitShiftRight = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: x.I >> uint(y.I)}
 }
 
 var procUnsignedBitShiftRight = func(args []Object) Object {
-	x, y := AssertInts(args)
+	x, y := EnsureObjectIsInts(args)
 	return Int{I: int(uint(x.I) >> uint(y.I))}
 }
 
@@ -319,10 +319,10 @@ var procExInfo = func(args []Object) Object {
 	res := &ExInfo{
 		rt: RT.clone(),
 	}
-	res.Add(KEYWORDS.message, EnsureString(args, 0))
-	res.Add(KEYWORDS.data, EnsureMap(args, 1))
+	res.Add(KEYWORDS.message, EnsureArgIsString(args, 0))
+	res.Add(KEYWORDS.data, EnsureArgIsMap(args, 1))
 	if len(args) == 3 {
-		res.Add(KEYWORDS.cause, EnsureError(args, 2))
+		res.Add(KEYWORDS.cause, EnsureArgIsError(args, 2))
 	}
 	return res
 }
@@ -346,7 +346,7 @@ var procExMessage = func(args []Object) Object {
 }
 
 var procRegex = func(args []Object) Object {
-	r, err := regexp.Compile(EnsureString(args, 0).S)
+	r, err := regexp.Compile(EnsureArgIsString(args, 0).S)
 	if err != nil {
 		panic(RT.NewError("Invalid regex: " + err.Error()))
 	}
@@ -376,8 +376,8 @@ func reGroups(s string, indexes []int) Object {
 }
 
 var procReSeq = func(args []Object) Object {
-	re := EnsureRegex(args, 0)
-	s := EnsureString(args, 1)
+	re := EnsureArgIsRegex(args, 0)
+	s := EnsureArgIsString(args, 1)
 	matches := re.R.FindAllStringSubmatchIndex(s.S, -1)
 	if matches == nil {
 		return NIL
@@ -390,8 +390,8 @@ var procReSeq = func(args []Object) Object {
 }
 
 var procReFind = func(args []Object) Object {
-	re := EnsureRegex(args, 0)
-	s := EnsureString(args, 1)
+	re := EnsureArgIsRegex(args, 0)
+	s := EnsureArgIsString(args, 1)
 	match := re.R.FindStringSubmatchIndex(s.S)
 	return reGroups(s.S, match)
 }
@@ -406,12 +406,12 @@ var procIsSpecialSymbol = func(args []Object) Object {
 }
 
 var procSubs = func(args []Object) Object {
-	s := EnsureString(args, 0).S
-	start := EnsureInt(args, 1).I
+	s := EnsureArgIsString(args, 0).S
+	start := EnsureArgIsInt(args, 1).I
 	slen := utf8.RuneCountInString(s)
 	end := slen
 	if len(args) > 2 {
-		end = EnsureInt(args, 2).I
+		end = EnsureArgIsInt(args, 2).I
 	}
 	if start < 0 || start > slen {
 		panic(RT.NewError(fmt.Sprintf("String index out of range: %d", start)))
@@ -423,8 +423,8 @@ var procSubs = func(args []Object) Object {
 }
 
 var procIntern = func(args []Object) Object {
-	ns := EnsureNamespace(args, 0)
-	sym := EnsureSymbol(args, 1)
+	ns := EnsureArgIsNamespace(args, 0)
+	sym := EnsureArgIsSymbol(args, 1)
 	vr := ns.Intern(sym)
 	if len(args) == 3 {
 		vr.Value = args[2]
@@ -433,8 +433,8 @@ var procIntern = func(args []Object) Object {
 }
 
 var procSetMeta = func(args []Object) Object {
-	vr := EnsureVar(args, 0)
-	meta := EnsureMap(args, 1)
+	vr := EnsureArgIsVar(args, 0)
+	meta := EnsureArgIsMap(args, 1)
 	vr.meta = meta
 	return NIL
 }
@@ -446,27 +446,27 @@ var procAtom = func(args []Object) Object {
 	if len(args) > 1 {
 		m := NewHashMap(args[1:]...)
 		if ok, v := m.Get(KEYWORDS.meta); ok {
-			res.meta = AssertMap(v, "")
+			res.meta = EnsureObjectIsMap(v, "")
 		}
 	}
 	return res
 }
 
 var procDeref = func(args []Object) Object {
-	return EnsureDeref(args, 0).Deref()
+	return EnsureArgIsDeref(args, 0).Deref()
 }
 
 var procSwap = func(args []Object) Object {
-	a := EnsureAtom(args, 0)
-	f := EnsureCallable(args, 1)
+	a := EnsureArgIsAtom(args, 0)
+	f := EnsureArgIsCallable(args, 1)
 	fargs := append([]Object{a.value}, args[2:]...)
 	a.value = f.Call(fargs)
 	return a.value
 }
 
 var procSwapVals = func(args []Object) Object {
-	a := EnsureAtom(args, 0)
-	f := EnsureCallable(args, 1)
+	a := EnsureArgIsAtom(args, 0)
+	f := EnsureArgIsCallable(args, 1)
 	fargs := append([]Object{a.value}, args[2:]...)
 	oldValue := a.value
 	a.value = f.Call(fargs)
@@ -474,27 +474,27 @@ var procSwapVals = func(args []Object) Object {
 }
 
 var procReset = func(args []Object) Object {
-	a := EnsureAtom(args, 0)
+	a := EnsureArgIsAtom(args, 0)
 	a.value = args[1]
 	return a.value
 }
 
 var procResetVals = func(args []Object) Object {
-	a := EnsureAtom(args, 0)
+	a := EnsureArgIsAtom(args, 0)
 	oldValue := a.value
 	a.value = args[1]
 	return NewVectorFrom(oldValue, a.value)
 }
 
 var procAlterMeta = func(args []Object) Object {
-	r := EnsureRef(args, 0)
-	f := EnsureFn(args, 1)
+	r := EnsureArgIsRef(args, 0)
+	f := EnsureArgIsFn(args, 1)
 	return r.AlterMeta(f, args[2:])
 }
 
 var procResetMeta = func(args []Object) Object {
-	r := EnsureRef(args, 0)
-	m := EnsureMap(args, 1)
+	r := EnsureArgIsRef(args, 0)
+	m := EnsureArgIsMap(args, 1)
 	return r.ResetMeta(m)
 }
 
@@ -508,7 +508,7 @@ var procEmpty = func(args []Object) Object {
 }
 
 var procIsBound = func(args []Object) Object {
-	vr := EnsureVar(args, 0)
+	vr := EnsureArgIsVar(args, 0)
 	return Boolean{B: vr.Value != nil}
 }
 
@@ -522,7 +522,7 @@ func toNative(obj Object) interface{} {
 }
 
 var procFormat = func(args []Object) Object {
-	s := EnsureString(args, 0)
+	s := EnsureArgIsString(args, 0)
 	objs := args[1:]
 	fargs := make([]interface{}, len(objs))
 	for i, v := range objs {
@@ -538,19 +538,19 @@ var procList = func(args []Object) Object {
 
 var procCons = func(args []Object) Object {
 	CheckArity(args, 2, 2)
-	s := EnsureSeqable(args, 1).Seq()
+	s := EnsureArgIsSeqable(args, 1).Seq()
 	return s.Cons(args[0])
 }
 
 var procFirst = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	s := EnsureSeqable(args, 0).Seq()
+	s := EnsureArgIsSeqable(args, 0).Seq()
 	return s.First()
 }
 
 var procNext = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	s := EnsureSeqable(args, 0).Seq()
+	s := EnsureArgIsSeqable(args, 0).Seq()
 	res := s.Rest()
 	if res.IsEmpty() {
 		return NIL
@@ -560,7 +560,7 @@ var procNext = func(args []Object) Object {
 
 var procRest = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	s := EnsureSeqable(args, 0).Seq()
+	s := EnsureArgIsSeqable(args, 0).Seq()
 	return s.Rest()
 }
 
@@ -577,7 +577,7 @@ var procConj = func(args []Object) Object {
 
 var procSeq = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	s := EnsureSeqable(args, 0).Seq()
+	s := EnsureArgIsSeqable(args, 0).Seq()
 	if s.IsEmpty() {
 		return NIL
 	}
@@ -586,12 +586,12 @@ var procSeq = func(args []Object) Object {
 
 var procIsInstance = func(args []Object) Object {
 	CheckArity(args, 2, 2)
-	t := EnsureType(args, 0)
+	t := EnsureArgIsType(args, 0)
 	return Boolean{B: IsInstance(t, args[1])}
 }
 
 var procAssoc = func(args []Object) Object {
-	return EnsureAssociative(args, 0).Assoc(args[1], args[2])
+	return EnsureArgIsAssociative(args, 0).Assoc(args[1], args[2])
 }
 
 var procEquals = func(args []Object) Object {
@@ -603,16 +603,16 @@ var procCount = func(args []Object) Object {
 	case Counted:
 		return Int{I: obj.Count()}
 	default:
-		s := AssertSeqable(obj, "count not supported on this type: "+obj.GetType().ToString(false))
+		s := EnsureObjectIsSeqable(obj, "count not supported on this type: %s")
 		return Int{I: SeqCount(s.Seq())}
 	}
 }
 
 var procSubvec = func(args []Object) Object {
 	// TODO: implement proper Subvector structure
-	v := EnsureVector(args, 0)
-	start := EnsureInt(args, 1).I
-	end := EnsureInt(args, 2).I
+	v := EnsureArgIsVector(args, 0)
+	start := EnsureArgIsInt(args, 1).I
+	end := EnsureArgIsInt(args, 2).I
 	if start > end {
 		panic(RT.NewError(fmt.Sprintf("subvec's start index (%d) is greater than end index (%d)", start, end)))
 	}
@@ -624,7 +624,7 @@ var procSubvec = func(args []Object) Object {
 }
 
 var procCast = func(args []Object) Object {
-	t := EnsureType(args, 0)
+	t := EnsureArgIsType(args, 0)
 	if t.reflectType.Kind() == reflect.Interface &&
 		args[1].GetType().reflectType.Implements(t.reflectType) ||
 		args[1].GetType().reflectType == t.reflectType {
@@ -634,7 +634,7 @@ var procCast = func(args []Object) Object {
 }
 
 var procVec = func(args []Object) Object {
-	return NewVectorFromSeq(EnsureSeqable(args, 0).Seq())
+	return NewVectorFromSeq(EnsureArgIsSeqable(args, 0).Seq())
 }
 
 var procHashMap = func(args []Object) Object {
@@ -671,15 +671,15 @@ var procStr = func(args []Object) Object {
 
 var procSymbol = func(args []Object) Object {
 	if len(args) == 1 {
-		return MakeSymbol(EnsureString(args, 0).S)
+		return MakeSymbol(EnsureArgIsString(args, 0).S)
 	}
 	var ns *string = nil
 	if !args[0].Equals(NIL) {
-		ns = STRINGS.Intern(EnsureString(args, 0).S)
+		ns = STRINGS.Intern(EnsureArgIsString(args, 0).S)
 	}
 	return Symbol{
 		ns:   ns,
-		name: STRINGS.Intern(EnsureString(args, 1).S),
+		name: STRINGS.Intern(EnsureArgIsString(args, 1).S),
 	}
 }
 
@@ -700,9 +700,9 @@ var procKeyword = func(args []Object) Object {
 	}
 	var ns *string = nil
 	if !args[0].Equals(NIL) {
-		ns = STRINGS.Intern(EnsureString(args, 0).S)
+		ns = STRINGS.Intern(EnsureArgIsString(args, 0).S)
 	}
-	name := STRINGS.Intern(EnsureString(args, 1).S)
+	name := STRINGS.Intern(EnsureArgIsString(args, 1).S)
 	return Keyword{
 		ns:   ns,
 		name: name,
@@ -711,15 +711,15 @@ var procKeyword = func(args []Object) Object {
 }
 
 var procGensym = func(args []Object) Object {
-	return genSym(EnsureString(args, 0).S, "")
+	return genSym(EnsureArgIsString(args, 0).S, "")
 }
 
 var procApply = func(args []Object) Object {
 	// TODO:
 	// Stacktrace is broken. Need to somehow know
 	// the name of the function passed ...
-	f := EnsureCallable(args, 0)
-	return f.Call(ToSlice(EnsureSeqable(args, 1).Seq()))
+	f := EnsureArgIsCallable(args, 0)
+	return f.Call(ToSlice(EnsureArgIsSeqable(args, 1).Seq()))
 }
 
 var procLazySeq = func(args []Object) Object {
@@ -777,11 +777,11 @@ var procInt = func(args []Object) Object {
 }
 
 var procNumber = func(args []Object) Object {
-	return AssertNumber(args[0], fmt.Sprintf("Cannot cast %s (type: %s) to Number", args[0].ToString(true), args[0].GetType().ToString(false)))
+	return EnsureObjectIsNumber(args[0], "Cannot cast "+args[0].ToString(true)+": %s")
 }
 
 var procDouble = func(args []Object) Object {
-	n := AssertNumber(args[0], fmt.Sprintf("Cannot cast %s (type: %s) to Double", args[0].ToString(true), args[0].GetType().ToString(false)))
+	n := EnsureObjectIsNumber(args[0], "Cannot cast "+args[0].ToString(true)+": %s")
 	return n.Double()
 }
 
@@ -805,12 +805,12 @@ var procBoolean = func(args []Object) Object {
 }
 
 var procNumerator = func(args []Object) Object {
-	bi := EnsureRatio(args, 0).r.Num()
+	bi := EnsureArgIsRatio(args, 0).r.Num()
 	return &BigInt{b: *bi}
 }
 
 var procDenominator = func(args []Object) Object {
-	bi := EnsureRatio(args, 0).r.Denom()
+	bi := EnsureArgIsRatio(args, 0).r.Denom()
 	return &BigInt{b: *bi}
 }
 
@@ -845,7 +845,7 @@ var procBigFloat = func(args []Object) Object {
 }
 
 var procNth = func(args []Object) Object {
-	n := EnsureNumber(args, 1).Int().I
+	n := EnsureArgIsNumber(args, 1).Int().I
 	switch coll := args[0].(type) {
 	case Indexed:
 		if len(args) == 3 {
@@ -867,78 +867,78 @@ var procNth = func(args []Object) Object {
 }
 
 var procLt = func(args []Object) Object {
-	a := AssertNumber(args[0], "")
-	b := AssertNumber(args[1], "")
+	a := EnsureObjectIsNumber(args[0], "")
+	b := EnsureObjectIsNumber(args[1], "")
 	return Boolean{B: GetOps(a).Combine(GetOps(b)).Lt(a, b)}
 }
 
 var procLte = func(args []Object) Object {
-	a := AssertNumber(args[0], "")
-	b := AssertNumber(args[1], "")
+	a := EnsureObjectIsNumber(args[0], "")
+	b := EnsureObjectIsNumber(args[1], "")
 	return Boolean{B: GetOps(a).Combine(GetOps(b)).Lte(a, b)}
 }
 
 var procGt = func(args []Object) Object {
-	a := AssertNumber(args[0], "")
-	b := AssertNumber(args[1], "")
+	a := EnsureObjectIsNumber(args[0], "")
+	b := EnsureObjectIsNumber(args[1], "")
 	return Boolean{B: GetOps(a).Combine(GetOps(b)).Gt(a, b)}
 }
 
 var procGte = func(args []Object) Object {
-	a := AssertNumber(args[0], "")
-	b := AssertNumber(args[1], "")
+	a := EnsureObjectIsNumber(args[0], "")
+	b := EnsureObjectIsNumber(args[1], "")
 	return Boolean{B: GetOps(a).Combine(GetOps(b)).Gte(a, b)}
 }
 
 var procEq = func(args []Object) Object {
-	a := AssertNumber(args[0], "")
-	b := AssertNumber(args[1], "")
+	a := EnsureObjectIsNumber(args[0], "")
+	b := EnsureObjectIsNumber(args[1], "")
 	return MakeBoolean(numbersEq(a, b))
 }
 
 var procMax = func(args []Object) Object {
-	a := AssertNumber(args[0], "")
-	b := AssertNumber(args[1], "")
+	a := EnsureObjectIsNumber(args[0], "")
+	b := EnsureObjectIsNumber(args[1], "")
 	return Max(a, b)
 }
 
 var procMin = func(args []Object) Object {
-	a := AssertNumber(args[0], "")
-	b := AssertNumber(args[1], "")
+	a := EnsureObjectIsNumber(args[0], "")
+	b := EnsureObjectIsNumber(args[1], "")
 	return Min(a, b)
 }
 
 var procIncEx = func(args []Object) Object {
-	x := EnsureNumber(args, 0)
+	x := EnsureArgIsNumber(args, 0)
 	ops := GetOps(x).Combine(BIGINT_OPS)
 	return ops.Add(x, Int{I: 1})
 }
 
 var procDecEx = func(args []Object) Object {
-	x := EnsureNumber(args, 0)
+	x := EnsureArgIsNumber(args, 0)
 	ops := GetOps(x).Combine(BIGINT_OPS)
 	return ops.Subtract(x, Int{I: 1})
 }
 
 var procInc = func(args []Object) Object {
-	x := EnsureNumber(args, 0)
+	x := EnsureArgIsNumber(args, 0)
 	ops := GetOps(x).Combine(INT_OPS)
 	return ops.Add(x, Int{I: 1})
 }
 
 var procDec = func(args []Object) Object {
-	x := EnsureNumber(args, 0)
+	x := EnsureArgIsNumber(args, 0)
 	ops := GetOps(x).Combine(INT_OPS)
 	return ops.Subtract(x, Int{I: 1})
 }
 
 var procPeek = func(args []Object) Object {
-	s := AssertStack(args[0], "")
+	s := EnsureObjectIsStack(args[0], "")
 	return s.Peek()
 }
 
 var procPop = func(args []Object) Object {
-	s := AssertStack(args[0], "")
+	s := EnsureObjectIsStack(args[0], "")
 	return s.Pop().(Object)
 }
 
@@ -969,15 +969,15 @@ var procGet = func(args []Object) Object {
 }
 
 var procDissoc = func(args []Object) Object {
-	return EnsureMap(args, 0).Without(args[1])
+	return EnsureArgIsMap(args, 0).Without(args[1])
 }
 
 var procDisj = func(args []Object) Object {
-	return EnsureSet(args, 0).Disjoin(args[1])
+	return EnsureArgIsSet(args, 0).Disjoin(args[1])
 }
 
 var procFind = func(args []Object) Object {
-	res := EnsureAssociative(args, 0).EntryAt(args[1])
+	res := EnsureArgIsAssociative(args, 0).EntryAt(args[1])
 	if res == nil {
 		return NIL
 	}
@@ -985,23 +985,23 @@ var procFind = func(args []Object) Object {
 }
 
 var procKeys = func(args []Object) Object {
-	return EnsureMap(args, 0).Keys()
+	return EnsureArgIsMap(args, 0).Keys()
 }
 
 var procVals = func(args []Object) Object {
-	return EnsureMap(args, 0).Vals()
+	return EnsureArgIsMap(args, 0).Vals()
 }
 
 var procRseq = func(args []Object) Object {
-	return EnsureReversible(args, 0).Rseq()
+	return EnsureArgIsReversible(args, 0).Rseq()
 }
 
 var procName = func(args []Object) Object {
-	return String{S: EnsureNamed(args, 0).Name()}
+	return String{S: EnsureArgIsNamed(args, 0).Name()}
 }
 
 var procNamespace = func(args []Object) Object {
-	ns := EnsureNamed(args, 0).Namespace()
+	ns := EnsureArgIsNamed(args, 0).Namespace()
 	if ns == "" {
 		return NIL
 	}
@@ -1009,7 +1009,7 @@ var procNamespace = func(args []Object) Object {
 }
 
 var procFindVar = func(args []Object) Object {
-	sym := EnsureSymbol(args, 0)
+	sym := EnsureArgIsSymbol(args, 0)
 	if sym.ns == nil {
 		panic(RT.NewError("find-var argument must be namespace-qualified symbol"))
 	}
@@ -1020,8 +1020,8 @@ var procFindVar = func(args []Object) Object {
 }
 
 var procSort = func(args []Object) Object {
-	cmp := EnsureComparator(args, 0)
-	coll := EnsureSeqable(args, 1)
+	cmp := EnsureArgIsComparator(args, 0)
+	coll := EnsureArgIsSeqable(args, 1)
 	s := SortableSlice{
 		s:   ToSlice(coll.Seq()),
 		cmp: cmp,
@@ -1042,7 +1042,7 @@ var procType = func(args []Object) Object {
 
 var procPprint = func(args []Object) Object {
 	obj := args[0]
-	w := Assertio_Writer(GLOBAL_ENV.stdout.Value, "")
+	w := EnsureObjectIsio_Writer(GLOBAL_ENV.stdout.Value, "")
 	pprintObject(obj, 0, w)
 	fmt.Fprint(w, "\n")
 	return NIL
@@ -1061,7 +1061,7 @@ func PrintObject(obj Object, w io.Writer) {
 var procPr = func(args []Object) Object {
 	n := len(args)
 	if n > 0 {
-		f := Assertio_Writer(GLOBAL_ENV.stdout.Value, "")
+		f := EnsureObjectIsio_Writer(GLOBAL_ENV.stdout.Value, "")
 		for _, arg := range args[:n-1] {
 			PrintObject(arg, f)
 			fmt.Fprint(f, " ")
@@ -1072,7 +1072,7 @@ var procPr = func(args []Object) Object {
 }
 
 var procNewline = func(args []Object) Object {
-	f := Assertio_Writer(GLOBAL_ENV.stdout.Value, "")
+	f := EnsureObjectIsio_Writer(GLOBAL_ENV.stdout.Value, "")
 	fmt.Fprintln(f)
 	return NIL
 }
@@ -1093,13 +1093,13 @@ func readFromReader(reader io.RuneReader) Object {
 }
 
 var procRead = func(args []Object) Object {
-	f := Ensureio_RuneReader(args, 0)
+	f := EnsureArgIsio_RuneReader(args, 0)
 	return readFromReader(f)
 }
 
 var procReadString = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	return readFromReader(strings.NewReader(EnsureString(args, 0).S))
+	return readFromReader(strings.NewReader(EnsureArgIsString(args, 0).S))
 }
 
 func readLine(r StringReader) (s string, e error) {
@@ -1121,7 +1121,7 @@ func readLine(r StringReader) (s string, e error) {
 
 var procReadLine = func(args []Object) Object {
 	CheckArity(args, 0, 0)
-	f := AssertStringReader(GLOBAL_ENV.stdin.Value, "")
+	f := EnsureObjectIsStringReader(GLOBAL_ENV.stdin.Value, "")
 	line, err := readLine(f)
 	if err != nil {
 		return NIL
@@ -1131,7 +1131,7 @@ var procReadLine = func(args []Object) Object {
 
 var procReaderReadLine = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	rdr := EnsureStringReader(args, 0)
+	rdr := EnsureArgIsStringReader(args, 0)
 	line, err := readLine(rdr)
 	if err != nil {
 		return NIL
@@ -1176,7 +1176,7 @@ func loadReader(reader *Reader) (Object, error) {
 }
 
 var procLoadString = func(args []Object) Object {
-	s := EnsureString(args, 0)
+	s := EnsureArgIsString(args, 0)
 	obj, err := loadReader(NewReader(strings.NewReader(s.S), "<string>"))
 	if err != nil {
 		panic(err)
@@ -1185,7 +1185,7 @@ var procLoadString = func(args []Object) Object {
 }
 
 var procFindNamespace = func(args []Object) Object {
-	ns := GLOBAL_ENV.FindNamespace(EnsureSymbol(args, 0))
+	ns := GLOBAL_ENV.FindNamespace(EnsureArgIsSymbol(args, 0))
 	if ns == nil {
 		return NIL
 	}
@@ -1193,8 +1193,8 @@ var procFindNamespace = func(args []Object) Object {
 }
 
 var procCreateNamespace = func(args []Object) Object {
-	sym := EnsureSymbol(args, 0)
-	res := GLOBAL_ENV.EnsureNamespace(sym)
+	sym := EnsureArgIsSymbol(args, 0)
+	res := GLOBAL_ENV.EnsureObjectIsNamespace(sym)
 	// In linter mode the latest create-ns call overrides position info.
 	// This is for the cases when (ns ...) is called in .jokerd/linter.clj file and alike.
 	// Also, isUsed needs to be reset in this case.
@@ -1206,15 +1206,15 @@ var procCreateNamespace = func(args []Object) Object {
 }
 
 var procInjectNamespace = func(args []Object) Object {
-	sym := EnsureSymbol(args, 0)
-	ns := GLOBAL_ENV.EnsureNamespace(sym)
+	sym := EnsureArgIsSymbol(args, 0)
+	ns := GLOBAL_ENV.EnsureObjectIsNamespace(sym)
 	ns.isUsed = true
 	ns.isGloballyUsed = true
 	return ns
 }
 
 var procRemoveNamespace = func(args []Object) Object {
-	ns := GLOBAL_ENV.RemoveNamespace(EnsureSymbol(args, 0))
+	ns := GLOBAL_ENV.RemoveNamespace(EnsureArgIsSymbol(args, 0))
 	if ns == nil {
 		return NIL
 	}
@@ -1230,20 +1230,20 @@ var procAllNamespaces = func(args []Object) Object {
 }
 
 var procNamespaceName = func(args []Object) Object {
-	return EnsureNamespace(args, 0).Name
+	return EnsureArgIsNamespace(args, 0).Name
 }
 
 var procNamespaceMap = func(args []Object) Object {
 	r := &ArrayMap{}
-	for k, v := range EnsureNamespace(args, 0).mappings {
+	for k, v := range EnsureArgIsNamespace(args, 0).mappings {
 		r.Add(MakeSymbol(*k), v)
 	}
 	return r
 }
 
 var procNamespaceUnmap = func(args []Object) Object {
-	ns := EnsureNamespace(args, 0)
-	sym := EnsureSymbol(args, 1)
+	ns := EnsureArgIsNamespace(args, 0)
+	sym := EnsureArgIsSymbol(args, 1)
 	if sym.ns != nil {
 		panic(RT.NewError("Can't unintern namespace-qualified symbol"))
 	}
@@ -1252,33 +1252,33 @@ var procNamespaceUnmap = func(args []Object) Object {
 }
 
 var procVarNamespace = func(args []Object) Object {
-	v := EnsureVar(args, 0)
+	v := EnsureArgIsVar(args, 0)
 	return v.ns
 }
 
 var procRefer = func(args []Object) Object {
-	ns := EnsureNamespace(args, 0)
-	sym := EnsureSymbol(args, 1)
-	v := EnsureVar(args, 2)
+	ns := EnsureArgIsNamespace(args, 0)
+	sym := EnsureArgIsSymbol(args, 1)
+	v := EnsureArgIsVar(args, 2)
 	return ns.Refer(sym, v)
 }
 
 var procAlias = func(args []Object) Object {
-	EnsureNamespace(args, 0).AddAlias(EnsureSymbol(args, 1), EnsureNamespace(args, 2))
+	EnsureArgIsNamespace(args, 0).AddAlias(EnsureArgIsSymbol(args, 1), EnsureArgIsNamespace(args, 2))
 	return NIL
 }
 
 var procNamespaceAliases = func(args []Object) Object {
 	r := &ArrayMap{}
-	for k, v := range EnsureNamespace(args, 0).aliases {
+	for k, v := range EnsureArgIsNamespace(args, 0).aliases {
 		r.Add(MakeSymbol(*k), v)
 	}
 	return r
 }
 
 var procNamespaceUnalias = func(args []Object) Object {
-	ns := EnsureNamespace(args, 0)
-	sym := EnsureSymbol(args, 1)
+	ns := EnsureArgIsNamespace(args, 0)
+	sym := EnsureArgIsSymbol(args, 1)
 	if sym.ns != nil {
 		panic(RT.NewError("Alias can't be namespace-qualified"))
 	}
@@ -1287,17 +1287,17 @@ var procNamespaceUnalias = func(args []Object) Object {
 }
 
 var procVarGet = func(args []Object) Object {
-	return EnsureVar(args, 0).Resolve()
+	return EnsureArgIsVar(args, 0).Resolve()
 }
 
 var procVarSet = func(args []Object) Object {
-	EnsureVar(args, 0).Value = args[1]
+	EnsureArgIsVar(args, 0).Value = args[1]
 	return args[1]
 }
 
 var procNsResolve = func(args []Object) Object {
-	ns := EnsureNamespace(args, 0)
-	sym := EnsureSymbol(args, 1)
+	ns := EnsureArgIsNamespace(args, 0)
+	sym := EnsureArgIsSymbol(args, 1)
 	if sym.ns == nil && TYPES[sym.name] != nil {
 		return TYPES[sym.name]
 	}
@@ -1322,7 +1322,7 @@ const bufferHashMask uint32 = 0x5ed19e84
 
 var procBuffer = func(args []Object) Object {
 	if len(args) > 0 {
-		s := EnsureString(args, 0)
+		s := EnsureArgIsString(args, 0)
 		return MakeBuffer(bytes.NewBufferString(s.S))
 	}
 	return MakeBuffer(&bytes.Buffer{})
@@ -1355,7 +1355,7 @@ var procSlurp = func(args []Object) Object {
 var procSpit = func(args []Object) Object {
 	f := args[0]
 	content := args[1]
-	opts := EnsureMap(args, 2)
+	opts := EnsureArgIsMap(args, 2)
 	appendFile := false
 	if ok, append := opts.Get(MakeKeyword("append")); ok {
 		appendFile = ToBool(append)
@@ -1383,7 +1383,7 @@ var procSpit = func(args []Object) Object {
 }
 
 var procShuffle = func(args []Object) Object {
-	s := ToSlice(EnsureSeqable(args, 0).Seq())
+	s := ToSlice(EnsureArgIsSeqable(args, 0).Seq())
 	for i := range s {
 		j := rand.Intn(i + 1)
 		s[i], s[j] = s[j], s[i]
@@ -1392,7 +1392,7 @@ var procShuffle = func(args []Object) Object {
 }
 
 var procIsRealized = func(args []Object) Object {
-	return Boolean{B: EnsurePending(args, 0).IsRealized()}
+	return Boolean{B: EnsureArgIsPending(args, 0).IsRealized()}
 }
 
 var procDeriveInfo = func(args []Object) Object {
@@ -1419,15 +1419,15 @@ func loadFile(filename string) Object {
 }
 
 var procLoadFile = func(args []Object) Object {
-	filename := EnsureString(args, 0)
+	filename := EnsureArgIsString(args, 0)
 	return loadFile(filename.S)
 }
 
 var procLoadLibFromPath = func(args []Object) Object {
-	libname := EnsureSymbol(args, 0).Name()
-	pathname := EnsureString(args, 1).S
+	libname := EnsureArgIsSymbol(args, 0).Name()
+	pathname := EnsureArgIsString(args, 1).S
 	cp := GLOBAL_ENV.classPath.Value
-	cpvec := AssertVector(cp, "*classpath* must be a Vector, not a "+cp.GetType().ToString(false))
+	cpvec := EnsureObjectIsVector(cp, "*classpath*: %s")
 	count := cpvec.Count()
 	var f *os.File
 	var err error
@@ -1435,7 +1435,7 @@ var procLoadLibFromPath = func(args []Object) Object {
 	var filename string
 	for i := 0; i < count; i++ {
 		elem := cpvec.at(i)
-		cpelem := AssertString(elem, "*classpath* must contain only Strings, not a "+elem.GetType().ToString(false)+" (at element "+strconv.Itoa(i)+")")
+		cpelem := EnsureObjectIsString(elem, "*classpath*["+strconv.Itoa(i)+"]: %s")
 		s := cpelem.S
 		if s == "" {
 			filename = pathname
@@ -1459,15 +1459,15 @@ var procLoadLibFromPath = func(args []Object) Object {
 }
 
 var procReduceKv = func(args []Object) Object {
-	f := EnsureCallable(args, 0)
+	f := EnsureArgIsCallable(args, 0)
 	init := args[1]
-	coll := EnsureKVReduce(args, 2)
+	coll := EnsureArgIsKVReduce(args, 2)
 	return coll.kvreduce(f, init)
 }
 
 var procIndexOf = func(args []Object) Object {
-	s := EnsureString(args, 0)
-	ch := EnsureChar(args, 1)
+	s := EnsureArgIsString(args, 0)
+	ch := EnsureArgIsChar(args, 1)
 	for i, r := range s.S {
 		if r == ch.Ch {
 			return Int{I: i}
@@ -1502,7 +1502,7 @@ func libExternalPath(sym Symbol) (path string, ok bool) {
 }
 
 var procLibPath = func(args []Object) Object {
-	sym := EnsureSymbol(args, 0)
+	sym := EnsureArgIsSymbol(args, 0)
 	var path string
 
 	path, ok := libExternalPath(sym)
@@ -1514,7 +1514,7 @@ var procLibPath = func(args []Object) Object {
 			file, err = filepath.Abs("user")
 			PanicOnErr(err)
 		} else {
-			file = AssertString(GLOBAL_ENV.file.Value, "").S
+			file = EnsureObjectIsString(GLOBAL_ENV.file.Value, "").S
 			if linkDest, err := os.Readlink(file); err == nil {
 				file = linkDest
 			}
@@ -1535,8 +1535,8 @@ var procLibPath = func(args []Object) Object {
 }
 
 var procInternFakeVar = func(args []Object) Object {
-	nsSym := EnsureSymbol(args, 0)
-	sym := EnsureSymbol(args, 1)
+	nsSym := EnsureArgIsSymbol(args, 0)
+	sym := EnsureArgIsSymbol(args, 1)
 	isMacro := ToBool(args[2])
 	res := InternFakeSymbol(GLOBAL_ENV.FindNamespace(nsSym), sym)
 	res.isMacro = isMacro
@@ -1567,20 +1567,20 @@ var procTypes = func(args []Object) Object {
 
 var procCreateChan = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	n := EnsureInt(args, 0)
+	n := EnsureArgIsInt(args, 0)
 	ch := make(chan FutureResult, n.I)
 	return MakeChannel(ch)
 }
 
 var procCloseChan = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	EnsureChannel(args, 0).Close()
+	EnsureArgIsChannel(args, 0).Close()
 	return NIL
 }
 
 var procSend = func(args []Object) (obj Object) {
 	CheckArity(args, 2, 2)
-	ch := EnsureChannel(args, 0)
+	ch := EnsureArgIsChannel(args, 0)
 	v := args[1]
 	if v.Equals(NIL) {
 		panic(RT.NewError("Can't put nil on channel"))
@@ -1603,7 +1603,7 @@ var procSend = func(args []Object) (obj Object) {
 
 var procReceive = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	ch := EnsureChannel(args, 0)
+	ch := EnsureArgIsChannel(args, 0)
 	RT.GIL.Unlock()
 	res, ok := <-ch.ch
 	RT.GIL.Lock()
@@ -1618,7 +1618,7 @@ var procReceive = func(args []Object) Object {
 
 var procGo = func(args []Object) Object {
 	CheckArity(args, 1, 1)
-	f := EnsureCallable(args, 0)
+	f := EnsureArgIsCallable(args, 0)
 	ch := MakeChannel(make(chan FutureResult, 1))
 	go func() {
 
@@ -1650,7 +1650,7 @@ var procVerbosityLevel = func(args []Object) Object {
 }
 
 var procExit = func(args []Object) Object {
-	ExitJoker(EnsureInt(args, 0).I)
+	ExitJoker(EnsureArgIsInt(args, 0).I)
 	return NIL
 }
 
@@ -1822,7 +1822,7 @@ func setCoreNamespaces() {
 }
 
 var procIsNamespaceInitialized = func(args []Object) Object {
-	sym := EnsureSymbol(args, 0)
+	sym := EnsureArgIsSymbol(args, 0)
 	if sym.ns != nil {
 		panic(RT.NewError("Can't ask for namespace info on namespace-qualified symbol"))
 	}

--- a/core/procs.go
+++ b/core/procs.go
@@ -1194,7 +1194,7 @@ var procFindNamespace = func(args []Object) Object {
 
 var procCreateNamespace = func(args []Object) Object {
 	sym := EnsureArgIsSymbol(args, 0)
-	res := GLOBAL_ENV.EnsureObjectIsNamespace(sym)
+	res := GLOBAL_ENV.EnsureSymbolIsNamespace(sym)
 	// In linter mode the latest create-ns call overrides position info.
 	// This is for the cases when (ns ...) is called in .jokerd/linter.clj file and alike.
 	// Also, isUsed needs to be reset in this case.
@@ -1207,7 +1207,7 @@ var procCreateNamespace = func(args []Object) Object {
 
 var procInjectNamespace = func(args []Object) Object {
 	sym := EnsureArgIsSymbol(args, 0)
-	ns := GLOBAL_ENV.EnsureObjectIsNamespace(sym)
+	ns := GLOBAL_ENV.EnsureSymbolIsNamespace(sym)
 	ns.isUsed = true
 	ns.isGloballyUsed = true
 	return ns

--- a/core/read.go
+++ b/core/read.go
@@ -926,7 +926,7 @@ func readTagged(reader *Reader) Object {
 		if !ok {
 			return handleNoReaderError(reader, s)
 		}
-		return AssertVar(readFunc, "").Call([]Object{readFirst(reader)})
+		return EnsureObjectIsVar(readFunc, "").Call([]Object{readFirst(reader)})
 	default:
 		panic(MakeReadError(reader, "Reader tag must be a symbol"))
 	}

--- a/core/seq.go
+++ b/core/seq.go
@@ -132,7 +132,7 @@ func (seq *LazySeq) Seq() Seq {
 
 func (seq *LazySeq) realize() {
 	if seq.seq == nil {
-		seq.seq = AssertSeqable(seq.fn.Call([]Object{}), "").Seq()
+		seq.seq = EnsureObjectIsSeqable(seq.fn.Call([]Object{}), "").Seq()
 	}
 }
 

--- a/core/stringable.go
+++ b/core/stringable.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func AssertStringable(obj Object, msg string) String {
+func EnsureObjectIsStringable(obj Object, msg string) String {
 	switch c := obj.(type) {
 	case String:
 		return c
@@ -18,7 +18,7 @@ func AssertStringable(obj Object, msg string) String {
 	}
 }
 
-func EnsureStringable(args []Object, index int) String {
+func EnsureArgIsStringable(args []Object, index int) String {
 	switch c := args[index].(type) {
 	case String:
 		return c

--- a/core/types_assert_gen.go
+++ b/core/types_assert_gen.go
@@ -7,19 +7,20 @@ import (
 	"io"
 )
 
-func AssertComparable(obj Object, msg string) Comparable {
+func EnsureObjectIsComparable(obj Object, pattern string) Comparable {
 	switch c := obj.(type) {
 	case Comparable:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Comparable", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Comparable", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureComparable(args []Object, index int) Comparable {
+func EnsureArgIsComparable(args []Object, index int) Comparable {
 	switch c := args[index].(type) {
 	case Comparable:
 		return c
@@ -28,19 +29,20 @@ func EnsureComparable(args []Object, index int) Comparable {
 	}
 }
 
-func AssertVector(obj Object, msg string) *Vector {
+func EnsureObjectIsVector(obj Object, pattern string) *Vector {
 	switch c := obj.(type) {
 	case *Vector:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Vector", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Vector", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureVector(args []Object, index int) *Vector {
+func EnsureArgIsVector(args []Object, index int) *Vector {
 	switch c := args[index].(type) {
 	case *Vector:
 		return c
@@ -49,19 +51,20 @@ func EnsureVector(args []Object, index int) *Vector {
 	}
 }
 
-func AssertChar(obj Object, msg string) Char {
+func EnsureObjectIsChar(obj Object, pattern string) Char {
 	switch c := obj.(type) {
 	case Char:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Char", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Char", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureChar(args []Object, index int) Char {
+func EnsureArgIsChar(args []Object, index int) Char {
 	switch c := args[index].(type) {
 	case Char:
 		return c
@@ -70,19 +73,20 @@ func EnsureChar(args []Object, index int) Char {
 	}
 }
 
-func AssertString(obj Object, msg string) String {
+func EnsureObjectIsString(obj Object, pattern string) String {
 	switch c := obj.(type) {
 	case String:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "String", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "String", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureString(args []Object, index int) String {
+func EnsureArgIsString(args []Object, index int) String {
 	switch c := args[index].(type) {
 	case String:
 		return c
@@ -91,19 +95,20 @@ func EnsureString(args []Object, index int) String {
 	}
 }
 
-func AssertSymbol(obj Object, msg string) Symbol {
+func EnsureObjectIsSymbol(obj Object, pattern string) Symbol {
 	switch c := obj.(type) {
 	case Symbol:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Symbol", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Symbol", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureSymbol(args []Object, index int) Symbol {
+func EnsureArgIsSymbol(args []Object, index int) Symbol {
 	switch c := args[index].(type) {
 	case Symbol:
 		return c
@@ -112,19 +117,20 @@ func EnsureSymbol(args []Object, index int) Symbol {
 	}
 }
 
-func AssertKeyword(obj Object, msg string) Keyword {
+func EnsureObjectIsKeyword(obj Object, pattern string) Keyword {
 	switch c := obj.(type) {
 	case Keyword:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Keyword", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Keyword", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureKeyword(args []Object, index int) Keyword {
+func EnsureArgIsKeyword(args []Object, index int) Keyword {
 	switch c := args[index].(type) {
 	case Keyword:
 		return c
@@ -133,19 +139,20 @@ func EnsureKeyword(args []Object, index int) Keyword {
 	}
 }
 
-func AssertRegex(obj Object, msg string) *Regex {
+func EnsureObjectIsRegex(obj Object, pattern string) *Regex {
 	switch c := obj.(type) {
 	case *Regex:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Regex", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Regex", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureRegex(args []Object, index int) *Regex {
+func EnsureArgIsRegex(args []Object, index int) *Regex {
 	switch c := args[index].(type) {
 	case *Regex:
 		return c
@@ -154,19 +161,20 @@ func EnsureRegex(args []Object, index int) *Regex {
 	}
 }
 
-func AssertBoolean(obj Object, msg string) Boolean {
+func EnsureObjectIsBoolean(obj Object, pattern string) Boolean {
 	switch c := obj.(type) {
 	case Boolean:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Boolean", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Boolean", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureBoolean(args []Object, index int) Boolean {
+func EnsureArgIsBoolean(args []Object, index int) Boolean {
 	switch c := args[index].(type) {
 	case Boolean:
 		return c
@@ -175,19 +183,20 @@ func EnsureBoolean(args []Object, index int) Boolean {
 	}
 }
 
-func AssertTime(obj Object, msg string) Time {
+func EnsureObjectIsTime(obj Object, pattern string) Time {
 	switch c := obj.(type) {
 	case Time:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Time", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Time", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureTime(args []Object, index int) Time {
+func EnsureArgIsTime(args []Object, index int) Time {
 	switch c := args[index].(type) {
 	case Time:
 		return c
@@ -196,19 +205,20 @@ func EnsureTime(args []Object, index int) Time {
 	}
 }
 
-func AssertNumber(obj Object, msg string) Number {
+func EnsureObjectIsNumber(obj Object, pattern string) Number {
 	switch c := obj.(type) {
 	case Number:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Number", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Number", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureNumber(args []Object, index int) Number {
+func EnsureArgIsNumber(args []Object, index int) Number {
 	switch c := args[index].(type) {
 	case Number:
 		return c
@@ -217,19 +227,20 @@ func EnsureNumber(args []Object, index int) Number {
 	}
 }
 
-func AssertSeqable(obj Object, msg string) Seqable {
+func EnsureObjectIsSeqable(obj Object, pattern string) Seqable {
 	switch c := obj.(type) {
 	case Seqable:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Seqable", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Seqable", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureSeqable(args []Object, index int) Seqable {
+func EnsureArgIsSeqable(args []Object, index int) Seqable {
 	switch c := args[index].(type) {
 	case Seqable:
 		return c
@@ -238,19 +249,20 @@ func EnsureSeqable(args []Object, index int) Seqable {
 	}
 }
 
-func AssertCallable(obj Object, msg string) Callable {
+func EnsureObjectIsCallable(obj Object, pattern string) Callable {
 	switch c := obj.(type) {
 	case Callable:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Callable", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Callable", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureCallable(args []Object, index int) Callable {
+func EnsureArgIsCallable(args []Object, index int) Callable {
 	switch c := args[index].(type) {
 	case Callable:
 		return c
@@ -259,19 +271,20 @@ func EnsureCallable(args []Object, index int) Callable {
 	}
 }
 
-func AssertType(obj Object, msg string) *Type {
+func EnsureObjectIsType(obj Object, pattern string) *Type {
 	switch c := obj.(type) {
 	case *Type:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Type", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Type", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureType(args []Object, index int) *Type {
+func EnsureArgIsType(args []Object, index int) *Type {
 	switch c := args[index].(type) {
 	case *Type:
 		return c
@@ -280,19 +293,20 @@ func EnsureType(args []Object, index int) *Type {
 	}
 }
 
-func AssertMeta(obj Object, msg string) Meta {
+func EnsureObjectIsMeta(obj Object, pattern string) Meta {
 	switch c := obj.(type) {
 	case Meta:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Meta", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Meta", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureMeta(args []Object, index int) Meta {
+func EnsureArgIsMeta(args []Object, index int) Meta {
 	switch c := args[index].(type) {
 	case Meta:
 		return c
@@ -301,19 +315,20 @@ func EnsureMeta(args []Object, index int) Meta {
 	}
 }
 
-func AssertInt(obj Object, msg string) Int {
+func EnsureObjectIsInt(obj Object, pattern string) Int {
 	switch c := obj.(type) {
 	case Int:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Int", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Int", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureInt(args []Object, index int) Int {
+func EnsureArgIsInt(args []Object, index int) Int {
 	switch c := args[index].(type) {
 	case Int:
 		return c
@@ -322,19 +337,20 @@ func EnsureInt(args []Object, index int) Int {
 	}
 }
 
-func AssertDouble(obj Object, msg string) Double {
+func EnsureObjectIsDouble(obj Object, pattern string) Double {
 	switch c := obj.(type) {
 	case Double:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Double", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Double", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureDouble(args []Object, index int) Double {
+func EnsureArgIsDouble(args []Object, index int) Double {
 	switch c := args[index].(type) {
 	case Double:
 		return c
@@ -343,19 +359,20 @@ func EnsureDouble(args []Object, index int) Double {
 	}
 }
 
-func AssertStack(obj Object, msg string) Stack {
+func EnsureObjectIsStack(obj Object, pattern string) Stack {
 	switch c := obj.(type) {
 	case Stack:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Stack", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Stack", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureStack(args []Object, index int) Stack {
+func EnsureArgIsStack(args []Object, index int) Stack {
 	switch c := args[index].(type) {
 	case Stack:
 		return c
@@ -364,19 +381,20 @@ func EnsureStack(args []Object, index int) Stack {
 	}
 }
 
-func AssertMap(obj Object, msg string) Map {
+func EnsureObjectIsMap(obj Object, pattern string) Map {
 	switch c := obj.(type) {
 	case Map:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Map", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Map", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureMap(args []Object, index int) Map {
+func EnsureArgIsMap(args []Object, index int) Map {
 	switch c := args[index].(type) {
 	case Map:
 		return c
@@ -385,19 +403,20 @@ func EnsureMap(args []Object, index int) Map {
 	}
 }
 
-func AssertSet(obj Object, msg string) Set {
+func EnsureObjectIsSet(obj Object, pattern string) Set {
 	switch c := obj.(type) {
 	case Set:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Set", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Set", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureSet(args []Object, index int) Set {
+func EnsureArgIsSet(args []Object, index int) Set {
 	switch c := args[index].(type) {
 	case Set:
 		return c
@@ -406,19 +425,20 @@ func EnsureSet(args []Object, index int) Set {
 	}
 }
 
-func AssertAssociative(obj Object, msg string) Associative {
+func EnsureObjectIsAssociative(obj Object, pattern string) Associative {
 	switch c := obj.(type) {
 	case Associative:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Associative", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Associative", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureAssociative(args []Object, index int) Associative {
+func EnsureArgIsAssociative(args []Object, index int) Associative {
 	switch c := args[index].(type) {
 	case Associative:
 		return c
@@ -427,19 +447,20 @@ func EnsureAssociative(args []Object, index int) Associative {
 	}
 }
 
-func AssertReversible(obj Object, msg string) Reversible {
+func EnsureObjectIsReversible(obj Object, pattern string) Reversible {
 	switch c := obj.(type) {
 	case Reversible:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Reversible", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Reversible", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureReversible(args []Object, index int) Reversible {
+func EnsureArgIsReversible(args []Object, index int) Reversible {
 	switch c := args[index].(type) {
 	case Reversible:
 		return c
@@ -448,19 +469,20 @@ func EnsureReversible(args []Object, index int) Reversible {
 	}
 }
 
-func AssertNamed(obj Object, msg string) Named {
+func EnsureObjectIsNamed(obj Object, pattern string) Named {
 	switch c := obj.(type) {
 	case Named:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Named", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Named", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureNamed(args []Object, index int) Named {
+func EnsureArgIsNamed(args []Object, index int) Named {
 	switch c := args[index].(type) {
 	case Named:
 		return c
@@ -469,19 +491,20 @@ func EnsureNamed(args []Object, index int) Named {
 	}
 }
 
-func AssertComparator(obj Object, msg string) Comparator {
+func EnsureObjectIsComparator(obj Object, pattern string) Comparator {
 	switch c := obj.(type) {
 	case Comparator:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Comparator", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Comparator", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureComparator(args []Object, index int) Comparator {
+func EnsureArgIsComparator(args []Object, index int) Comparator {
 	switch c := args[index].(type) {
 	case Comparator:
 		return c
@@ -490,19 +513,20 @@ func EnsureComparator(args []Object, index int) Comparator {
 	}
 }
 
-func AssertRatio(obj Object, msg string) *Ratio {
+func EnsureObjectIsRatio(obj Object, pattern string) *Ratio {
 	switch c := obj.(type) {
 	case *Ratio:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Ratio", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Ratio", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureRatio(args []Object, index int) *Ratio {
+func EnsureArgIsRatio(args []Object, index int) *Ratio {
 	switch c := args[index].(type) {
 	case *Ratio:
 		return c
@@ -511,19 +535,20 @@ func EnsureRatio(args []Object, index int) *Ratio {
 	}
 }
 
-func AssertNamespace(obj Object, msg string) *Namespace {
+func EnsureObjectIsNamespace(obj Object, pattern string) *Namespace {
 	switch c := obj.(type) {
 	case *Namespace:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Namespace", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Namespace", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureNamespace(args []Object, index int) *Namespace {
+func EnsureArgIsNamespace(args []Object, index int) *Namespace {
 	switch c := args[index].(type) {
 	case *Namespace:
 		return c
@@ -532,19 +557,20 @@ func EnsureNamespace(args []Object, index int) *Namespace {
 	}
 }
 
-func AssertVar(obj Object, msg string) *Var {
+func EnsureObjectIsVar(obj Object, pattern string) *Var {
 	switch c := obj.(type) {
 	case *Var:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Var", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Var", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureVar(args []Object, index int) *Var {
+func EnsureArgIsVar(args []Object, index int) *Var {
 	switch c := args[index].(type) {
 	case *Var:
 		return c
@@ -553,19 +579,20 @@ func EnsureVar(args []Object, index int) *Var {
 	}
 }
 
-func AssertError(obj Object, msg string) Error {
+func EnsureObjectIsError(obj Object, pattern string) Error {
 	switch c := obj.(type) {
 	case Error:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Error", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Error", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureError(args []Object, index int) Error {
+func EnsureArgIsError(args []Object, index int) Error {
 	switch c := args[index].(type) {
 	case Error:
 		return c
@@ -574,19 +601,20 @@ func EnsureError(args []Object, index int) Error {
 	}
 }
 
-func AssertFn(obj Object, msg string) *Fn {
+func EnsureObjectIsFn(obj Object, pattern string) *Fn {
 	switch c := obj.(type) {
 	case *Fn:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Fn", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Fn", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureFn(args []Object, index int) *Fn {
+func EnsureArgIsFn(args []Object, index int) *Fn {
 	switch c := args[index].(type) {
 	case *Fn:
 		return c
@@ -595,19 +623,20 @@ func EnsureFn(args []Object, index int) *Fn {
 	}
 }
 
-func AssertDeref(obj Object, msg string) Deref {
+func EnsureObjectIsDeref(obj Object, pattern string) Deref {
 	switch c := obj.(type) {
 	case Deref:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Deref", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Deref", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureDeref(args []Object, index int) Deref {
+func EnsureArgIsDeref(args []Object, index int) Deref {
 	switch c := args[index].(type) {
 	case Deref:
 		return c
@@ -616,19 +645,20 @@ func EnsureDeref(args []Object, index int) Deref {
 	}
 }
 
-func AssertAtom(obj Object, msg string) *Atom {
+func EnsureObjectIsAtom(obj Object, pattern string) *Atom {
 	switch c := obj.(type) {
 	case *Atom:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Atom", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Atom", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureAtom(args []Object, index int) *Atom {
+func EnsureArgIsAtom(args []Object, index int) *Atom {
 	switch c := args[index].(type) {
 	case *Atom:
 		return c
@@ -637,19 +667,20 @@ func EnsureAtom(args []Object, index int) *Atom {
 	}
 }
 
-func AssertRef(obj Object, msg string) Ref {
+func EnsureObjectIsRef(obj Object, pattern string) Ref {
 	switch c := obj.(type) {
 	case Ref:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Ref", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Ref", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureRef(args []Object, index int) Ref {
+func EnsureArgIsRef(args []Object, index int) Ref {
 	switch c := args[index].(type) {
 	case Ref:
 		return c
@@ -658,19 +689,20 @@ func EnsureRef(args []Object, index int) Ref {
 	}
 }
 
-func AssertKVReduce(obj Object, msg string) KVReduce {
+func EnsureObjectIsKVReduce(obj Object, pattern string) KVReduce {
 	switch c := obj.(type) {
 	case KVReduce:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "KVReduce", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "KVReduce", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureKVReduce(args []Object, index int) KVReduce {
+func EnsureArgIsKVReduce(args []Object, index int) KVReduce {
 	switch c := args[index].(type) {
 	case KVReduce:
 		return c
@@ -679,19 +711,20 @@ func EnsureKVReduce(args []Object, index int) KVReduce {
 	}
 }
 
-func AssertPending(obj Object, msg string) Pending {
+func EnsureObjectIsPending(obj Object, pattern string) Pending {
 	switch c := obj.(type) {
 	case Pending:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Pending", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Pending", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsurePending(args []Object, index int) Pending {
+func EnsureArgIsPending(args []Object, index int) Pending {
 	switch c := args[index].(type) {
 	case Pending:
 		return c
@@ -700,19 +733,20 @@ func EnsurePending(args []Object, index int) Pending {
 	}
 }
 
-func AssertFile(obj Object, msg string) *File {
+func EnsureObjectIsFile(obj Object, pattern string) *File {
 	switch c := obj.(type) {
 	case *File:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "File", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "File", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureFile(args []Object, index int) *File {
+func EnsureArgIsFile(args []Object, index int) *File {
 	switch c := args[index].(type) {
 	case *File:
 		return c
@@ -721,19 +755,20 @@ func EnsureFile(args []Object, index int) *File {
 	}
 }
 
-func Assertio_Reader(obj Object, msg string) io.Reader {
+func EnsureObjectIsio_Reader(obj Object, pattern string) io.Reader {
 	switch c := obj.(type) {
 	case io.Reader:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "io.Reader", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "io.Reader", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func Ensureio_Reader(args []Object, index int) io.Reader {
+func EnsureArgIsio_Reader(args []Object, index int) io.Reader {
 	switch c := args[index].(type) {
 	case io.Reader:
 		return c
@@ -742,19 +777,20 @@ func Ensureio_Reader(args []Object, index int) io.Reader {
 	}
 }
 
-func Assertio_Writer(obj Object, msg string) io.Writer {
+func EnsureObjectIsio_Writer(obj Object, pattern string) io.Writer {
 	switch c := obj.(type) {
 	case io.Writer:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "io.Writer", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "io.Writer", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func Ensureio_Writer(args []Object, index int) io.Writer {
+func EnsureArgIsio_Writer(args []Object, index int) io.Writer {
 	switch c := args[index].(type) {
 	case io.Writer:
 		return c
@@ -763,19 +799,20 @@ func Ensureio_Writer(args []Object, index int) io.Writer {
 	}
 }
 
-func AssertStringReader(obj Object, msg string) StringReader {
+func EnsureObjectIsStringReader(obj Object, pattern string) StringReader {
 	switch c := obj.(type) {
 	case StringReader:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "StringReader", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "StringReader", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureStringReader(args []Object, index int) StringReader {
+func EnsureArgIsStringReader(args []Object, index int) StringReader {
 	switch c := args[index].(type) {
 	case StringReader:
 		return c
@@ -784,19 +821,20 @@ func EnsureStringReader(args []Object, index int) StringReader {
 	}
 }
 
-func Assertio_RuneReader(obj Object, msg string) io.RuneReader {
+func EnsureObjectIsio_RuneReader(obj Object, pattern string) io.RuneReader {
 	switch c := obj.(type) {
 	case io.RuneReader:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "io.RuneReader", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "io.RuneReader", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func Ensureio_RuneReader(args []Object, index int) io.RuneReader {
+func EnsureArgIsio_RuneReader(args []Object, index int) io.RuneReader {
 	switch c := args[index].(type) {
 	case io.RuneReader:
 		return c
@@ -805,19 +843,20 @@ func Ensureio_RuneReader(args []Object, index int) io.RuneReader {
 	}
 }
 
-func AssertChannel(obj Object, msg string) *Channel {
+func EnsureObjectIsChannel(obj Object, pattern string) *Channel {
 	switch c := obj.(type) {
 	case *Channel:
 		return c
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Channel", obj.GetType().ToString(false))
+		if pattern == "" {
+			pattern = "%s"
 		}
-		panic(RT.NewError(msg))
+		msg := fmt.Sprintf("Expected %s, got %s", "Channel", obj.GetType().ToString(false))
+		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
 	}
 }
 
-func EnsureChannel(args []Object, index int) *Channel {
+func EnsureArgIsChannel(args []Object, index int) *Channel {
 	switch c := args[index].(type) {
 	case *Channel:
 		return c

--- a/core/vector.go
+++ b/core/vector.go
@@ -286,7 +286,7 @@ func (v *Vector) TryNth(i int, d Object) Object {
 func (v *Vector) sequential() {}
 
 func (v *Vector) Compare(other Object) int {
-	v2 := AssertVector(other, "Cannot compare Vector and "+other.GetType().ToString(false))
+	v2 := EnsureObjectIsVector(other, "Cannot compare Vector: %s")
 	if v.Count() > v2.Count() {
 		return 1
 	}
@@ -294,7 +294,7 @@ func (v *Vector) Compare(other Object) int {
 		return -1
 	}
 	for i := 0; i < v.Count(); i++ {
-		c := AssertComparable(v.at(i), "").Compare(v2.at(i))
+		c := EnsureObjectIsComparable(v.at(i), "").Compare(v2.at(i))
 		if c != 0 {
 			return c
 		}

--- a/std/base64/a_base64.go
+++ b/std/base64/a_base64.go
@@ -45,7 +45,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var base64Namespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.base64"))
+var base64Namespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.base64"))
 
 func init() {
 	base64Namespace.Lazy = Init

--- a/std/bolt/a_bolt.go
+++ b/std/bolt/a_bolt.go
@@ -195,7 +195,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var boltNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.bolt"))
+var boltNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.bolt"))
 
 func init() {
 	boltNamespace.Lazy = Init

--- a/std/bolt/bolt_native.go
+++ b/std/bolt/bolt_native.go
@@ -51,7 +51,7 @@ func (db BoltDB) WithInfo(info *ObjectInfo) Object {
 	return db
 }
 
-func EnsureBoltDB(args []Object, index int) BoltDB {
+func EnsureArgIsBoltDB(args []Object, index int) BoltDB {
 	switch c := args[index].(type) {
 	case BoltDB:
 		return c
@@ -61,7 +61,7 @@ func EnsureBoltDB(args []Object, index int) BoltDB {
 }
 
 func ExtractBoltDB(args []Object, index int) *bolt.DB {
-	return EnsureBoltDB(args, index).DB
+	return EnsureArgIsBoltDB(args, index).DB
 }
 
 func open(filename string, mode int) *bolt.DB {

--- a/std/crypto/a_crypto.go
+++ b/std/crypto/a_crypto.go
@@ -178,7 +178,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var cryptoNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.crypto"))
+var cryptoNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.crypto"))
 
 func init() {
 	cryptoNamespace.Lazy = Init

--- a/std/csv/a_csv.go
+++ b/std/csv/a_csv.go
@@ -82,7 +82,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var csvNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.csv"))
+var csvNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.csv"))
 
 func init() {
 	csvNamespace.Lazy = Init

--- a/std/csv/csv_native.go
+++ b/std/csv/csv_native.go
@@ -33,25 +33,25 @@ func csvSeqOpts(src Object, opts Map) Object {
 	csvReader := csv.NewReader(rdr)
 	csvReader.ReuseRecord = true
 	if ok, c := opts.Get(MakeKeyword("comma")); ok {
-		csvReader.Comma = AssertChar(c, "comma must be a char").Ch
+		csvReader.Comma = EnsureObjectIsChar(c, "comma: %s").Ch
 	}
 	if ok, c := opts.Get(MakeKeyword("comment")); ok {
-		csvReader.Comment = AssertChar(c, "comment must be a char").Ch
+		csvReader.Comment = EnsureObjectIsChar(c, "comment: %s").Ch
 	}
 	if ok, c := opts.Get(MakeKeyword("fields-per-record")); ok {
-		csvReader.FieldsPerRecord = AssertInt(c, "fields-per-record must be an integer").I
+		csvReader.FieldsPerRecord = EnsureObjectIsInt(c, "fields-per-record: %s").I
 	}
 	if ok, c := opts.Get(MakeKeyword("lazy-quotes")); ok {
-		csvReader.LazyQuotes = AssertBoolean(c, "lazy-quotes must be a boolean").B
+		csvReader.LazyQuotes = EnsureObjectIsBoolean(c, "lazy-quotes: %s").B
 	}
 	if ok, c := opts.Get(MakeKeyword("trim-leading-space")); ok {
-		csvReader.TrimLeadingSpace = AssertBoolean(c, "trim-leading-space must be a boolean").B
+		csvReader.TrimLeadingSpace = EnsureObjectIsBoolean(c, "trim-leading-space: %s").B
 	}
 	return csvLazySeq(csvReader)
 }
 
 func sliceOfStrings(obj Object) (res []string) {
-	s := AssertSeqable(obj, "CSV record must be Seqable").Seq()
+	s := EnsureObjectIsSeqable(obj, "CSV record: %s").Seq()
 	for !s.IsEmpty() {
 		res = append(res, s.First().ToString(false))
 		s = s.Rest()
@@ -62,10 +62,10 @@ func sliceOfStrings(obj Object) (res []string) {
 func writeWriter(wr io.Writer, data Seqable, opts Map) {
 	csvWriter := csv.NewWriter(wr)
 	if ok, c := opts.Get(MakeKeyword("comma")); ok {
-		csvWriter.Comma = AssertChar(c, "comma must be a char").Ch
+		csvWriter.Comma = EnsureObjectIsChar(c, "comma: %s").Ch
 	}
 	if ok, c := opts.Get(MakeKeyword("use-crlf")); ok {
-		csvWriter.UseCRLF = AssertBoolean(c, "use-crlf must be a boolean").B
+		csvWriter.UseCRLF = EnsureObjectIsBoolean(c, "use-crlf: %s").B
 	}
 	s := data.Seq()
 	for !s.IsEmpty() {

--- a/std/filepath/a_filepath.go
+++ b/std/filepath/a_filepath.go
@@ -313,7 +313,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var filepathNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.filepath"))
+var filepathNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.filepath"))
 
 func init() {
 	filepathNamespace.Lazy = Init

--- a/std/hex/a_hex.go
+++ b/std/hex/a_hex.go
@@ -48,7 +48,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var hexNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.hex"))
+var hexNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.hex"))
 
 func init() {
 	hexNamespace.Lazy = Init

--- a/std/html/a_html.go
+++ b/std/html/a_html.go
@@ -46,7 +46,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var htmlNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.html"))
+var htmlNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.html"))
 
 func init() {
 	htmlNamespace.Lazy = Init

--- a/std/http/a_http.go
+++ b/std/http/a_http.go
@@ -64,7 +64,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var httpNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.http"))
+var httpNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.http"))
 
 func init() {
 	httpNamespace.Lazy = Init

--- a/std/io/a_io.go
+++ b/std/io/a_io.go
@@ -65,7 +65,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var ioNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.io"))
+var ioNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.io"))
 
 func init() {
 	ioNamespace.Lazy = Init

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -51,7 +51,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var jsonNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.json"))
+var jsonNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.json"))
 
 func init() {
 	jsonNamespace.Lazy = Init

--- a/std/math/a_math.go
+++ b/std/math/a_math.go
@@ -552,7 +552,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var mathNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.math"))
+var mathNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.math"))
 
 func init() {
 	mathNamespace.Lazy = Init

--- a/std/os/a_os.go
+++ b/std/os/a_os.go
@@ -409,7 +409,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var osNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.os"))
+var osNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.os"))
 
 func init() {
 	osNamespace.Lazy = Init

--- a/std/os/os_native.go
+++ b/std/os/os_native.go
@@ -47,12 +47,12 @@ func execute(name string, opts Map) Object {
 	var stdin io.Reader
 	var stdout, stderr io.Writer
 	if ok, dirObj := opts.Get(MakeKeyword("dir")); ok {
-		dir = AssertString(dirObj, "dir must be a string").S
+		dir = EnsureObjectIsString(dirObj, "dir: %s").S
 	}
 	if ok, argsObj := opts.Get(MakeKeyword("args")); ok {
-		s := AssertSeqable(argsObj, "args must be Seqable").Seq()
+		s := EnsureObjectIsSeqable(argsObj, "args: %s").Seq()
 		for !s.IsEmpty() {
-			args = append(args, AssertString(s.First(), "args must be strings").S)
+			args = append(args, EnsureObjectIsString(s.First(), "args: %s").S)
 			s = s.Rest()
 		}
 	}

--- a/std/package.tmpl
+++ b/std/package.tmpl
@@ -13,7 +13,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var {nsName}Namespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.{nsFullName}"))
+var {nsName}Namespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.{nsFullName}"))
 
 func init() {
 	{nsName}Namespace.Lazy = Init

--- a/std/strconv/a_strconv.go
+++ b/std/strconv/a_strconv.go
@@ -330,7 +330,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var strconvNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.strconv"))
+var strconvNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.strconv"))
 
 func init() {
 	strconvNamespace.Lazy = Init

--- a/std/string/a_string.go
+++ b/std/string/a_string.go
@@ -481,7 +481,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var stringNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.string"))
+var stringNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.string"))
 
 func init() {
 	stringNamespace.Lazy = Init

--- a/std/string/string_native.go
+++ b/std/string/string_native.go
@@ -91,7 +91,7 @@ func isBlank(s Object) bool {
 	if s.Equals(NIL) {
 		return true
 	}
-	str := AssertString(s, "").S
+	str := EnsureObjectIsString(s, "").S
 	for _, r := range str {
 		if !unicode.IsSpace(r) {
 			return false

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -392,7 +392,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var timeNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.time"))
+var timeNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.time"))
 
 func init() {
 	timeNamespace.Lazy = Init

--- a/std/url/a_url.go
+++ b/std/url/a_url.go
@@ -80,7 +80,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var urlNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.url"))
+var urlNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.url"))
 
 func init() {
 	urlNamespace.Lazy = Init

--- a/std/uuid/a_uuid.go
+++ b/std/uuid/a_uuid.go
@@ -27,7 +27,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var uuidNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.uuid"))
+var uuidNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.uuid"))
 
 func init() {
 	uuidNamespace.Lazy = Init

--- a/std/yaml/a_yaml.go
+++ b/std/yaml/a_yaml.go
@@ -45,7 +45,7 @@ func Init() {
 	InternsOrThunks()
 }
 
-var yamlNamespace = GLOBAL_ENV.EnsureLib(MakeSymbol("joker.yaml"))
+var yamlNamespace = GLOBAL_ENV.EnsureSymbolIsLib(MakeSymbol("joker.yaml"))
 
 func init() {
 	yamlNamespace.Lazy = Init


### PR DESCRIPTION
Currently the caller of `Assert*` is given a binary choice: pass an empty message, letting the API (if necessary) compose a useful one with the expected and actual type information; or, provide a complete message, requiring the caller to go to the expense of doing that even if (as is most often the case) it's not needed due to the type being in conformance.

Herein, the message is converted to a pattern (the default being "`%s`"), and the pattern is expanded only when needed, providing the current default message as the only argument to the pattern. (For most callers, this is sufficient; a few must still precompute a pattern based on runtime info, so if that is deemed an issue, arbitrary additional arguments could be supported via e.g. "`...interface{}`" and such. Callers that don't want the default argument inserted at all can and should put "`%.s`", which indicates a 0-length-truncated string, somewhere in their pattern.)

The result is simplified, as well as slightly faster, code. The resulting messages are different , but that -- surprisingly -- doesn't seem to affect the current set of tests:

```
$ joker
Welcome to joker v0.15.7. Use '(exit)', EOF (Ctrl-D), or SIGINT (Ctrl-C) to exit.
user=> (double "hey")
<joker.core>:2040:23: Eval error: Cannot cast "hey" (type: String) to Double
Stacktrace:
  global <repl>:1:1
  core/double <joker.core>:2040:23
user=> ^D
$ ./joker
Welcome to joker v0.15.7. Use '(exit)', EOF (Ctrl-D), or SIGINT (Ctrl-C) to exit.
user=> (double "hey")
<joker.core>:2040:23: Eval error: Cannot cast "hey": Expected Number, got String
Stacktrace:
  global <repl>:1:1
  core/double <joker.core>:2040:23
user=> ^D
$
```

Also, I've consistently been confused by the distinction between "Assert" and "Ensure". While I don't have a strong feeling about which term is used, it seems like only one should be (and "Assert" implies, to me, a mere check, not also the return of a value of the desired datatype).

So I've renamed "`Assert<T>`" to "`EnsureObjectIs<T>`", after first renaming "`Ensure<T>`" to "`EnsureArgIs<T>`" (where appropriate). I think this'll make it a little easier to read code without resorting to looking at `types_assert_gen.go` so frequently.