### PR TITLE
Fix (compare true 2) diagnostic message

### DIFF
--- a/core/object.go
+++ b/core/object.go
@@ -1186,7 +1186,7 @@ func (b Boolean) Hash() uint32 {
 }
 
 func (b Boolean) Compare(other Object) int {
-	b2 := EnsureObjectIsBoolean(other, "Cannot compare Boolean and "+other.GetType().ToString(false))
+	b2 := EnsureObjectIsBoolean(other, "Cannot compare Boolean: %s")
 	if b.B == b2.B {
 		return 0
 	}


### PR DESCRIPTION
My most-recent PR missed changing this one, so broke the diagnostic.