### PR TITLE
Fix float output

### DIFF
--- a/core/object.go
+++ b/core/object.go
@@ -1086,14 +1086,7 @@ func (d Double) ToString(escape bool) string {
 	if math.IsNaN(dbl) {
 		return "##NaN"
 	}
-	res := fmt.Sprintf("%f", dbl)
-	var i int
-	for i = len(res) - 1; res[i] == '0'; i-- {
-	}
-	if res[i] == '.' {
-		return res[0 : i+2]
-	}
-	return res[0 : i+1]
+	return fmt.Sprintf("%g", dbl)
 }
 
 func (d Double) Equals(other interface{}) bool {

--- a/core/object.go
+++ b/core/object.go
@@ -1086,7 +1086,11 @@ func (d Double) ToString(escape bool) string {
 	if math.IsNaN(dbl) {
 		return "##NaN"
 	}
-	return fmt.Sprintf("%g", dbl)
+	res := fmt.Sprintf("%g", dbl)
+	if strings.ContainsAny(res, ".e") {
+		return res
+	}
+	return res + ".0"
 }
 
 func (d Double) Equals(other interface{}) bool {

--- a/tests/eval/printer.joke
+++ b/tests/eval/printer.joke
@@ -16,3 +16,11 @@
     "##Inf" (joker.math/inf 1)
     "##-Inf" (joker.math/inf -1)
     "##NaN" (joker.math/nan)))
+
+(deftest print-double-values
+  (are [s v] (= s (pr-str v))
+    "1.9999999" 1.9999999
+    "1e-09" 1e-9
+    "1e-07" 1e-7
+    "0.001" 1e-3
+    "1.0" 1e0))


### PR DESCRIPTION
Fixes https://github.com/candid82/joker/issues/434.

Note that Go's "%g" format specifier always outputs exactly three non-whitespace runes after the "e" (for exponent), besides other differences to Clojure/JVM, such as using "e" instead of "E", and not ensuring the string preceding "e"/"E" has a decimal point and at least one trailing digit.

So `1e-7` renders as "1e-07", for example. (Clojure 1.10.1 renders this "1.0E-7".)

ClojureScript's output looks more like what Joker would with this PR applied, except it renders `1e-7` (or any numerical equivalent) as "1e-7", omitting the unnecessary leading 0. (It also renders values that can be precisely converted to integers as integers; this PR avoids doing that via some extra code, which I think is necessary to avoid bugs such as when formatting code that might depend on having the types strictly correct. In ClojureScript, or at least lumo 1.10.1, integers and floats all appear to become `Number` type; that's not true of Clojure nor Joker.)

As the Clojureverse seems to generally tend towards relying on the underlying run-time environment (JVM, JS, Go, etc), rather than strict specifications, to make such decisions, it should be okay for Joker to rely on "%g" with the current extra code to ensure the result would be read back in as a `Double`; but if we want to go further and remove the leading "0" after "e-", let me know and I'll make that change. Ditto replacing "e" with "E" and/or ensuring the preceding text looks like a floating-point value in isolation (e.g. "1.0" instead of just "1" before an "e"/"E").
