### PR TITLE
Further simplify ensurers

### DIFF
--- a/core/gen/gen_types.go
+++ b/core/gen/gen_types.go
@@ -31,7 +31,7 @@ func EnsureObjectIs{{.Name}}(obj Object, pattern string) {{.TypeName}} {
 	if c, yes := obj.({{.TypeName}}); yes {
 		return c
 	}
-	panic(FailObject(obj, "{{.TypeName}}", pattern))
+	panic(FailObject(obj, "{{.ShowName}}", pattern))
 }
 `
 
@@ -41,7 +41,7 @@ func EnsureArgIs{{.Name}}(args []Object, index int) {{.TypeName}} {
 	if c, yes := obj.({{.TypeName}}); yes {
 		return c
 	}
-	panic(FailArg(obj, "{{.TypeName}}", index))
+	panic(FailArg(obj, "{{.ShowName}}", index))
 }
 `
 

--- a/core/object.go
+++ b/core/object.go
@@ -1,4 +1,4 @@
-//go:generate go run gen/gen_types.go assert Comparable *Vector Char String Symbol Keyword *Regex Boolean Time Number Seqable Callable *Type Meta Int Double Stack Map Set Associative Reversible Named Comparator *Ratio *Namespace *Var Error *Fn Deref *Atom Ref KVReduce Pending *File io.Reader io.Writer StringReader io.RuneReader *Channel
+//go:generate go run gen/gen_types.go assert Comparable *Vector =Char =String =Symbol =Keyword *Regex =Boolean =Time Number Seqable Callable *Type Meta =Int =Double Stack Map Set Associative Reversible Named Comparator *Ratio *Namespace *Var Error *Fn Deref *Atom Ref KVReduce Pending *File io.Reader io.Writer StringReader io.RuneReader *Channel
 //go:generate go run gen/gen_types.go info *List *ArrayMapSeq *ArrayMap *HashMap *ExInfo *Fn *Var Nil *Ratio *BigInt *BigFloat Char Double Int Boolean Time Keyword *Regex Symbol String Comment *LazySeq *MappingSeq *ArraySeq *ConsSeq *NodeSeq *ArrayNodeSeq *MapSet *Vector *VectorSeq *VectorRSeq
 //go:generate go run -tags gen_code gen_code/gen_code.go
 

--- a/core/object.go
+++ b/core/object.go
@@ -1,4 +1,4 @@
-//go:generate go run gen/gen_types.go assert Comparable *Vector =Char =String =Symbol =Keyword *Regex =Boolean =Time Number Seqable Callable *Type Meta =Int =Double Stack Map Set Associative Reversible Named Comparator *Ratio *Namespace *Var Error *Fn Deref *Atom Ref KVReduce Pending *File io.Reader io.Writer StringReader io.RuneReader *Channel
+//go:generate go run gen/gen_types.go assert Comparable *Vector Char String Symbol Keyword *Regex Boolean Time Number Seqable Callable *Type Meta Int Double Stack Map Set Associative Reversible Named Comparator *Ratio *Namespace *Var Error *Fn Deref *Atom Ref KVReduce Pending *File io.Reader io.Writer StringReader io.RuneReader *Channel
 //go:generate go run gen/gen_types.go info *List *ArrayMapSeq *ArrayMap *HashMap *ExInfo *Fn *Var Nil *Ratio *BigInt *BigFloat Char Double Int Boolean Time Keyword *Regex Symbol String Comment *LazySeq *MappingSeq *ArraySeq *ConsSeq *NodeSeq *ArrayNodeSeq *MapSet *Vector *VectorSeq *VectorRSeq
 //go:generate go run -tags gen_code gen_code/gen_code.go
 

--- a/core/procs.go
+++ b/core/procs.go
@@ -93,15 +93,15 @@ func ExtractBoolean(args []Object, index int) bool {
 	return EnsureArgIsBoolean(args, index).B
 }
 
-func FailExtract(obj Object, index int) *EvalError {
-	return RT.NewArgTypeError(index, obj, "Boolean")
+func FailArg(obj Object, typeName string, index int) *EvalError {
+	return RT.NewArgTypeError(index, obj, typeName)
 }
 
-func FailObject(obj Object, pattern string) *EvalError {
+func FailObject(obj Object, typeName, pattern string) *EvalError {
 	if pattern == "" {
 		pattern = "%s"
 	}
-	msg := fmt.Sprintf("Expected Boolean, got %s", obj.GetType().ToString(false))
+	msg := fmt.Sprintf("Expected %s, got %s", typeName, obj.GetType().ToString(false))
 	return RT.NewError(fmt.Sprintf(pattern, msg))
 }
 

--- a/core/procs.go
+++ b/core/procs.go
@@ -93,15 +93,6 @@ func ExtractBoolean(args []Object, index int) bool {
 	return EnsureArgIsBoolean(args, index).B
 }
 
-func EnsureIsBoolean(obj Object, failFn FailFn, failArgs ...interface{}) Boolean {
-	switch c := obj.(type) {
-	case Boolean:
-		return c
-	default:
-		panic(failFn(obj, failArgs...))
-	}
-}
-
 type FailFn func(obj Object, args ...interface{}) interface{}
 
 func FailExtract(obj Object, args ...interface{}) interface{} {

--- a/core/procs.go
+++ b/core/procs.go
@@ -93,15 +93,11 @@ func ExtractBoolean(args []Object, index int) bool {
 	return EnsureArgIsBoolean(args, index).B
 }
 
-type FailFn func(obj Object, args ...interface{}) interface{}
-
-func FailExtract(obj Object, args ...interface{}) interface{} {
-	index := args[0].(int)
+func FailExtract(obj Object, index int) *EvalError {
 	return RT.NewArgTypeError(index, obj, "Boolean")
 }
 
-func FailObject(obj Object, args ...interface{}) interface{} {
-	pattern := args[0].(string)
+func FailObject(obj Object, pattern string) *EvalError {
 	if pattern == "" {
 		pattern = "%s"
 	}

--- a/core/procs.go
+++ b/core/procs.go
@@ -93,6 +93,31 @@ func ExtractBoolean(args []Object, index int) bool {
 	return EnsureArgIsBoolean(args, index).B
 }
 
+func EnsureIsBoolean(obj Object, failFn FailFn, failArgs ...interface{}) Boolean {
+	switch c := obj.(type) {
+	case Boolean:
+		return c
+	default:
+		panic(failFn(obj, failArgs...))
+	}
+}
+
+type FailFn func(obj Object, args ...interface{}) interface{}
+
+func FailExtract(obj Object, args ...interface{}) interface{} {
+	index := args[0].(int)
+	return RT.NewArgTypeError(index, obj, "Boolean")
+}
+
+func FailObject(obj Object, args ...interface{}) interface{} {
+	pattern := args[0].(string)
+	if pattern == "" {
+		pattern = "%s"
+	}
+	msg := fmt.Sprintf("Expected Boolean, got %s", obj.GetType().ToString(false))
+	return RT.NewError(fmt.Sprintf(pattern, msg))
+}
+
 func ExtractChar(args []Object, index int) rune {
 	return EnsureArgIsChar(args, index).Ch
 }

--- a/core/stringable.go
+++ b/core/stringable.go
@@ -1,20 +1,13 @@
 package core
 
-import (
-	"fmt"
-)
-
-func EnsureObjectIsStringable(obj Object, msg string) String {
+func EnsureObjectIsStringable(obj Object, pattern string) String {
 	switch c := obj.(type) {
 	case String:
 		return c
 	case Char:
 		return String{S: string(c.Ch)}
 	default:
-		if msg == "" {
-			msg = fmt.Sprintf("Expected %s, got %s", "Stringable", obj.GetType().ToString(false))
-		}
-		panic(RT.NewError(msg))
+		panic(FailObject(c, "Stringable", pattern))
 	}
 }
 
@@ -25,6 +18,6 @@ func EnsureArgIsStringable(args []Object, index int) String {
 	case Char:
 		return String{S: string(c.Ch)}
 	default:
-		panic(RT.NewArgTypeError(index, c, "Stringable"))
+		panic(FailArg(c, "Stringable", index))
 	}
 }

--- a/core/types_assert_gen.go
+++ b/core/types_assert_gen.go
@@ -3,161 +3,134 @@
 package core
 
 import (
-	"fmt"
 	"io"
 )
 
-func EnsureObjectIsComparable(obj Object, pattern string) Comparable {
+func EnsureIsComparable(obj Object, failFn FailFn, failArgs ...interface{}) Comparable {
 	switch c := obj.(type) {
 	case Comparable:
 		return c
 	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Comparable", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
+func EnsureObjectIsComparable(obj Object, pattern string) Comparable {
+	return EnsureIsComparable(obj, FailObject, pattern)
+}
+
 func EnsureArgIsComparable(args []Object, index int) Comparable {
-	switch c := args[index].(type) {
-	case Comparable:
+	return EnsureIsComparable(args[index], FailExtract, index)
+}
+
+func EnsureIsVector(obj Object, failFn FailFn, failArgs ...interface{}) *Vector {
+	switch c := obj.(type) {
+	case *Vector:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Comparable"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsVector(obj Object, pattern string) *Vector {
-	switch c := obj.(type) {
-	case *Vector:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Vector", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsVector(obj, FailObject, pattern)
 }
 
 func EnsureArgIsVector(args []Object, index int) *Vector {
-	switch c := args[index].(type) {
-	case *Vector:
+	return EnsureIsVector(args[index], FailExtract, index)
+}
+
+func EnsureIsChar(obj Object, failFn FailFn, failArgs ...interface{}) Char {
+	switch c := obj.(type) {
+	case Char:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Vector"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsChar(obj Object, pattern string) Char {
-	switch c := obj.(type) {
-	case Char:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Char", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsChar(obj, FailObject, pattern)
 }
 
 func EnsureArgIsChar(args []Object, index int) Char {
-	switch c := args[index].(type) {
-	case Char:
+	return EnsureIsChar(args[index], FailExtract, index)
+}
+
+func EnsureIsString(obj Object, failFn FailFn, failArgs ...interface{}) String {
+	switch c := obj.(type) {
+	case String:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Char"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsString(obj Object, pattern string) String {
-	switch c := obj.(type) {
-	case String:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "String", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsString(obj, FailObject, pattern)
 }
 
 func EnsureArgIsString(args []Object, index int) String {
-	switch c := args[index].(type) {
-	case String:
+	return EnsureIsString(args[index], FailExtract, index)
+}
+
+func EnsureIsSymbol(obj Object, failFn FailFn, failArgs ...interface{}) Symbol {
+	switch c := obj.(type) {
+	case Symbol:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "String"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsSymbol(obj Object, pattern string) Symbol {
-	switch c := obj.(type) {
-	case Symbol:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Symbol", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsSymbol(obj, FailObject, pattern)
 }
 
 func EnsureArgIsSymbol(args []Object, index int) Symbol {
-	switch c := args[index].(type) {
-	case Symbol:
+	return EnsureIsSymbol(args[index], FailExtract, index)
+}
+
+func EnsureIsKeyword(obj Object, failFn FailFn, failArgs ...interface{}) Keyword {
+	switch c := obj.(type) {
+	case Keyword:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Symbol"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsKeyword(obj Object, pattern string) Keyword {
-	switch c := obj.(type) {
-	case Keyword:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Keyword", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsKeyword(obj, FailObject, pattern)
 }
 
 func EnsureArgIsKeyword(args []Object, index int) Keyword {
-	switch c := args[index].(type) {
-	case Keyword:
+	return EnsureIsKeyword(args[index], FailExtract, index)
+}
+
+func EnsureIsRegex(obj Object, failFn FailFn, failArgs ...interface{}) *Regex {
+	switch c := obj.(type) {
+	case *Regex:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Keyword"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsRegex(obj Object, pattern string) *Regex {
-	switch c := obj.(type) {
-	case *Regex:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Regex", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsRegex(obj, FailObject, pattern)
 }
 
 func EnsureArgIsRegex(args []Object, index int) *Regex {
-	switch c := args[index].(type) {
-	case *Regex:
+	return EnsureIsRegex(args[index], FailExtract, index)
+}
+
+func EnsureIsBoolean(obj Object, failFn FailFn, failArgs ...interface{}) Boolean {
+	switch c := obj.(type) {
+	case Boolean:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Regex"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
@@ -169,684 +142,529 @@ func EnsureArgIsBoolean(args []Object, index int) Boolean {
 	return EnsureIsBoolean(args[index], FailExtract, index)
 }
 
-func EnsureObjectIsTime(obj Object, pattern string) Time {
+func EnsureIsTime(obj Object, failFn FailFn, failArgs ...interface{}) Time {
 	switch c := obj.(type) {
 	case Time:
 		return c
 	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Time", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
+func EnsureObjectIsTime(obj Object, pattern string) Time {
+	return EnsureIsTime(obj, FailObject, pattern)
+}
+
 func EnsureArgIsTime(args []Object, index int) Time {
-	switch c := args[index].(type) {
-	case Time:
+	return EnsureIsTime(args[index], FailExtract, index)
+}
+
+func EnsureIsNumber(obj Object, failFn FailFn, failArgs ...interface{}) Number {
+	switch c := obj.(type) {
+	case Number:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Time"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsNumber(obj Object, pattern string) Number {
-	switch c := obj.(type) {
-	case Number:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Number", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsNumber(obj, FailObject, pattern)
 }
 
 func EnsureArgIsNumber(args []Object, index int) Number {
-	switch c := args[index].(type) {
-	case Number:
+	return EnsureIsNumber(args[index], FailExtract, index)
+}
+
+func EnsureIsSeqable(obj Object, failFn FailFn, failArgs ...interface{}) Seqable {
+	switch c := obj.(type) {
+	case Seqable:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Number"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsSeqable(obj Object, pattern string) Seqable {
-	switch c := obj.(type) {
-	case Seqable:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Seqable", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsSeqable(obj, FailObject, pattern)
 }
 
 func EnsureArgIsSeqable(args []Object, index int) Seqable {
-	switch c := args[index].(type) {
-	case Seqable:
+	return EnsureIsSeqable(args[index], FailExtract, index)
+}
+
+func EnsureIsCallable(obj Object, failFn FailFn, failArgs ...interface{}) Callable {
+	switch c := obj.(type) {
+	case Callable:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Seqable"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsCallable(obj Object, pattern string) Callable {
-	switch c := obj.(type) {
-	case Callable:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Callable", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsCallable(obj, FailObject, pattern)
 }
 
 func EnsureArgIsCallable(args []Object, index int) Callable {
-	switch c := args[index].(type) {
-	case Callable:
+	return EnsureIsCallable(args[index], FailExtract, index)
+}
+
+func EnsureIsType(obj Object, failFn FailFn, failArgs ...interface{}) *Type {
+	switch c := obj.(type) {
+	case *Type:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Callable"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsType(obj Object, pattern string) *Type {
-	switch c := obj.(type) {
-	case *Type:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Type", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsType(obj, FailObject, pattern)
 }
 
 func EnsureArgIsType(args []Object, index int) *Type {
-	switch c := args[index].(type) {
-	case *Type:
+	return EnsureIsType(args[index], FailExtract, index)
+}
+
+func EnsureIsMeta(obj Object, failFn FailFn, failArgs ...interface{}) Meta {
+	switch c := obj.(type) {
+	case Meta:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Type"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsMeta(obj Object, pattern string) Meta {
-	switch c := obj.(type) {
-	case Meta:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Meta", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsMeta(obj, FailObject, pattern)
 }
 
 func EnsureArgIsMeta(args []Object, index int) Meta {
-	switch c := args[index].(type) {
-	case Meta:
+	return EnsureIsMeta(args[index], FailExtract, index)
+}
+
+func EnsureIsInt(obj Object, failFn FailFn, failArgs ...interface{}) Int {
+	switch c := obj.(type) {
+	case Int:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Meta"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsInt(obj Object, pattern string) Int {
-	switch c := obj.(type) {
-	case Int:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Int", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsInt(obj, FailObject, pattern)
 }
 
 func EnsureArgIsInt(args []Object, index int) Int {
-	switch c := args[index].(type) {
-	case Int:
+	return EnsureIsInt(args[index], FailExtract, index)
+}
+
+func EnsureIsDouble(obj Object, failFn FailFn, failArgs ...interface{}) Double {
+	switch c := obj.(type) {
+	case Double:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Int"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsDouble(obj Object, pattern string) Double {
-	switch c := obj.(type) {
-	case Double:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Double", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsDouble(obj, FailObject, pattern)
 }
 
 func EnsureArgIsDouble(args []Object, index int) Double {
-	switch c := args[index].(type) {
-	case Double:
+	return EnsureIsDouble(args[index], FailExtract, index)
+}
+
+func EnsureIsStack(obj Object, failFn FailFn, failArgs ...interface{}) Stack {
+	switch c := obj.(type) {
+	case Stack:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Double"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsStack(obj Object, pattern string) Stack {
-	switch c := obj.(type) {
-	case Stack:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Stack", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsStack(obj, FailObject, pattern)
 }
 
 func EnsureArgIsStack(args []Object, index int) Stack {
-	switch c := args[index].(type) {
-	case Stack:
+	return EnsureIsStack(args[index], FailExtract, index)
+}
+
+func EnsureIsMap(obj Object, failFn FailFn, failArgs ...interface{}) Map {
+	switch c := obj.(type) {
+	case Map:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Stack"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsMap(obj Object, pattern string) Map {
-	switch c := obj.(type) {
-	case Map:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Map", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsMap(obj, FailObject, pattern)
 }
 
 func EnsureArgIsMap(args []Object, index int) Map {
-	switch c := args[index].(type) {
-	case Map:
+	return EnsureIsMap(args[index], FailExtract, index)
+}
+
+func EnsureIsSet(obj Object, failFn FailFn, failArgs ...interface{}) Set {
+	switch c := obj.(type) {
+	case Set:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Map"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsSet(obj Object, pattern string) Set {
-	switch c := obj.(type) {
-	case Set:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Set", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsSet(obj, FailObject, pattern)
 }
 
 func EnsureArgIsSet(args []Object, index int) Set {
-	switch c := args[index].(type) {
-	case Set:
+	return EnsureIsSet(args[index], FailExtract, index)
+}
+
+func EnsureIsAssociative(obj Object, failFn FailFn, failArgs ...interface{}) Associative {
+	switch c := obj.(type) {
+	case Associative:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Set"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsAssociative(obj Object, pattern string) Associative {
-	switch c := obj.(type) {
-	case Associative:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Associative", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsAssociative(obj, FailObject, pattern)
 }
 
 func EnsureArgIsAssociative(args []Object, index int) Associative {
-	switch c := args[index].(type) {
-	case Associative:
+	return EnsureIsAssociative(args[index], FailExtract, index)
+}
+
+func EnsureIsReversible(obj Object, failFn FailFn, failArgs ...interface{}) Reversible {
+	switch c := obj.(type) {
+	case Reversible:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Associative"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsReversible(obj Object, pattern string) Reversible {
-	switch c := obj.(type) {
-	case Reversible:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Reversible", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsReversible(obj, FailObject, pattern)
 }
 
 func EnsureArgIsReversible(args []Object, index int) Reversible {
-	switch c := args[index].(type) {
-	case Reversible:
+	return EnsureIsReversible(args[index], FailExtract, index)
+}
+
+func EnsureIsNamed(obj Object, failFn FailFn, failArgs ...interface{}) Named {
+	switch c := obj.(type) {
+	case Named:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Reversible"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsNamed(obj Object, pattern string) Named {
-	switch c := obj.(type) {
-	case Named:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Named", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsNamed(obj, FailObject, pattern)
 }
 
 func EnsureArgIsNamed(args []Object, index int) Named {
-	switch c := args[index].(type) {
-	case Named:
+	return EnsureIsNamed(args[index], FailExtract, index)
+}
+
+func EnsureIsComparator(obj Object, failFn FailFn, failArgs ...interface{}) Comparator {
+	switch c := obj.(type) {
+	case Comparator:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Named"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsComparator(obj Object, pattern string) Comparator {
-	switch c := obj.(type) {
-	case Comparator:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Comparator", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsComparator(obj, FailObject, pattern)
 }
 
 func EnsureArgIsComparator(args []Object, index int) Comparator {
-	switch c := args[index].(type) {
-	case Comparator:
+	return EnsureIsComparator(args[index], FailExtract, index)
+}
+
+func EnsureIsRatio(obj Object, failFn FailFn, failArgs ...interface{}) *Ratio {
+	switch c := obj.(type) {
+	case *Ratio:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Comparator"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsRatio(obj Object, pattern string) *Ratio {
-	switch c := obj.(type) {
-	case *Ratio:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Ratio", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsRatio(obj, FailObject, pattern)
 }
 
 func EnsureArgIsRatio(args []Object, index int) *Ratio {
-	switch c := args[index].(type) {
-	case *Ratio:
+	return EnsureIsRatio(args[index], FailExtract, index)
+}
+
+func EnsureIsNamespace(obj Object, failFn FailFn, failArgs ...interface{}) *Namespace {
+	switch c := obj.(type) {
+	case *Namespace:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Ratio"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsNamespace(obj Object, pattern string) *Namespace {
-	switch c := obj.(type) {
-	case *Namespace:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Namespace", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsNamespace(obj, FailObject, pattern)
 }
 
 func EnsureArgIsNamespace(args []Object, index int) *Namespace {
-	switch c := args[index].(type) {
-	case *Namespace:
+	return EnsureIsNamespace(args[index], FailExtract, index)
+}
+
+func EnsureIsVar(obj Object, failFn FailFn, failArgs ...interface{}) *Var {
+	switch c := obj.(type) {
+	case *Var:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Namespace"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsVar(obj Object, pattern string) *Var {
-	switch c := obj.(type) {
-	case *Var:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Var", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsVar(obj, FailObject, pattern)
 }
 
 func EnsureArgIsVar(args []Object, index int) *Var {
-	switch c := args[index].(type) {
-	case *Var:
+	return EnsureIsVar(args[index], FailExtract, index)
+}
+
+func EnsureIsError(obj Object, failFn FailFn, failArgs ...interface{}) Error {
+	switch c := obj.(type) {
+	case Error:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Var"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsError(obj Object, pattern string) Error {
-	switch c := obj.(type) {
-	case Error:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Error", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsError(obj, FailObject, pattern)
 }
 
 func EnsureArgIsError(args []Object, index int) Error {
-	switch c := args[index].(type) {
-	case Error:
+	return EnsureIsError(args[index], FailExtract, index)
+}
+
+func EnsureIsFn(obj Object, failFn FailFn, failArgs ...interface{}) *Fn {
+	switch c := obj.(type) {
+	case *Fn:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Error"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsFn(obj Object, pattern string) *Fn {
-	switch c := obj.(type) {
-	case *Fn:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Fn", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsFn(obj, FailObject, pattern)
 }
 
 func EnsureArgIsFn(args []Object, index int) *Fn {
-	switch c := args[index].(type) {
-	case *Fn:
+	return EnsureIsFn(args[index], FailExtract, index)
+}
+
+func EnsureIsDeref(obj Object, failFn FailFn, failArgs ...interface{}) Deref {
+	switch c := obj.(type) {
+	case Deref:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Fn"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsDeref(obj Object, pattern string) Deref {
-	switch c := obj.(type) {
-	case Deref:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Deref", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsDeref(obj, FailObject, pattern)
 }
 
 func EnsureArgIsDeref(args []Object, index int) Deref {
-	switch c := args[index].(type) {
-	case Deref:
+	return EnsureIsDeref(args[index], FailExtract, index)
+}
+
+func EnsureIsAtom(obj Object, failFn FailFn, failArgs ...interface{}) *Atom {
+	switch c := obj.(type) {
+	case *Atom:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Deref"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsAtom(obj Object, pattern string) *Atom {
-	switch c := obj.(type) {
-	case *Atom:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Atom", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsAtom(obj, FailObject, pattern)
 }
 
 func EnsureArgIsAtom(args []Object, index int) *Atom {
-	switch c := args[index].(type) {
-	case *Atom:
+	return EnsureIsAtom(args[index], FailExtract, index)
+}
+
+func EnsureIsRef(obj Object, failFn FailFn, failArgs ...interface{}) Ref {
+	switch c := obj.(type) {
+	case Ref:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Atom"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsRef(obj Object, pattern string) Ref {
-	switch c := obj.(type) {
-	case Ref:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Ref", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsRef(obj, FailObject, pattern)
 }
 
 func EnsureArgIsRef(args []Object, index int) Ref {
-	switch c := args[index].(type) {
-	case Ref:
+	return EnsureIsRef(args[index], FailExtract, index)
+}
+
+func EnsureIsKVReduce(obj Object, failFn FailFn, failArgs ...interface{}) KVReduce {
+	switch c := obj.(type) {
+	case KVReduce:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Ref"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsKVReduce(obj Object, pattern string) KVReduce {
-	switch c := obj.(type) {
-	case KVReduce:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "KVReduce", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsKVReduce(obj, FailObject, pattern)
 }
 
 func EnsureArgIsKVReduce(args []Object, index int) KVReduce {
-	switch c := args[index].(type) {
-	case KVReduce:
+	return EnsureIsKVReduce(args[index], FailExtract, index)
+}
+
+func EnsureIsPending(obj Object, failFn FailFn, failArgs ...interface{}) Pending {
+	switch c := obj.(type) {
+	case Pending:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "KVReduce"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsPending(obj Object, pattern string) Pending {
-	switch c := obj.(type) {
-	case Pending:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Pending", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsPending(obj, FailObject, pattern)
 }
 
 func EnsureArgIsPending(args []Object, index int) Pending {
-	switch c := args[index].(type) {
-	case Pending:
+	return EnsureIsPending(args[index], FailExtract, index)
+}
+
+func EnsureIsFile(obj Object, failFn FailFn, failArgs ...interface{}) *File {
+	switch c := obj.(type) {
+	case *File:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "Pending"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsFile(obj Object, pattern string) *File {
-	switch c := obj.(type) {
-	case *File:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "File", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsFile(obj, FailObject, pattern)
 }
 
 func EnsureArgIsFile(args []Object, index int) *File {
-	switch c := args[index].(type) {
-	case *File:
+	return EnsureIsFile(args[index], FailExtract, index)
+}
+
+func EnsureIsio_Reader(obj Object, failFn FailFn, failArgs ...interface{}) io.Reader {
+	switch c := obj.(type) {
+	case io.Reader:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "File"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsio_Reader(obj Object, pattern string) io.Reader {
-	switch c := obj.(type) {
-	case io.Reader:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "io.Reader", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsio_Reader(obj, FailObject, pattern)
 }
 
 func EnsureArgIsio_Reader(args []Object, index int) io.Reader {
-	switch c := args[index].(type) {
-	case io.Reader:
+	return EnsureIsio_Reader(args[index], FailExtract, index)
+}
+
+func EnsureIsio_Writer(obj Object, failFn FailFn, failArgs ...interface{}) io.Writer {
+	switch c := obj.(type) {
+	case io.Writer:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "io.Reader"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsio_Writer(obj Object, pattern string) io.Writer {
-	switch c := obj.(type) {
-	case io.Writer:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "io.Writer", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsio_Writer(obj, FailObject, pattern)
 }
 
 func EnsureArgIsio_Writer(args []Object, index int) io.Writer {
-	switch c := args[index].(type) {
-	case io.Writer:
+	return EnsureIsio_Writer(args[index], FailExtract, index)
+}
+
+func EnsureIsStringReader(obj Object, failFn FailFn, failArgs ...interface{}) StringReader {
+	switch c := obj.(type) {
+	case StringReader:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "io.Writer"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsStringReader(obj Object, pattern string) StringReader {
-	switch c := obj.(type) {
-	case StringReader:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "StringReader", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsStringReader(obj, FailObject, pattern)
 }
 
 func EnsureArgIsStringReader(args []Object, index int) StringReader {
-	switch c := args[index].(type) {
-	case StringReader:
+	return EnsureIsStringReader(args[index], FailExtract, index)
+}
+
+func EnsureIsio_RuneReader(obj Object, failFn FailFn, failArgs ...interface{}) io.RuneReader {
+	switch c := obj.(type) {
+	case io.RuneReader:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "StringReader"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsio_RuneReader(obj Object, pattern string) io.RuneReader {
-	switch c := obj.(type) {
-	case io.RuneReader:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "io.RuneReader", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsio_RuneReader(obj, FailObject, pattern)
 }
 
 func EnsureArgIsio_RuneReader(args []Object, index int) io.RuneReader {
-	switch c := args[index].(type) {
-	case io.RuneReader:
+	return EnsureIsio_RuneReader(args[index], FailExtract, index)
+}
+
+func EnsureIsChannel(obj Object, failFn FailFn, failArgs ...interface{}) *Channel {
+	switch c := obj.(type) {
+	case *Channel:
 		return c
 	default:
-		panic(RT.NewArgTypeError(index, c, "io.RuneReader"))
+		panic(failFn(obj, failArgs...))
 	}
 }
 
 func EnsureObjectIsChannel(obj Object, pattern string) *Channel {
-	switch c := obj.(type) {
-	case *Channel:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Channel", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsChannel(obj, FailObject, pattern)
 }
 
 func EnsureArgIsChannel(args []Object, index int) *Channel {
-	switch c := args[index].(type) {
-	case *Channel:
-		return c
-	default:
-		panic(RT.NewArgTypeError(index, c, "Channel"))
-	}
+	return EnsureIsChannel(args[index], FailExtract, index)
 }

--- a/core/types_assert_gen.go
+++ b/core/types_assert_gen.go
@@ -6,938 +6,587 @@ import (
 	"io"
 )
 
-func EnsureIsComparable(obj Object) (Comparable, bool) {
-	switch c := obj.(type) {
-	case Comparable:
-		return c, true
-	default:
-		return nil, false
-	}
-}
-
 func EnsureObjectIsComparable(obj Object, pattern string) Comparable {
-	if c, yes := EnsureIsComparable(obj); yes {
+	if c, yes := obj.(Comparable); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Comparable", pattern))
 }
 
 func EnsureArgIsComparable(args []Object, index int) Comparable {
 	obj := args[index]
-	if c, yes := EnsureIsComparable(obj); yes {
+	if c, yes := obj.(Comparable); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsVector(obj Object) (*Vector, bool) {
-	switch c := obj.(type) {
-	case *Vector:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Comparable", index))
 }
 
 func EnsureObjectIsVector(obj Object, pattern string) *Vector {
-	if c, yes := EnsureIsVector(obj); yes {
+	if c, yes := obj.(*Vector); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Vector", pattern))
 }
 
 func EnsureArgIsVector(args []Object, index int) *Vector {
 	obj := args[index]
-	if c, yes := EnsureIsVector(obj); yes {
+	if c, yes := obj.(*Vector); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsChar(obj Object) (Char, bool) {
-	switch c := obj.(type) {
-	case Char:
-		return c, true
-	default:
-		return Char{}, false
-	}
+	panic(FailArg(obj, "*Vector", index))
 }
 
 func EnsureObjectIsChar(obj Object, pattern string) Char {
-	if c, yes := EnsureIsChar(obj); yes {
+	if c, yes := obj.(Char); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Char", pattern))
 }
 
 func EnsureArgIsChar(args []Object, index int) Char {
 	obj := args[index]
-	if c, yes := EnsureIsChar(obj); yes {
+	if c, yes := obj.(Char); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsString(obj Object) (String, bool) {
-	switch c := obj.(type) {
-	case String:
-		return c, true
-	default:
-		return String{}, false
-	}
+	panic(FailArg(obj, "Char", index))
 }
 
 func EnsureObjectIsString(obj Object, pattern string) String {
-	if c, yes := EnsureIsString(obj); yes {
+	if c, yes := obj.(String); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "String", pattern))
 }
 
 func EnsureArgIsString(args []Object, index int) String {
 	obj := args[index]
-	if c, yes := EnsureIsString(obj); yes {
+	if c, yes := obj.(String); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsSymbol(obj Object) (Symbol, bool) {
-	switch c := obj.(type) {
-	case Symbol:
-		return c, true
-	default:
-		return Symbol{}, false
-	}
+	panic(FailArg(obj, "String", index))
 }
 
 func EnsureObjectIsSymbol(obj Object, pattern string) Symbol {
-	if c, yes := EnsureIsSymbol(obj); yes {
+	if c, yes := obj.(Symbol); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Symbol", pattern))
 }
 
 func EnsureArgIsSymbol(args []Object, index int) Symbol {
 	obj := args[index]
-	if c, yes := EnsureIsSymbol(obj); yes {
+	if c, yes := obj.(Symbol); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsKeyword(obj Object) (Keyword, bool) {
-	switch c := obj.(type) {
-	case Keyword:
-		return c, true
-	default:
-		return Keyword{}, false
-	}
+	panic(FailArg(obj, "Symbol", index))
 }
 
 func EnsureObjectIsKeyword(obj Object, pattern string) Keyword {
-	if c, yes := EnsureIsKeyword(obj); yes {
+	if c, yes := obj.(Keyword); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Keyword", pattern))
 }
 
 func EnsureArgIsKeyword(args []Object, index int) Keyword {
 	obj := args[index]
-	if c, yes := EnsureIsKeyword(obj); yes {
+	if c, yes := obj.(Keyword); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsRegex(obj Object) (*Regex, bool) {
-	switch c := obj.(type) {
-	case *Regex:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Keyword", index))
 }
 
 func EnsureObjectIsRegex(obj Object, pattern string) *Regex {
-	if c, yes := EnsureIsRegex(obj); yes {
+	if c, yes := obj.(*Regex); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Regex", pattern))
 }
 
 func EnsureArgIsRegex(args []Object, index int) *Regex {
 	obj := args[index]
-	if c, yes := EnsureIsRegex(obj); yes {
+	if c, yes := obj.(*Regex); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsBoolean(obj Object) (Boolean, bool) {
-	switch c := obj.(type) {
-	case Boolean:
-		return c, true
-	default:
-		return Boolean{}, false
-	}
+	panic(FailArg(obj, "*Regex", index))
 }
 
 func EnsureObjectIsBoolean(obj Object, pattern string) Boolean {
-	if c, yes := EnsureIsBoolean(obj); yes {
+	if c, yes := obj.(Boolean); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Boolean", pattern))
 }
 
 func EnsureArgIsBoolean(args []Object, index int) Boolean {
 	obj := args[index]
-	if c, yes := EnsureIsBoolean(obj); yes {
+	if c, yes := obj.(Boolean); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsTime(obj Object) (Time, bool) {
-	switch c := obj.(type) {
-	case Time:
-		return c, true
-	default:
-		return Time{}, false
-	}
+	panic(FailArg(obj, "Boolean", index))
 }
 
 func EnsureObjectIsTime(obj Object, pattern string) Time {
-	if c, yes := EnsureIsTime(obj); yes {
+	if c, yes := obj.(Time); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Time", pattern))
 }
 
 func EnsureArgIsTime(args []Object, index int) Time {
 	obj := args[index]
-	if c, yes := EnsureIsTime(obj); yes {
+	if c, yes := obj.(Time); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsNumber(obj Object) (Number, bool) {
-	switch c := obj.(type) {
-	case Number:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Time", index))
 }
 
 func EnsureObjectIsNumber(obj Object, pattern string) Number {
-	if c, yes := EnsureIsNumber(obj); yes {
+	if c, yes := obj.(Number); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Number", pattern))
 }
 
 func EnsureArgIsNumber(args []Object, index int) Number {
 	obj := args[index]
-	if c, yes := EnsureIsNumber(obj); yes {
+	if c, yes := obj.(Number); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsSeqable(obj Object) (Seqable, bool) {
-	switch c := obj.(type) {
-	case Seqable:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Number", index))
 }
 
 func EnsureObjectIsSeqable(obj Object, pattern string) Seqable {
-	if c, yes := EnsureIsSeqable(obj); yes {
+	if c, yes := obj.(Seqable); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Seqable", pattern))
 }
 
 func EnsureArgIsSeqable(args []Object, index int) Seqable {
 	obj := args[index]
-	if c, yes := EnsureIsSeqable(obj); yes {
+	if c, yes := obj.(Seqable); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsCallable(obj Object) (Callable, bool) {
-	switch c := obj.(type) {
-	case Callable:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Seqable", index))
 }
 
 func EnsureObjectIsCallable(obj Object, pattern string) Callable {
-	if c, yes := EnsureIsCallable(obj); yes {
+	if c, yes := obj.(Callable); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Callable", pattern))
 }
 
 func EnsureArgIsCallable(args []Object, index int) Callable {
 	obj := args[index]
-	if c, yes := EnsureIsCallable(obj); yes {
+	if c, yes := obj.(Callable); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsType(obj Object) (*Type, bool) {
-	switch c := obj.(type) {
-	case *Type:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Callable", index))
 }
 
 func EnsureObjectIsType(obj Object, pattern string) *Type {
-	if c, yes := EnsureIsType(obj); yes {
+	if c, yes := obj.(*Type); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Type", pattern))
 }
 
 func EnsureArgIsType(args []Object, index int) *Type {
 	obj := args[index]
-	if c, yes := EnsureIsType(obj); yes {
+	if c, yes := obj.(*Type); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsMeta(obj Object) (Meta, bool) {
-	switch c := obj.(type) {
-	case Meta:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "*Type", index))
 }
 
 func EnsureObjectIsMeta(obj Object, pattern string) Meta {
-	if c, yes := EnsureIsMeta(obj); yes {
+	if c, yes := obj.(Meta); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Meta", pattern))
 }
 
 func EnsureArgIsMeta(args []Object, index int) Meta {
 	obj := args[index]
-	if c, yes := EnsureIsMeta(obj); yes {
+	if c, yes := obj.(Meta); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsInt(obj Object) (Int, bool) {
-	switch c := obj.(type) {
-	case Int:
-		return c, true
-	default:
-		return Int{}, false
-	}
+	panic(FailArg(obj, "Meta", index))
 }
 
 func EnsureObjectIsInt(obj Object, pattern string) Int {
-	if c, yes := EnsureIsInt(obj); yes {
+	if c, yes := obj.(Int); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Int", pattern))
 }
 
 func EnsureArgIsInt(args []Object, index int) Int {
 	obj := args[index]
-	if c, yes := EnsureIsInt(obj); yes {
+	if c, yes := obj.(Int); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsDouble(obj Object) (Double, bool) {
-	switch c := obj.(type) {
-	case Double:
-		return c, true
-	default:
-		return Double{}, false
-	}
+	panic(FailArg(obj, "Int", index))
 }
 
 func EnsureObjectIsDouble(obj Object, pattern string) Double {
-	if c, yes := EnsureIsDouble(obj); yes {
+	if c, yes := obj.(Double); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Double", pattern))
 }
 
 func EnsureArgIsDouble(args []Object, index int) Double {
 	obj := args[index]
-	if c, yes := EnsureIsDouble(obj); yes {
+	if c, yes := obj.(Double); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsStack(obj Object) (Stack, bool) {
-	switch c := obj.(type) {
-	case Stack:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Double", index))
 }
 
 func EnsureObjectIsStack(obj Object, pattern string) Stack {
-	if c, yes := EnsureIsStack(obj); yes {
+	if c, yes := obj.(Stack); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Stack", pattern))
 }
 
 func EnsureArgIsStack(args []Object, index int) Stack {
 	obj := args[index]
-	if c, yes := EnsureIsStack(obj); yes {
+	if c, yes := obj.(Stack); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsMap(obj Object) (Map, bool) {
-	switch c := obj.(type) {
-	case Map:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Stack", index))
 }
 
 func EnsureObjectIsMap(obj Object, pattern string) Map {
-	if c, yes := EnsureIsMap(obj); yes {
+	if c, yes := obj.(Map); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Map", pattern))
 }
 
 func EnsureArgIsMap(args []Object, index int) Map {
 	obj := args[index]
-	if c, yes := EnsureIsMap(obj); yes {
+	if c, yes := obj.(Map); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsSet(obj Object) (Set, bool) {
-	switch c := obj.(type) {
-	case Set:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Map", index))
 }
 
 func EnsureObjectIsSet(obj Object, pattern string) Set {
-	if c, yes := EnsureIsSet(obj); yes {
+	if c, yes := obj.(Set); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Set", pattern))
 }
 
 func EnsureArgIsSet(args []Object, index int) Set {
 	obj := args[index]
-	if c, yes := EnsureIsSet(obj); yes {
+	if c, yes := obj.(Set); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsAssociative(obj Object) (Associative, bool) {
-	switch c := obj.(type) {
-	case Associative:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Set", index))
 }
 
 func EnsureObjectIsAssociative(obj Object, pattern string) Associative {
-	if c, yes := EnsureIsAssociative(obj); yes {
+	if c, yes := obj.(Associative); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Associative", pattern))
 }
 
 func EnsureArgIsAssociative(args []Object, index int) Associative {
 	obj := args[index]
-	if c, yes := EnsureIsAssociative(obj); yes {
+	if c, yes := obj.(Associative); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsReversible(obj Object) (Reversible, bool) {
-	switch c := obj.(type) {
-	case Reversible:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Associative", index))
 }
 
 func EnsureObjectIsReversible(obj Object, pattern string) Reversible {
-	if c, yes := EnsureIsReversible(obj); yes {
+	if c, yes := obj.(Reversible); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Reversible", pattern))
 }
 
 func EnsureArgIsReversible(args []Object, index int) Reversible {
 	obj := args[index]
-	if c, yes := EnsureIsReversible(obj); yes {
+	if c, yes := obj.(Reversible); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsNamed(obj Object) (Named, bool) {
-	switch c := obj.(type) {
-	case Named:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Reversible", index))
 }
 
 func EnsureObjectIsNamed(obj Object, pattern string) Named {
-	if c, yes := EnsureIsNamed(obj); yes {
+	if c, yes := obj.(Named); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Named", pattern))
 }
 
 func EnsureArgIsNamed(args []Object, index int) Named {
 	obj := args[index]
-	if c, yes := EnsureIsNamed(obj); yes {
+	if c, yes := obj.(Named); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsComparator(obj Object) (Comparator, bool) {
-	switch c := obj.(type) {
-	case Comparator:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Named", index))
 }
 
 func EnsureObjectIsComparator(obj Object, pattern string) Comparator {
-	if c, yes := EnsureIsComparator(obj); yes {
+	if c, yes := obj.(Comparator); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Comparator", pattern))
 }
 
 func EnsureArgIsComparator(args []Object, index int) Comparator {
 	obj := args[index]
-	if c, yes := EnsureIsComparator(obj); yes {
+	if c, yes := obj.(Comparator); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsRatio(obj Object) (*Ratio, bool) {
-	switch c := obj.(type) {
-	case *Ratio:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Comparator", index))
 }
 
 func EnsureObjectIsRatio(obj Object, pattern string) *Ratio {
-	if c, yes := EnsureIsRatio(obj); yes {
+	if c, yes := obj.(*Ratio); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Ratio", pattern))
 }
 
 func EnsureArgIsRatio(args []Object, index int) *Ratio {
 	obj := args[index]
-	if c, yes := EnsureIsRatio(obj); yes {
+	if c, yes := obj.(*Ratio); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsNamespace(obj Object) (*Namespace, bool) {
-	switch c := obj.(type) {
-	case *Namespace:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "*Ratio", index))
 }
 
 func EnsureObjectIsNamespace(obj Object, pattern string) *Namespace {
-	if c, yes := EnsureIsNamespace(obj); yes {
+	if c, yes := obj.(*Namespace); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Namespace", pattern))
 }
 
 func EnsureArgIsNamespace(args []Object, index int) *Namespace {
 	obj := args[index]
-	if c, yes := EnsureIsNamespace(obj); yes {
+	if c, yes := obj.(*Namespace); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsVar(obj Object) (*Var, bool) {
-	switch c := obj.(type) {
-	case *Var:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "*Namespace", index))
 }
 
 func EnsureObjectIsVar(obj Object, pattern string) *Var {
-	if c, yes := EnsureIsVar(obj); yes {
+	if c, yes := obj.(*Var); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Var", pattern))
 }
 
 func EnsureArgIsVar(args []Object, index int) *Var {
 	obj := args[index]
-	if c, yes := EnsureIsVar(obj); yes {
+	if c, yes := obj.(*Var); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsError(obj Object) (Error, bool) {
-	switch c := obj.(type) {
-	case Error:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "*Var", index))
 }
 
 func EnsureObjectIsError(obj Object, pattern string) Error {
-	if c, yes := EnsureIsError(obj); yes {
+	if c, yes := obj.(Error); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Error", pattern))
 }
 
 func EnsureArgIsError(args []Object, index int) Error {
 	obj := args[index]
-	if c, yes := EnsureIsError(obj); yes {
+	if c, yes := obj.(Error); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsFn(obj Object) (*Fn, bool) {
-	switch c := obj.(type) {
-	case *Fn:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Error", index))
 }
 
 func EnsureObjectIsFn(obj Object, pattern string) *Fn {
-	if c, yes := EnsureIsFn(obj); yes {
+	if c, yes := obj.(*Fn); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Fn", pattern))
 }
 
 func EnsureArgIsFn(args []Object, index int) *Fn {
 	obj := args[index]
-	if c, yes := EnsureIsFn(obj); yes {
+	if c, yes := obj.(*Fn); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsDeref(obj Object) (Deref, bool) {
-	switch c := obj.(type) {
-	case Deref:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "*Fn", index))
 }
 
 func EnsureObjectIsDeref(obj Object, pattern string) Deref {
-	if c, yes := EnsureIsDeref(obj); yes {
+	if c, yes := obj.(Deref); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Deref", pattern))
 }
 
 func EnsureArgIsDeref(args []Object, index int) Deref {
 	obj := args[index]
-	if c, yes := EnsureIsDeref(obj); yes {
+	if c, yes := obj.(Deref); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsAtom(obj Object) (*Atom, bool) {
-	switch c := obj.(type) {
-	case *Atom:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Deref", index))
 }
 
 func EnsureObjectIsAtom(obj Object, pattern string) *Atom {
-	if c, yes := EnsureIsAtom(obj); yes {
+	if c, yes := obj.(*Atom); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Atom", pattern))
 }
 
 func EnsureArgIsAtom(args []Object, index int) *Atom {
 	obj := args[index]
-	if c, yes := EnsureIsAtom(obj); yes {
+	if c, yes := obj.(*Atom); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsRef(obj Object) (Ref, bool) {
-	switch c := obj.(type) {
-	case Ref:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "*Atom", index))
 }
 
 func EnsureObjectIsRef(obj Object, pattern string) Ref {
-	if c, yes := EnsureIsRef(obj); yes {
+	if c, yes := obj.(Ref); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Ref", pattern))
 }
 
 func EnsureArgIsRef(args []Object, index int) Ref {
 	obj := args[index]
-	if c, yes := EnsureIsRef(obj); yes {
+	if c, yes := obj.(Ref); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsKVReduce(obj Object) (KVReduce, bool) {
-	switch c := obj.(type) {
-	case KVReduce:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Ref", index))
 }
 
 func EnsureObjectIsKVReduce(obj Object, pattern string) KVReduce {
-	if c, yes := EnsureIsKVReduce(obj); yes {
+	if c, yes := obj.(KVReduce); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "KVReduce", pattern))
 }
 
 func EnsureArgIsKVReduce(args []Object, index int) KVReduce {
 	obj := args[index]
-	if c, yes := EnsureIsKVReduce(obj); yes {
+	if c, yes := obj.(KVReduce); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsPending(obj Object) (Pending, bool) {
-	switch c := obj.(type) {
-	case Pending:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "KVReduce", index))
 }
 
 func EnsureObjectIsPending(obj Object, pattern string) Pending {
-	if c, yes := EnsureIsPending(obj); yes {
+	if c, yes := obj.(Pending); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "Pending", pattern))
 }
 
 func EnsureArgIsPending(args []Object, index int) Pending {
 	obj := args[index]
-	if c, yes := EnsureIsPending(obj); yes {
+	if c, yes := obj.(Pending); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsFile(obj Object) (*File, bool) {
-	switch c := obj.(type) {
-	case *File:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "Pending", index))
 }
 
 func EnsureObjectIsFile(obj Object, pattern string) *File {
-	if c, yes := EnsureIsFile(obj); yes {
+	if c, yes := obj.(*File); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*File", pattern))
 }
 
 func EnsureArgIsFile(args []Object, index int) *File {
 	obj := args[index]
-	if c, yes := EnsureIsFile(obj); yes {
+	if c, yes := obj.(*File); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsio_Reader(obj Object) (io.Reader, bool) {
-	switch c := obj.(type) {
-	case io.Reader:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "*File", index))
 }
 
 func EnsureObjectIsio_Reader(obj Object, pattern string) io.Reader {
-	if c, yes := EnsureIsio_Reader(obj); yes {
+	if c, yes := obj.(io.Reader); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "io.Reader", pattern))
 }
 
 func EnsureArgIsio_Reader(args []Object, index int) io.Reader {
 	obj := args[index]
-	if c, yes := EnsureIsio_Reader(obj); yes {
+	if c, yes := obj.(io.Reader); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsio_Writer(obj Object) (io.Writer, bool) {
-	switch c := obj.(type) {
-	case io.Writer:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "io.Reader", index))
 }
 
 func EnsureObjectIsio_Writer(obj Object, pattern string) io.Writer {
-	if c, yes := EnsureIsio_Writer(obj); yes {
+	if c, yes := obj.(io.Writer); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "io.Writer", pattern))
 }
 
 func EnsureArgIsio_Writer(args []Object, index int) io.Writer {
 	obj := args[index]
-	if c, yes := EnsureIsio_Writer(obj); yes {
+	if c, yes := obj.(io.Writer); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsStringReader(obj Object) (StringReader, bool) {
-	switch c := obj.(type) {
-	case StringReader:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "io.Writer", index))
 }
 
 func EnsureObjectIsStringReader(obj Object, pattern string) StringReader {
-	if c, yes := EnsureIsStringReader(obj); yes {
+	if c, yes := obj.(StringReader); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "StringReader", pattern))
 }
 
 func EnsureArgIsStringReader(args []Object, index int) StringReader {
 	obj := args[index]
-	if c, yes := EnsureIsStringReader(obj); yes {
+	if c, yes := obj.(StringReader); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsio_RuneReader(obj Object) (io.RuneReader, bool) {
-	switch c := obj.(type) {
-	case io.RuneReader:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "StringReader", index))
 }
 
 func EnsureObjectIsio_RuneReader(obj Object, pattern string) io.RuneReader {
-	if c, yes := EnsureIsio_RuneReader(obj); yes {
+	if c, yes := obj.(io.RuneReader); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "io.RuneReader", pattern))
 }
 
 func EnsureArgIsio_RuneReader(args []Object, index int) io.RuneReader {
 	obj := args[index]
-	if c, yes := EnsureIsio_RuneReader(obj); yes {
+	if c, yes := obj.(io.RuneReader); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
-}
-
-func EnsureIsChannel(obj Object) (*Channel, bool) {
-	switch c := obj.(type) {
-	case *Channel:
-		return c, true
-	default:
-		return nil, false
-	}
+	panic(FailArg(obj, "io.RuneReader", index))
 }
 
 func EnsureObjectIsChannel(obj Object, pattern string) *Channel {
-	if c, yes := EnsureIsChannel(obj); yes {
+	if c, yes := obj.(*Channel); yes {
 		return c
 	}
-	panic(FailObject(obj, pattern))
+	panic(FailObject(obj, "*Channel", pattern))
 }
 
 func EnsureArgIsChannel(args []Object, index int) *Channel {
 	obj := args[index]
-	if c, yes := EnsureIsChannel(obj); yes {
+	if c, yes := obj.(*Channel); yes {
 		return c
 	}
-	panic(FailExtract(obj, index))
+	panic(FailArg(obj, "*Channel", index))
 }

--- a/core/types_assert_gen.go
+++ b/core/types_assert_gen.go
@@ -162,25 +162,11 @@ func EnsureArgIsRegex(args []Object, index int) *Regex {
 }
 
 func EnsureObjectIsBoolean(obj Object, pattern string) Boolean {
-	switch c := obj.(type) {
-	case Boolean:
-		return c
-	default:
-		if pattern == "" {
-			pattern = "%s"
-		}
-		msg := fmt.Sprintf("Expected %s, got %s", "Boolean", obj.GetType().ToString(false))
-		panic(RT.NewError(fmt.Sprintf(pattern, msg)))
-	}
+	return EnsureIsBoolean(obj, FailObject, pattern)
 }
 
 func EnsureArgIsBoolean(args []Object, index int) Boolean {
-	switch c := args[index].(type) {
-	case Boolean:
-		return c
-	default:
-		panic(RT.NewArgTypeError(index, c, "Boolean"))
-	}
+	return EnsureIsBoolean(args[index], FailExtract, index)
 }
 
 func EnsureObjectIsTime(obj Object, pattern string) Time {

--- a/core/types_assert_gen.go
+++ b/core/types_assert_gen.go
@@ -6,665 +6,938 @@ import (
 	"io"
 )
 
-func EnsureIsComparable(obj Object, failFn FailFn, failArgs ...interface{}) Comparable {
+func EnsureIsComparable(obj Object) (Comparable, bool) {
 	switch c := obj.(type) {
 	case Comparable:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsComparable(obj Object, pattern string) Comparable {
-	return EnsureIsComparable(obj, FailObject, pattern)
+	if c, yes := EnsureIsComparable(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsComparable(args []Object, index int) Comparable {
-	return EnsureIsComparable(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsComparable(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsVector(obj Object, failFn FailFn, failArgs ...interface{}) *Vector {
+func EnsureIsVector(obj Object) (*Vector, bool) {
 	switch c := obj.(type) {
 	case *Vector:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsVector(obj Object, pattern string) *Vector {
-	return EnsureIsVector(obj, FailObject, pattern)
+	if c, yes := EnsureIsVector(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsVector(args []Object, index int) *Vector {
-	return EnsureIsVector(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsVector(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsChar(obj Object, failFn FailFn, failArgs ...interface{}) Char {
+func EnsureIsChar(obj Object) (Char, bool) {
 	switch c := obj.(type) {
 	case Char:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return Char{}, false
 	}
 }
 
 func EnsureObjectIsChar(obj Object, pattern string) Char {
-	return EnsureIsChar(obj, FailObject, pattern)
+	if c, yes := EnsureIsChar(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsChar(args []Object, index int) Char {
-	return EnsureIsChar(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsChar(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsString(obj Object, failFn FailFn, failArgs ...interface{}) String {
+func EnsureIsString(obj Object) (String, bool) {
 	switch c := obj.(type) {
 	case String:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return String{}, false
 	}
 }
 
 func EnsureObjectIsString(obj Object, pattern string) String {
-	return EnsureIsString(obj, FailObject, pattern)
+	if c, yes := EnsureIsString(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsString(args []Object, index int) String {
-	return EnsureIsString(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsString(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsSymbol(obj Object, failFn FailFn, failArgs ...interface{}) Symbol {
+func EnsureIsSymbol(obj Object) (Symbol, bool) {
 	switch c := obj.(type) {
 	case Symbol:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return Symbol{}, false
 	}
 }
 
 func EnsureObjectIsSymbol(obj Object, pattern string) Symbol {
-	return EnsureIsSymbol(obj, FailObject, pattern)
+	if c, yes := EnsureIsSymbol(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsSymbol(args []Object, index int) Symbol {
-	return EnsureIsSymbol(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsSymbol(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsKeyword(obj Object, failFn FailFn, failArgs ...interface{}) Keyword {
+func EnsureIsKeyword(obj Object) (Keyword, bool) {
 	switch c := obj.(type) {
 	case Keyword:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return Keyword{}, false
 	}
 }
 
 func EnsureObjectIsKeyword(obj Object, pattern string) Keyword {
-	return EnsureIsKeyword(obj, FailObject, pattern)
+	if c, yes := EnsureIsKeyword(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsKeyword(args []Object, index int) Keyword {
-	return EnsureIsKeyword(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsKeyword(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsRegex(obj Object, failFn FailFn, failArgs ...interface{}) *Regex {
+func EnsureIsRegex(obj Object) (*Regex, bool) {
 	switch c := obj.(type) {
 	case *Regex:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsRegex(obj Object, pattern string) *Regex {
-	return EnsureIsRegex(obj, FailObject, pattern)
+	if c, yes := EnsureIsRegex(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsRegex(args []Object, index int) *Regex {
-	return EnsureIsRegex(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsRegex(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsBoolean(obj Object, failFn FailFn, failArgs ...interface{}) Boolean {
+func EnsureIsBoolean(obj Object) (Boolean, bool) {
 	switch c := obj.(type) {
 	case Boolean:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return Boolean{}, false
 	}
 }
 
 func EnsureObjectIsBoolean(obj Object, pattern string) Boolean {
-	return EnsureIsBoolean(obj, FailObject, pattern)
+	if c, yes := EnsureIsBoolean(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsBoolean(args []Object, index int) Boolean {
-	return EnsureIsBoolean(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsBoolean(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsTime(obj Object, failFn FailFn, failArgs ...interface{}) Time {
+func EnsureIsTime(obj Object) (Time, bool) {
 	switch c := obj.(type) {
 	case Time:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return Time{}, false
 	}
 }
 
 func EnsureObjectIsTime(obj Object, pattern string) Time {
-	return EnsureIsTime(obj, FailObject, pattern)
+	if c, yes := EnsureIsTime(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsTime(args []Object, index int) Time {
-	return EnsureIsTime(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsTime(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsNumber(obj Object, failFn FailFn, failArgs ...interface{}) Number {
+func EnsureIsNumber(obj Object) (Number, bool) {
 	switch c := obj.(type) {
 	case Number:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsNumber(obj Object, pattern string) Number {
-	return EnsureIsNumber(obj, FailObject, pattern)
+	if c, yes := EnsureIsNumber(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsNumber(args []Object, index int) Number {
-	return EnsureIsNumber(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsNumber(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsSeqable(obj Object, failFn FailFn, failArgs ...interface{}) Seqable {
+func EnsureIsSeqable(obj Object) (Seqable, bool) {
 	switch c := obj.(type) {
 	case Seqable:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsSeqable(obj Object, pattern string) Seqable {
-	return EnsureIsSeqable(obj, FailObject, pattern)
+	if c, yes := EnsureIsSeqable(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsSeqable(args []Object, index int) Seqable {
-	return EnsureIsSeqable(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsSeqable(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsCallable(obj Object, failFn FailFn, failArgs ...interface{}) Callable {
+func EnsureIsCallable(obj Object) (Callable, bool) {
 	switch c := obj.(type) {
 	case Callable:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsCallable(obj Object, pattern string) Callable {
-	return EnsureIsCallable(obj, FailObject, pattern)
+	if c, yes := EnsureIsCallable(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsCallable(args []Object, index int) Callable {
-	return EnsureIsCallable(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsCallable(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsType(obj Object, failFn FailFn, failArgs ...interface{}) *Type {
+func EnsureIsType(obj Object) (*Type, bool) {
 	switch c := obj.(type) {
 	case *Type:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsType(obj Object, pattern string) *Type {
-	return EnsureIsType(obj, FailObject, pattern)
+	if c, yes := EnsureIsType(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsType(args []Object, index int) *Type {
-	return EnsureIsType(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsType(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsMeta(obj Object, failFn FailFn, failArgs ...interface{}) Meta {
+func EnsureIsMeta(obj Object) (Meta, bool) {
 	switch c := obj.(type) {
 	case Meta:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsMeta(obj Object, pattern string) Meta {
-	return EnsureIsMeta(obj, FailObject, pattern)
+	if c, yes := EnsureIsMeta(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsMeta(args []Object, index int) Meta {
-	return EnsureIsMeta(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsMeta(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsInt(obj Object, failFn FailFn, failArgs ...interface{}) Int {
+func EnsureIsInt(obj Object) (Int, bool) {
 	switch c := obj.(type) {
 	case Int:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return Int{}, false
 	}
 }
 
 func EnsureObjectIsInt(obj Object, pattern string) Int {
-	return EnsureIsInt(obj, FailObject, pattern)
+	if c, yes := EnsureIsInt(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsInt(args []Object, index int) Int {
-	return EnsureIsInt(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsInt(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsDouble(obj Object, failFn FailFn, failArgs ...interface{}) Double {
+func EnsureIsDouble(obj Object) (Double, bool) {
 	switch c := obj.(type) {
 	case Double:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return Double{}, false
 	}
 }
 
 func EnsureObjectIsDouble(obj Object, pattern string) Double {
-	return EnsureIsDouble(obj, FailObject, pattern)
+	if c, yes := EnsureIsDouble(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsDouble(args []Object, index int) Double {
-	return EnsureIsDouble(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsDouble(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsStack(obj Object, failFn FailFn, failArgs ...interface{}) Stack {
+func EnsureIsStack(obj Object) (Stack, bool) {
 	switch c := obj.(type) {
 	case Stack:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsStack(obj Object, pattern string) Stack {
-	return EnsureIsStack(obj, FailObject, pattern)
+	if c, yes := EnsureIsStack(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsStack(args []Object, index int) Stack {
-	return EnsureIsStack(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsStack(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsMap(obj Object, failFn FailFn, failArgs ...interface{}) Map {
+func EnsureIsMap(obj Object) (Map, bool) {
 	switch c := obj.(type) {
 	case Map:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsMap(obj Object, pattern string) Map {
-	return EnsureIsMap(obj, FailObject, pattern)
+	if c, yes := EnsureIsMap(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsMap(args []Object, index int) Map {
-	return EnsureIsMap(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsMap(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsSet(obj Object, failFn FailFn, failArgs ...interface{}) Set {
+func EnsureIsSet(obj Object) (Set, bool) {
 	switch c := obj.(type) {
 	case Set:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsSet(obj Object, pattern string) Set {
-	return EnsureIsSet(obj, FailObject, pattern)
+	if c, yes := EnsureIsSet(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsSet(args []Object, index int) Set {
-	return EnsureIsSet(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsSet(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsAssociative(obj Object, failFn FailFn, failArgs ...interface{}) Associative {
+func EnsureIsAssociative(obj Object) (Associative, bool) {
 	switch c := obj.(type) {
 	case Associative:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsAssociative(obj Object, pattern string) Associative {
-	return EnsureIsAssociative(obj, FailObject, pattern)
+	if c, yes := EnsureIsAssociative(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsAssociative(args []Object, index int) Associative {
-	return EnsureIsAssociative(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsAssociative(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsReversible(obj Object, failFn FailFn, failArgs ...interface{}) Reversible {
+func EnsureIsReversible(obj Object) (Reversible, bool) {
 	switch c := obj.(type) {
 	case Reversible:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsReversible(obj Object, pattern string) Reversible {
-	return EnsureIsReversible(obj, FailObject, pattern)
+	if c, yes := EnsureIsReversible(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsReversible(args []Object, index int) Reversible {
-	return EnsureIsReversible(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsReversible(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsNamed(obj Object, failFn FailFn, failArgs ...interface{}) Named {
+func EnsureIsNamed(obj Object) (Named, bool) {
 	switch c := obj.(type) {
 	case Named:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsNamed(obj Object, pattern string) Named {
-	return EnsureIsNamed(obj, FailObject, pattern)
+	if c, yes := EnsureIsNamed(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsNamed(args []Object, index int) Named {
-	return EnsureIsNamed(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsNamed(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsComparator(obj Object, failFn FailFn, failArgs ...interface{}) Comparator {
+func EnsureIsComparator(obj Object) (Comparator, bool) {
 	switch c := obj.(type) {
 	case Comparator:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsComparator(obj Object, pattern string) Comparator {
-	return EnsureIsComparator(obj, FailObject, pattern)
+	if c, yes := EnsureIsComparator(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsComparator(args []Object, index int) Comparator {
-	return EnsureIsComparator(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsComparator(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsRatio(obj Object, failFn FailFn, failArgs ...interface{}) *Ratio {
+func EnsureIsRatio(obj Object) (*Ratio, bool) {
 	switch c := obj.(type) {
 	case *Ratio:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsRatio(obj Object, pattern string) *Ratio {
-	return EnsureIsRatio(obj, FailObject, pattern)
+	if c, yes := EnsureIsRatio(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsRatio(args []Object, index int) *Ratio {
-	return EnsureIsRatio(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsRatio(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsNamespace(obj Object, failFn FailFn, failArgs ...interface{}) *Namespace {
+func EnsureIsNamespace(obj Object) (*Namespace, bool) {
 	switch c := obj.(type) {
 	case *Namespace:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsNamespace(obj Object, pattern string) *Namespace {
-	return EnsureIsNamespace(obj, FailObject, pattern)
+	if c, yes := EnsureIsNamespace(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsNamespace(args []Object, index int) *Namespace {
-	return EnsureIsNamespace(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsNamespace(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsVar(obj Object, failFn FailFn, failArgs ...interface{}) *Var {
+func EnsureIsVar(obj Object) (*Var, bool) {
 	switch c := obj.(type) {
 	case *Var:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsVar(obj Object, pattern string) *Var {
-	return EnsureIsVar(obj, FailObject, pattern)
+	if c, yes := EnsureIsVar(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsVar(args []Object, index int) *Var {
-	return EnsureIsVar(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsVar(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsError(obj Object, failFn FailFn, failArgs ...interface{}) Error {
+func EnsureIsError(obj Object) (Error, bool) {
 	switch c := obj.(type) {
 	case Error:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsError(obj Object, pattern string) Error {
-	return EnsureIsError(obj, FailObject, pattern)
+	if c, yes := EnsureIsError(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsError(args []Object, index int) Error {
-	return EnsureIsError(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsError(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsFn(obj Object, failFn FailFn, failArgs ...interface{}) *Fn {
+func EnsureIsFn(obj Object) (*Fn, bool) {
 	switch c := obj.(type) {
 	case *Fn:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsFn(obj Object, pattern string) *Fn {
-	return EnsureIsFn(obj, FailObject, pattern)
+	if c, yes := EnsureIsFn(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsFn(args []Object, index int) *Fn {
-	return EnsureIsFn(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsFn(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsDeref(obj Object, failFn FailFn, failArgs ...interface{}) Deref {
+func EnsureIsDeref(obj Object) (Deref, bool) {
 	switch c := obj.(type) {
 	case Deref:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsDeref(obj Object, pattern string) Deref {
-	return EnsureIsDeref(obj, FailObject, pattern)
+	if c, yes := EnsureIsDeref(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsDeref(args []Object, index int) Deref {
-	return EnsureIsDeref(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsDeref(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsAtom(obj Object, failFn FailFn, failArgs ...interface{}) *Atom {
+func EnsureIsAtom(obj Object) (*Atom, bool) {
 	switch c := obj.(type) {
 	case *Atom:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsAtom(obj Object, pattern string) *Atom {
-	return EnsureIsAtom(obj, FailObject, pattern)
+	if c, yes := EnsureIsAtom(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsAtom(args []Object, index int) *Atom {
-	return EnsureIsAtom(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsAtom(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsRef(obj Object, failFn FailFn, failArgs ...interface{}) Ref {
+func EnsureIsRef(obj Object) (Ref, bool) {
 	switch c := obj.(type) {
 	case Ref:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsRef(obj Object, pattern string) Ref {
-	return EnsureIsRef(obj, FailObject, pattern)
+	if c, yes := EnsureIsRef(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsRef(args []Object, index int) Ref {
-	return EnsureIsRef(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsRef(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsKVReduce(obj Object, failFn FailFn, failArgs ...interface{}) KVReduce {
+func EnsureIsKVReduce(obj Object) (KVReduce, bool) {
 	switch c := obj.(type) {
 	case KVReduce:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsKVReduce(obj Object, pattern string) KVReduce {
-	return EnsureIsKVReduce(obj, FailObject, pattern)
+	if c, yes := EnsureIsKVReduce(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsKVReduce(args []Object, index int) KVReduce {
-	return EnsureIsKVReduce(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsKVReduce(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsPending(obj Object, failFn FailFn, failArgs ...interface{}) Pending {
+func EnsureIsPending(obj Object) (Pending, bool) {
 	switch c := obj.(type) {
 	case Pending:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsPending(obj Object, pattern string) Pending {
-	return EnsureIsPending(obj, FailObject, pattern)
+	if c, yes := EnsureIsPending(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsPending(args []Object, index int) Pending {
-	return EnsureIsPending(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsPending(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsFile(obj Object, failFn FailFn, failArgs ...interface{}) *File {
+func EnsureIsFile(obj Object) (*File, bool) {
 	switch c := obj.(type) {
 	case *File:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsFile(obj Object, pattern string) *File {
-	return EnsureIsFile(obj, FailObject, pattern)
+	if c, yes := EnsureIsFile(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsFile(args []Object, index int) *File {
-	return EnsureIsFile(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsFile(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsio_Reader(obj Object, failFn FailFn, failArgs ...interface{}) io.Reader {
+func EnsureIsio_Reader(obj Object) (io.Reader, bool) {
 	switch c := obj.(type) {
 	case io.Reader:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsio_Reader(obj Object, pattern string) io.Reader {
-	return EnsureIsio_Reader(obj, FailObject, pattern)
+	if c, yes := EnsureIsio_Reader(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsio_Reader(args []Object, index int) io.Reader {
-	return EnsureIsio_Reader(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsio_Reader(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsio_Writer(obj Object, failFn FailFn, failArgs ...interface{}) io.Writer {
+func EnsureIsio_Writer(obj Object) (io.Writer, bool) {
 	switch c := obj.(type) {
 	case io.Writer:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsio_Writer(obj Object, pattern string) io.Writer {
-	return EnsureIsio_Writer(obj, FailObject, pattern)
+	if c, yes := EnsureIsio_Writer(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsio_Writer(args []Object, index int) io.Writer {
-	return EnsureIsio_Writer(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsio_Writer(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsStringReader(obj Object, failFn FailFn, failArgs ...interface{}) StringReader {
+func EnsureIsStringReader(obj Object) (StringReader, bool) {
 	switch c := obj.(type) {
 	case StringReader:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsStringReader(obj Object, pattern string) StringReader {
-	return EnsureIsStringReader(obj, FailObject, pattern)
+	if c, yes := EnsureIsStringReader(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsStringReader(args []Object, index int) StringReader {
-	return EnsureIsStringReader(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsStringReader(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsio_RuneReader(obj Object, failFn FailFn, failArgs ...interface{}) io.RuneReader {
+func EnsureIsio_RuneReader(obj Object) (io.RuneReader, bool) {
 	switch c := obj.(type) {
 	case io.RuneReader:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsio_RuneReader(obj Object, pattern string) io.RuneReader {
-	return EnsureIsio_RuneReader(obj, FailObject, pattern)
+	if c, yes := EnsureIsio_RuneReader(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsio_RuneReader(args []Object, index int) io.RuneReader {
-	return EnsureIsio_RuneReader(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsio_RuneReader(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }
 
-func EnsureIsChannel(obj Object, failFn FailFn, failArgs ...interface{}) *Channel {
+func EnsureIsChannel(obj Object) (*Channel, bool) {
 	switch c := obj.(type) {
 	case *Channel:
-		return c
+		return c, true
 	default:
-		panic(failFn(obj, failArgs...))
+		return nil, false
 	}
 }
 
 func EnsureObjectIsChannel(obj Object, pattern string) *Channel {
-	return EnsureIsChannel(obj, FailObject, pattern)
+	if c, yes := EnsureIsChannel(obj); yes {
+		return c
+	}
+	panic(FailObject(obj, pattern))
 }
 
 func EnsureArgIsChannel(args []Object, index int) *Channel {
-	return EnsureIsChannel(args[index], FailExtract, index)
+	obj := args[index]
+	if c, yes := EnsureIsChannel(obj); yes {
+		return c
+	}
+	panic(FailExtract(obj, index))
 }

--- a/core/types_assert_gen.go
+++ b/core/types_assert_gen.go
@@ -25,7 +25,7 @@ func EnsureObjectIsVector(obj Object, pattern string) *Vector {
 	if c, yes := obj.(*Vector); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Vector", pattern))
+	panic(FailObject(obj, "Vector", pattern))
 }
 
 func EnsureArgIsVector(args []Object, index int) *Vector {
@@ -33,7 +33,7 @@ func EnsureArgIsVector(args []Object, index int) *Vector {
 	if c, yes := obj.(*Vector); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Vector", index))
+	panic(FailArg(obj, "Vector", index))
 }
 
 func EnsureObjectIsChar(obj Object, pattern string) Char {
@@ -100,7 +100,7 @@ func EnsureObjectIsRegex(obj Object, pattern string) *Regex {
 	if c, yes := obj.(*Regex); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Regex", pattern))
+	panic(FailObject(obj, "Regex", pattern))
 }
 
 func EnsureArgIsRegex(args []Object, index int) *Regex {
@@ -108,7 +108,7 @@ func EnsureArgIsRegex(args []Object, index int) *Regex {
 	if c, yes := obj.(*Regex); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Regex", index))
+	panic(FailArg(obj, "Regex", index))
 }
 
 func EnsureObjectIsBoolean(obj Object, pattern string) Boolean {
@@ -190,7 +190,7 @@ func EnsureObjectIsType(obj Object, pattern string) *Type {
 	if c, yes := obj.(*Type); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Type", pattern))
+	panic(FailObject(obj, "Type", pattern))
 }
 
 func EnsureArgIsType(args []Object, index int) *Type {
@@ -198,7 +198,7 @@ func EnsureArgIsType(args []Object, index int) *Type {
 	if c, yes := obj.(*Type); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Type", index))
+	panic(FailArg(obj, "Type", index))
 }
 
 func EnsureObjectIsMeta(obj Object, pattern string) Meta {
@@ -355,7 +355,7 @@ func EnsureObjectIsRatio(obj Object, pattern string) *Ratio {
 	if c, yes := obj.(*Ratio); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Ratio", pattern))
+	panic(FailObject(obj, "Ratio", pattern))
 }
 
 func EnsureArgIsRatio(args []Object, index int) *Ratio {
@@ -363,14 +363,14 @@ func EnsureArgIsRatio(args []Object, index int) *Ratio {
 	if c, yes := obj.(*Ratio); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Ratio", index))
+	panic(FailArg(obj, "Ratio", index))
 }
 
 func EnsureObjectIsNamespace(obj Object, pattern string) *Namespace {
 	if c, yes := obj.(*Namespace); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Namespace", pattern))
+	panic(FailObject(obj, "Namespace", pattern))
 }
 
 func EnsureArgIsNamespace(args []Object, index int) *Namespace {
@@ -378,14 +378,14 @@ func EnsureArgIsNamespace(args []Object, index int) *Namespace {
 	if c, yes := obj.(*Namespace); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Namespace", index))
+	panic(FailArg(obj, "Namespace", index))
 }
 
 func EnsureObjectIsVar(obj Object, pattern string) *Var {
 	if c, yes := obj.(*Var); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Var", pattern))
+	panic(FailObject(obj, "Var", pattern))
 }
 
 func EnsureArgIsVar(args []Object, index int) *Var {
@@ -393,7 +393,7 @@ func EnsureArgIsVar(args []Object, index int) *Var {
 	if c, yes := obj.(*Var); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Var", index))
+	panic(FailArg(obj, "Var", index))
 }
 
 func EnsureObjectIsError(obj Object, pattern string) Error {
@@ -415,7 +415,7 @@ func EnsureObjectIsFn(obj Object, pattern string) *Fn {
 	if c, yes := obj.(*Fn); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Fn", pattern))
+	panic(FailObject(obj, "Fn", pattern))
 }
 
 func EnsureArgIsFn(args []Object, index int) *Fn {
@@ -423,7 +423,7 @@ func EnsureArgIsFn(args []Object, index int) *Fn {
 	if c, yes := obj.(*Fn); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Fn", index))
+	panic(FailArg(obj, "Fn", index))
 }
 
 func EnsureObjectIsDeref(obj Object, pattern string) Deref {
@@ -445,7 +445,7 @@ func EnsureObjectIsAtom(obj Object, pattern string) *Atom {
 	if c, yes := obj.(*Atom); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Atom", pattern))
+	panic(FailObject(obj, "Atom", pattern))
 }
 
 func EnsureArgIsAtom(args []Object, index int) *Atom {
@@ -453,7 +453,7 @@ func EnsureArgIsAtom(args []Object, index int) *Atom {
 	if c, yes := obj.(*Atom); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Atom", index))
+	panic(FailArg(obj, "Atom", index))
 }
 
 func EnsureObjectIsRef(obj Object, pattern string) Ref {
@@ -505,7 +505,7 @@ func EnsureObjectIsFile(obj Object, pattern string) *File {
 	if c, yes := obj.(*File); yes {
 		return c
 	}
-	panic(FailObject(obj, "*File", pattern))
+	panic(FailObject(obj, "File", pattern))
 }
 
 func EnsureArgIsFile(args []Object, index int) *File {
@@ -513,7 +513,7 @@ func EnsureArgIsFile(args []Object, index int) *File {
 	if c, yes := obj.(*File); yes {
 		return c
 	}
-	panic(FailArg(obj, "*File", index))
+	panic(FailArg(obj, "File", index))
 }
 
 func EnsureObjectIsio_Reader(obj Object, pattern string) io.Reader {
@@ -580,7 +580,7 @@ func EnsureObjectIsChannel(obj Object, pattern string) *Channel {
 	if c, yes := obj.(*Channel); yes {
 		return c
 	}
-	panic(FailObject(obj, "*Channel", pattern))
+	panic(FailObject(obj, "Channel", pattern))
 }
 
 func EnsureArgIsChannel(args []Object, index int) *Channel {
@@ -588,5 +588,5 @@ func EnsureArgIsChannel(args []Object, index int) *Channel {
 	if c, yes := obj.(*Channel); yes {
 		return c
 	}
-	panic(FailArg(obj, "*Channel", index))
+	panic(FailArg(obj, "Channel", index))
 }

--- a/std/bolt/bolt_native.go
+++ b/std/bolt/bolt_native.go
@@ -52,12 +52,11 @@ func (db BoltDB) WithInfo(info *ObjectInfo) Object {
 }
 
 func EnsureArgIsBoltDB(args []Object, index int) BoltDB {
-	switch c := args[index].(type) {
-	case BoltDB:
+	obj := args[index]
+	if c, yes := obj.(BoltDB); yes {
 		return c
-	default:
-		panic(RT.NewArgTypeError(index, c, "BoltDB"))
 	}
+	panic(FailArg(obj, "BoltDB", index))
 }
 
 func ExtractBoltDB(args []Object, index int) *bolt.DB {


### PR DESCRIPTION
This moves more of the repetitive code into a couple of new functions.

As a compiler writer, I'd expect the resulting binaries to be smaller; but they seem to get a tiny bit larger with this changeset. I'm not sure why, unless Go is somehow better at consolidating repeating code, when it's beyond a certain size or complexity, than writing (generating) less of it in the first place, when it might be not bothering?

But I think the results are easier to look at and understand, and (if merged) I think it puts my next chunk of `gostd` work in a better position, as that needs another "dimension" (or perhaps several) of ways to extract objects.