### PR TITLE
Linter Support for Validating Symbol/Keyword Characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,24 +139,6 @@ test.clj:1:1: Parse warning: let form with empty body
 ```
 The output format is as follows: `<filename>:<line>:<column>: <issue type>: <message>`, where `<issue type>` can be `Read error`, `Parse error`, `Parse warning` or `Exception`.
 
-### Valid Symbol (and Keyword) Characters
-
-The `--valid-letters` option specifies valid characters for symbol and keyword "letters", which are the non-special, non-digit characters that make up symbol names.
-
-While Clojure 1.10 allows, for example, em dashes in symbol names (which can lead to confusion), Joker does not; by default, it allows only Unicode letters (category L). E.g. `(def é "hey")` works as expected. `--valid-letters letters` specifies this explicitly.
-
-Earlier versions of Joker allowed any Unicode code points beyond MaxLatin1 (255, aka `0xff`) in addition to the ASCII letters (`[A-Z][a-z]`). This is more consistent with Clojure, in that it allows em dashes; e.g. `(def a–b "wow")`. Specify `--valid-letters unicode` for this behavior.
-
-Some developers prefer "strict ASCII". Joker supports this for symbol letters (though not for digits, which may be any Unicode digits) via `--valid-letters ascii`.
-
-On the other hand, `--valid-letters any` allows any character (not otherwise special, such as delimeters), including ASCII control characters.
-
-Note that `--valid-letters` affects only how symbols are parsed; `joker.core/symbol` is able to form a symbol from any string, regardless of content.
-
-Also note that, though most closely associated with linting, `--valid-letters` governs how symbols are parsed regardless of mode of operation (linting, running scripts, formatting, etc).
-
-Finally, the environment variable `JOKER_VALID_LETTERS` may be used to specify the default for `--valid-letters`.
-
 ### Integration with editors
 
 - Emacs: [flycheck syntax checker](https://github.com/candid82/flycheck-joker)
@@ -251,8 +233,8 @@ When linting directories Joker lints all files with the extension corresponding 
 When linting directories Joker can report globally unused namespaces and public vars. This is turned off by default but can be enabled with `--report-globally-unused` flag, e.g. `joker --lint --working-dir my-project --report-globally-unused`. This is useful for finding "dead" code. Some namespaces or vars are intended to be used by external systems (e.g. public API of a library or main function of a program). To exclude such namespaces and vars from being reported as globally unused list them in `:entry-points` vector in `.joker` file, which may contain the names of namespaces or fully qualified names of vars. For example:
 
 ```clojure
-:entry-points [my-project.public-api
-               my-project.core/-main]
+{:entry-points [my-project.public-api
+                my-project.core/-main]}
 ```
 
 ### Optional rules
@@ -260,13 +242,13 @@ When linting directories Joker can report globally unused namespaces and public 
 Joker supports a few configurable linting rules. To turn them on or off set their values to `true` or `false` in `:rules` map in `.joker` file. For example:
 
 ```clojure
-:rules {:if-without-else true
-        :no-forms-threading false}
+{:rules {:if-without-else true
+         :no-forms-threading false}}
 ```
 
 Below is the list of all configurable rules.
 
-|          Rule          |                      Description                      | Default value |
+| Rule                   | Description                                           | Default value |
 |------------------------|-------------------------------------------------------|---------------|
 | `if-without-else`      | warn on `if` without the `else` branch                | `false`       |
 | `no-forms-threading`   | warn on threading macros with no forms, i.e. `(-> a)` | `true`        |
@@ -274,6 +256,10 @@ Below is the list of all configurable rules.
 | `unused-keys`          | warn on unused `:keys`, `:strs`, and `:syms` bindings | `true`        |
 | `unused-fn-parameters` | warn on unused fn parameters                          | `false`       |
 | `fn-with-empty-body`   | warn on fn form with empty body                       | `true`        |
+| `invalid-letters`      | warn on symbols/keywords with non-special/non-digit   | `:letters`    |
+|                        | characters (normally letters) that are not `:unicode` |               |
+|                        | code points or letters; not `:letters` (category L);  |               |
+|                        | or not `:ascii` letters (`[A-Z][a-z]` as a regexp)    |               |
 
 Note that `unused binding` and `unused parameter` warnings are suppressed for names starting with underscore.
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Below is the list of all configurable rules.
 | `unused-keys`          | warn on unused `:keys`, `:strs`, and `:syms` bindings | `true`        |
 | `unused-fn-parameters` | warn on unused fn parameters                          | `false`       |
 | `fn-with-empty-body`   | warn on fn form with empty body                       | `true`        |
-| `invalid-letters`      | warn on symbols/keywords with non-special/non-digit   | `:letters`    |
+| `invalid-letters`      | warn on symbols/keywords with non-special/non-digit   | `:unicode`    |
 |                        | characters (normally letters) that are not `:unicode` |               |
 |                        | code points or letters; not `:letters` (category L);  |               |
 |                        | or not `:ascii` letters (`[A-Z][a-z]` as a regexp)    |               |

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Below is the list of all configurable rules.
 | `unused-keys`          | warn on unused `:keys`, `:strs`, and `:syms` bindings | `true`        |
 | `unused-fn-parameters` | warn on unused fn parameters                          | `false`       |
 | `fn-with-empty-body`   | warn on fn form with empty body                       | `true`        |
-| `invalid-letters`      | warn on symbols/keywords with non-special/non-digit   | `:unicode`    |
+| `valid-letters`        | warn on symbols/keywords with non-special/non-digit   | `:unicode`    |
 |                        | characters (normally letters) that are not `:unicode` |               |
 |                        | code points or letters; not `:letters` (category L);  |               |
 |                        | or not `:ascii` letters (`[A-Z][a-z]` as a regexp)    |               |

--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ test.clj:1:1: Parse warning: let form with empty body
 ```
 The output format is as follows: `<filename>:<line>:<column>: <issue type>: <message>`, where `<issue type>` can be `Read error`, `Parse error`, `Parse warning` or `Exception`.
 
+### Valid Symbol (and Keyword) Characters
+
+The `--valid-letters` option specifies valid characters for symbol and keyword "letters", which are the non-special, non-digit characters that make up symbol names.
+
+While Clojure 1.10 allows, for example, em dashes in symbol names (which can lead to confusion), Joker does not; by default, it allows only Unicode letters (category L). E.g. `(def é "hey")` works as expected. `--valid-letters letters` specifies this explicitly.
+
+Earlier versions of Joker allowed any Unicode code points beyond MaxLatin1 (255, aka `0xff`) in addition to the ASCII letters (`[A-Z][a-z]`). This is more consistent with Clojure, in that it allows em dashes; e.g. `(def a–b "wow")`. Specify `--valid-letters unicode` for this behavior.
+
+Some developers prefer "strict ASCII". Joker supports this for symbol letters (though not for digits, which may be any Unicode digits) via `--valid-letters ascii`.
+
+On the other hand, `--valid-letters any` allows any character (not otherwise special, such as delimeters), including ASCII control characters.
+
+Note that `--valid-letters` affects only how symbols are parsed; `joker.core/symbol` is able to form a symbol from any string, regardless of content.
+
+Also note that, though most closely associated with linting, `--valid-letters` governs how symbols are parsed regardless of mode of operation (linting, running scripts, formatting, etc).
+
+Finally, the environment variable `JOKER_VALID_LETTERS` may be used to specify the default for `--valid-letters`.
+
 ### Integration with editors
 
 - Emacs: [flycheck syntax checker](https://github.com/candid82/flycheck-joker)

--- a/core/parse.go
+++ b/core/parse.go
@@ -199,10 +199,11 @@ type (
 		dynamic            Keyword
 		require            Keyword
 		_import            Keyword
-		invalidLetters     Keyword
+		validLetters       Keyword
 		unicode            Keyword
 		letters            Keyword
 		ascii              Keyword
+		all                Keyword
 	}
 	Symbols struct {
 		joker_core         Symbol

--- a/core/parse.go
+++ b/core/parse.go
@@ -199,6 +199,10 @@ type (
 		dynamic            Keyword
 		require            Keyword
 		_import            Keyword
+		invalidLetters     Keyword
+		unicode            Keyword
+		letters            Keyword
+		ascii              Keyword
 	}
 	Symbols struct {
 		joker_core         Symbol

--- a/core/parse_slow_init.go
+++ b/core/parse_slow_init.go
@@ -42,6 +42,10 @@ var (
 		dynamic:            MakeKeyword("dynamic"),
 		require:            MakeKeyword("require"),
 		_import:            MakeKeyword("import"),
+		invalidLetters:     MakeKeyword("invalid-letters"),
+		unicode:            MakeKeyword("unicode"),
+		letters:            MakeKeyword("letters"),
+		ascii:              MakeKeyword("ascii"),
 	}
 	SYMBOLS = Symbols{
 		joker_core:         MakeSymbol("joker.core"),

--- a/core/parse_slow_init.go
+++ b/core/parse_slow_init.go
@@ -42,10 +42,11 @@ var (
 		dynamic:            MakeKeyword("dynamic"),
 		require:            MakeKeyword("require"),
 		_import:            MakeKeyword("import"),
-		invalidLetters:     MakeKeyword("invalid-letters"),
+		validLetters:       MakeKeyword("valid-letters"),
 		unicode:            MakeKeyword("unicode"),
 		letters:            MakeKeyword("letters"),
 		ascii:              MakeKeyword("ascii"),
+		all:                MakeKeyword("all"),
 	}
 	SYMBOLS = Symbols{
 		joker_core:         MakeSymbol("joker.core"),

--- a/core/procs.go
+++ b/core/procs.go
@@ -2021,7 +2021,7 @@ func ReadConfig(filename string, workingDir string) {
 		if ok, v := m.Get(KEYWORDS.fnWithEmptyBody); ok {
 			WARNINGS.fnWithEmptyBody = ToBool(v)
 		}
-		if ok, v := m.Get(KEYWORDS.invalidLetters); ok {
+		if ok, v := m.Get(KEYWORDS.validLetters); ok {
 			switch {
 			case v.Equals(KEYWORDS.unicode):
 				SetSymbolValidationUnicode()
@@ -2029,8 +2029,9 @@ func ReadConfig(filename string, workingDir string) {
 				SetSymbolValidationLetters()
 			case v.Equals(KEYWORDS.ascii):
 				SetSymbolValidationASCII()
+			case v.Equals(KEYWORDS.all):
 			default:
-				printConfigError(configFileName, ":invalid-letters value (in :rules) must be :unicode, :letters, or :ascii; got "+v.GetType().ToString(false)+" "+v.ToString(false))
+				printConfigError(configFileName, ":invalid-letters value (in :rules) must be :unicode, :letters, :ascii, or :all; got "+v.GetType().ToString(false)+" "+v.ToString(false))
 				return
 			}
 		}

--- a/core/procs.go
+++ b/core/procs.go
@@ -2021,6 +2021,19 @@ func ReadConfig(filename string, workingDir string) {
 		if ok, v := m.Get(KEYWORDS.fnWithEmptyBody); ok {
 			WARNINGS.fnWithEmptyBody = ToBool(v)
 		}
+		if ok, v := m.Get(KEYWORDS.invalidLetters); ok {
+			switch {
+			case v.Equals(KEYWORDS.unicode):
+				SetSymbolValidationUnicode()
+			case v.Equals(KEYWORDS.letters):
+				SetSymbolValidationLetters()
+			case v.Equals(KEYWORDS.ascii):
+				SetSymbolValidationASCII()
+			default:
+				printConfigError(configFileName, ":invalid-letters value (in :rules) must be :unicode, :letters, or :ascii; got "+v.GetType().ToString(false)+" "+v.ToString(false))
+				return
+			}
+		}
 	}
 	LINTER_CONFIG.Value = configMap
 }

--- a/core/read.go
+++ b/core/read.go
@@ -403,7 +403,7 @@ func AnyASCIILetterIsValid(r rune) bool {
 	return r <= unicode.MaxASCII && unicode.IsLetter(r)
 }
 
-var IsValidLetterFn = AnyUnicodeLetterIsValid
+var IsValidLetterFn = AnyUnicodeIsValid
 
 func isSymbolInitial(r rune) bool {
 	switch r {

--- a/core/read.go
+++ b/core/read.go
@@ -466,26 +466,9 @@ func readSymbol(reader *Reader, first rune) Object {
    ones (if new rules are desired), and c) hope for reasonably good
    performance. */
 
-/* Like isSymbolRune(), but returns false for other than special chars
-/* and digits (i.e. "letters" in the generic sense), so validation can
-/* check whether the chars that remain meet the criteria specified by
-/* LINTER_MODE :rules :invalid-letters. Parsing, already done by now,
-/* takes care of the initial and unique (e.g. '.') cases. */
-func isSymbolValidNonCharacter(r rune) bool {
-	switch r {
-	case '*', '+', '!', '-', '_', '?', ':', '=', '<', '>', '&', '%', '$', '|', '#', '/', '\'', '.':
-		return true
-	default:
-		if unicode.IsDigit(r) {
-			return true
-		}
-		return false
-	}
-}
-
 func isValidUnicode(s string) (bool, int) {
 	for i, r := range s {
-		if r <= unicode.MaxLatin1 && !unicode.IsLetter(r) && !isSymbolValidNonCharacter(r) {
+		if unicode.MaxASCII < r && r <= unicode.MaxLatin1 {
 			return false, i
 		}
 	}
@@ -494,7 +477,7 @@ func isValidUnicode(s string) (bool, int) {
 
 func isValidLetters(s string) (bool, int) {
 	for i, r := range s {
-		if !unicode.IsLetter(r) && !isSymbolValidNonCharacter(r) {
+		if unicode.MaxASCII < r && !unicode.IsLetter(r) {
 			return false, i
 		}
 	}
@@ -503,7 +486,7 @@ func isValidLetters(s string) (bool, int) {
 
 func isValidASCII(s string) (bool, int) {
 	for i, r := range s {
-		if (r > unicode.MaxASCII || !unicode.IsLetter(r)) && !isSymbolValidNonCharacter(r) {
+		if unicode.MaxASCII < r {
 			return false, i
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -369,22 +369,6 @@ func dialectFromArg(arg string) Dialect {
 	return UNKNOWN
 }
 
-func setValidLetters(arg, what string) {
-	switch strings.ToLower(arg) {
-	case "ascii":
-		IsValidLetterFn = AnyASCIILetterIsValid
-	case "letters":
-		IsValidLetterFn = AnyUnicodeLetterIsValid
-	case "unicode":
-		IsValidLetterFn = AnyUnicodeIsValid
-	case "any":
-		IsValidLetterFn = AnyRuneIsValid
-	default:
-		fmt.Fprintf(Stderr, "Error: Unrecognized %s '%s'.\n", what, arg)
-		ExitJoker(18)
-	}
-}
-
 func usage(out io.Writer) {
 	fmt.Fprintf(out, "Joker - %s\n\n", VERSION)
 	fmt.Fprintln(out, "Usage: joker [args] [-- <repl-args>]                starts a repl")
@@ -432,12 +416,6 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  --dialect <dialect>")
 	fmt.Fprintln(out, "    Set input dialect (\"clj\", \"cljs\", \"joker\", \"edn\") for linting;")
 	fmt.Fprintln(out, "    default is inferred from <filename> suffix, if any.")
-	fmt.Fprintln(out, "  --valid-letters <runes>")
-	fmt.Fprintln(out, "    Set valid runes for non-special/non-digit characters in symbol names; <runes> is:")
-	fmt.Fprintln(out, "      \"ascii\", denoting only [A-Za-z]")
-	fmt.Fprintln(out, "      \"letters\" (default), any Unicode Letter (category L)")
-	fmt.Fprintln(out, "      \"unicode\", [A-Za-z] or any Unicode code point beyond ASCII/Latin1 (255)")
-	fmt.Fprintln(out, "      \"any\", any character (that has no other specific meaning in Joker)")
 	fmt.Fprintln(out, "  --hashmap-threshold <n>")
 	fmt.Fprintln(out, "    Set HASHMAP_THRESHOLD accordingly (internal magic of some sort).")
 	fmt.Fprintln(out, "  --profiler <type>")
@@ -509,9 +487,6 @@ func parseArgs(args []string) {
 		classPath = v
 	} else {
 		classPath = ""
-	}
-	if v, ok := os.LookupEnv("JOKER_VALID_LETTERS"); ok {
-		setValidLetters(v, "JOKER_VALID_LETTERS environment-variable value")
 	}
 	var i int
 	for i = 1; i < length; i++ { // shift
@@ -589,13 +564,6 @@ func parseArgs(args []string) {
 			if i < length-1 && notOption(args[i+1]) {
 				i += 1 // shift
 				dialect = dialectFromArg(args[i])
-			} else {
-				missing = true
-			}
-		case "--valid-letters":
-			if i < length-1 && notOption(args[i+1]) {
-				i += 1 // shift
-				setValidLetters(args[i], "--valid-letters argument")
 			} else {
 				missing = true
 			}

--- a/main.go
+++ b/main.go
@@ -369,6 +369,22 @@ func dialectFromArg(arg string) Dialect {
 	return UNKNOWN
 }
 
+func setValidLetters(arg, what string) {
+	switch strings.ToLower(arg) {
+	case "ascii":
+		IsValidLetterFn = AnyASCIILetterIsValid
+	case "letters":
+		IsValidLetterFn = AnyUnicodeLetterIsValid
+	case "unicode":
+		IsValidLetterFn = AnyUnicodeIsValid
+	case "any":
+		IsValidLetterFn = AnyRuneIsValid
+	default:
+		fmt.Fprintf(Stderr, "Error: Unrecognized %s '%s'.\n", what, arg)
+		ExitJoker(18)
+	}
+}
+
 func usage(out io.Writer) {
 	fmt.Fprintf(out, "Joker - %s\n\n", VERSION)
 	fmt.Fprintln(out, "Usage: joker [args] [-- <repl-args>]                starts a repl")
@@ -416,6 +432,12 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  --dialect <dialect>")
 	fmt.Fprintln(out, "    Set input dialect (\"clj\", \"cljs\", \"joker\", \"edn\") for linting;")
 	fmt.Fprintln(out, "    default is inferred from <filename> suffix, if any.")
+	fmt.Fprintln(out, "  --valid-letters <runes>")
+	fmt.Fprintln(out, "    Set valid runes for non-special/non-digit characters in symbol names; <runes> is:")
+	fmt.Fprintln(out, "      \"ascii\", denoting only [A-Za-z]")
+	fmt.Fprintln(out, "      \"letters\" (default), any Unicode Letter (category L)")
+	fmt.Fprintln(out, "      \"unicode\", [A-Za-z] or any Unicode code point beyond ASCII/Latin1 (255)")
+	fmt.Fprintln(out, "      \"any\", any character (that has no other specific meaning in Joker)")
 	fmt.Fprintln(out, "  --hashmap-threshold <n>")
 	fmt.Fprintln(out, "    Set HASHMAP_THRESHOLD accordingly (internal magic of some sort).")
 	fmt.Fprintln(out, "  --profiler <type>")
@@ -487,6 +509,9 @@ func parseArgs(args []string) {
 		classPath = v
 	} else {
 		classPath = ""
+	}
+	if v, ok := os.LookupEnv("JOKER_VALID_LETTERS"); ok {
+		setValidLetters(v, "JOKER_VALID_LETTERS environment-variable value")
 	}
 	var i int
 	for i = 1; i < length; i++ { // shift
@@ -564,6 +589,13 @@ func parseArgs(args []string) {
 			if i < length-1 && notOption(args[i+1]) {
 				i += 1 // shift
 				dialect = dialectFromArg(args[i])
+			} else {
+				missing = true
+			}
+		case "--valid-letters":
+			if i < length-1 && notOption(args[i+1]) {
+				i += 1 // shift
+				setValidLetters(args[i], "--valid-letters argument")
 			} else {
 				missing = true
 			}


### PR DESCRIPTION
This is one approach to addressing https://github.com/candid82/joker/discussions/444.

Note that it changes Joker behavior in that it (by default) disallows em dashes, glyphs/graphics, and other such things in symbol/keyword names.

While that would make Joker less compatible with Clojure, I think it'd make a better argument for Joker as an effective linting and formatting tool, as it seems (to me) very unlikely any developers actually want such characters in symbol or keyword names in their source code.

But that default could be easily changed (to `--valid-letters unicode`) if stricter compatibility, out of the box, is desired.

If `--valid-letters ascii` is considered useful to/by some users, it might make sense to add a `--valid-digits` option to specify either `unicode` (the default) or `ascii` (only `[0-9]`); that possibility weighed on the decision on how to name `--valid-letters`. Limiting valid digits to only ASCII would affect parsing of not only symbol and keyword names, but (I would think) of numbers as well.