### PR TITLE
Better native conversion for (format ...)

### DIFF
--- a/core/procs.go
+++ b/core/procs.go
@@ -532,7 +532,7 @@ var procIsBound = func(args []Object) Object {
 // for use cases such as `(format "%x" value)`. Even for BigFloat and
 // BigRat, try to (accurately) convert them to native types so they
 // can be formatted via the usual ways.
-func toNative(obj Object) interface{} {
+func ToNative(obj Object) interface{} {
 	switch obj := obj.(type) {
 	case Native:
 		return obj.Native()
@@ -563,7 +563,7 @@ var procFormat = func(args []Object) Object {
 	objs := args[1:]
 	fargs := make([]interface{}, len(objs))
 	for i, v := range objs {
-		fargs[i] = toNative(v)
+		fargs[i] = ToNative(v)
 	}
 	res := fmt.Sprintf(s.S, fargs...)
 	return String{S: res}

--- a/tests/eval/format.joke
+++ b/tests/eval/format.joke
@@ -1,0 +1,10 @@
+(ns joker.test-joker.format
+  (:require [joker.test :refer [deftest is are]]))
+
+(defonce FF 1.23299299999999999999999999999999999999M)
+
+(deftest test-native
+  (are [x y] (= x y)
+    (format "%x" 0xFFFFFFFFFFFFFFFF) "ffffffffffffffff"
+    (format "%g" (- FF FF)) "0"
+    (format "%g" 1/2) "0.5" ))


### PR DESCRIPTION
This helps `(format ...)` produce useful results for format specifiers other than `%s`, such as `%x`, `%f`, and `%g`, when the operands don't fit into Native Joker types but can be accurately represented as native Go types.

The toNative() function is renamed so it's exported and thus usable by other libraries in the future.