### PR TITLE
Use math/big Package Properly

### DIFF
--- a/core/numbers.go
+++ b/core/numbers.go
@@ -58,9 +58,9 @@ func ratioOrInt(r *big.Rat) Number {
 			// TODO: 32-bit issue
 			return MakeInt(int(r.Num().Int64()))
 		}
-		return &BigInt{b: *r.Num()}
+		return &BigInt{b: r.Num()}
 	}
-	return &Ratio{r: *r}
+	return &Ratio{r: r}
 }
 
 func ratioOrIntWithOriginal(orig string, r *big.Rat) Number {
@@ -69,9 +69,9 @@ func ratioOrIntWithOriginal(orig string, r *big.Rat) Number {
 			// TODO: 32-bit issue
 			return MakeIntWithOriginal(orig, int(r.Num().Int64()))
 		}
-		return &BigInt{b: *r.Num(), Original: orig}
+		return &BigInt{b: r.Num(), Original: orig}
 	}
-	return &Ratio{r: *r, Original: orig}
+	return &Ratio{r: r, Original: orig}
 }
 
 func (ops IntOps) Combine(other Ops) Ops {
@@ -177,7 +177,7 @@ func (b *BigInt) Int() Int {
 }
 
 func (b *BigInt) BigInt() *big.Int {
-	return &b.b
+	return b.b
 }
 
 func (b *BigInt) Double() Double {
@@ -212,7 +212,7 @@ func (b *BigFloat) Double() Double {
 }
 
 func (b *BigFloat) BigFloat() *big.Float {
-	return &b.b
+	return b.b
 }
 
 func (b *BigFloat) Ratio() *big.Rat {
@@ -243,7 +243,7 @@ func (r *Ratio) BigFloat() *big.Float {
 }
 
 func (r *Ratio) Ratio() *big.Rat {
-	return &r.r
+	return r.r
 }
 
 // Ops
@@ -259,14 +259,14 @@ func (ops DoubleOps) Add(x, y Number) Number {
 }
 
 func (ops BigIntOps) Add(x, y Number) Number {
-	b := big.Int{}
+	b := &big.Int{}
 	b.Add(x.BigInt(), y.BigInt())
 	res := BigInt{b: b}
 	return &res
 }
 
 func (ops BigFloatOps) Add(x, y Number) Number {
-	b := big.Float{}
+	b := &big.Float{}
 	b.Add(x.BigFloat(), y.BigFloat())
 	res := BigFloat{b: b}
 	return &res
@@ -289,23 +289,23 @@ func (ops DoubleOps) Subtract(x, y Number) Number {
 }
 
 func (ops BigIntOps) Subtract(x, y Number) Number {
-	b := big.Int{}
+	b := &big.Int{}
 	b.Sub(x.BigInt(), y.BigInt())
 	res := BigInt{b: b}
 	return &res
 }
 
 func (ops BigFloatOps) Subtract(x, y Number) Number {
-	b := big.Float{}
+	b := &big.Float{}
 	b.Sub(x.BigFloat(), y.BigFloat())
 	res := BigFloat{b: b}
 	return &res
 }
 
 func (ops RatioOps) Subtract(x, y Number) Number {
-	r := big.Rat{}
+	r := &big.Rat{}
 	r.Sub(x.Ratio(), y.Ratio())
-	return ratioOrInt(&r)
+	return ratioOrInt(r)
 }
 
 // Multiply
@@ -319,14 +319,14 @@ func (ops DoubleOps) Multiply(x, y Number) Number {
 }
 
 func (ops BigIntOps) Multiply(x, y Number) Number {
-	b := big.Int{}
+	b := &big.Int{}
 	b.Mul(x.BigInt(), y.BigInt())
 	res := BigInt{b: b}
 	return &res
 }
 
 func (ops BigFloatOps) Multiply(x, y Number) Number {
-	b := big.Float{}
+	b := &big.Float{}
 	b.Mul(x.BigFloat(), y.BigFloat())
 	res := BigFloat{b: b}
 	return &res
@@ -358,10 +358,10 @@ func (ops DoubleOps) Divide(x, y Number) Number {
 
 func (ops BigIntOps) Divide(x, y Number) Number {
 	panicOnZero(ops, y)
-	b := big.Rat{}
+	b := &big.Rat{}
 	b.Quo(x.Ratio(), y.Ratio())
 	if b.IsInt() {
-		res := BigInt{b: *b.Num()}
+		res := BigInt{b: b.Num()}
 		return &res
 	}
 	res := Ratio{r: b}
@@ -369,7 +369,7 @@ func (ops BigIntOps) Divide(x, y Number) Number {
 }
 
 func (ops BigFloatOps) Divide(x, y Number) Number {
-	b := big.Float{}
+	b := &big.Float{}
 	b.Quo(x.BigFloat(), y.BigFloat())
 	res := BigFloat{b: b}
 	return &res
@@ -399,23 +399,23 @@ func (ops DoubleOps) Quotient(x, y Number) Number {
 
 func (ops BigIntOps) Quotient(x, y Number) Number {
 	panicOnZero(ops, y)
-	z := big.Int{}
+	z := &big.Int{}
 	z.Quo(x.BigInt(), y.BigInt())
 	return &BigInt{b: z}
 }
 
 func (ops BigFloatOps) Quotient(x, y Number) Number {
 	panicOnZero(ops, y)
-	z := big.Float{}
+	z := &big.Float{}
 	i, _ := z.Quo(x.BigFloat(), y.BigFloat()).Int64()
-	return &BigFloat{b: *z.SetInt64(i)}
+	return &BigFloat{b: z.SetInt64(i)}
 }
 
 func (ops RatioOps) Quotient(x, y Number) Number {
 	panicOnZero(ops, y)
-	z := big.Rat{}
+	z := &big.Rat{}
 	f, _ := z.Quo(x.Ratio(), y.Ratio()).Float64()
-	return &BigInt{b: *big.NewInt(int64(f))}
+	return &BigInt{b: big.NewInt(int64(f))}
 }
 
 // Remainder
@@ -435,7 +435,7 @@ func (ops DoubleOps) Rem(x, y Number) Number {
 
 func (ops BigIntOps) Rem(x, y Number) Number {
 	panicOnZero(ops, y)
-	z := big.Int{}
+	z := &big.Int{}
 	z.Rem(x.BigInt(), y.BigInt())
 	return &BigInt{b: z}
 }
@@ -444,7 +444,7 @@ func (ops BigFloatOps) Rem(x, y Number) Number {
 	panicOnZero(ops, y)
 	n := x.BigFloat()
 	d := y.BigFloat()
-	z := big.Float{}
+	z := &big.Float{}
 	i, _ := z.Quo(n, d).Int64()
 	d.Mul(d, big.NewFloat(float64(i)))
 	z.Sub(n, d)

--- a/core/object.go
+++ b/core/object.go
@@ -93,17 +93,17 @@ type (
 	}
 	BigInt struct {
 		InfoHolder
-		b        big.Int
+		b        *big.Int
 		Original string
 	}
 	BigFloat struct {
 		InfoHolder
-		b        big.Float
+		b        *big.Float
 		Original string
 	}
 	Ratio struct {
 		InfoHolder
-		r        big.Rat
+		r        *big.Rat
 		Original string
 	}
 	Boolean struct {
@@ -969,7 +969,7 @@ func (rat *Ratio) GetType() *Type {
 }
 
 func (rat *Ratio) Hash() uint32 {
-	return hashGobEncoder(&rat.r)
+	return hashGobEncoder(rat.r)
 }
 
 func (rat *Ratio) Compare(other Object) int {
@@ -977,7 +977,7 @@ func (rat *Ratio) Compare(other Object) int {
 }
 
 func MakeBigInt(bi int64) *BigInt {
-	return &BigInt{b: *big.NewInt(bi)}
+	return &BigInt{b: big.NewInt(bi)}
 }
 
 func (bi *BigInt) ToString(escape bool) string {
@@ -996,7 +996,7 @@ func (bi *BigInt) GetType() *Type {
 }
 
 func (bi *BigInt) Hash() uint32 {
-	return hashGobEncoder(&bi.b)
+	return hashGobEncoder(bi.b)
 }
 
 func (bi *BigInt) Compare(other Object) int {
@@ -1026,7 +1026,7 @@ func (bf *BigFloat) GetType() *Type {
 }
 
 func (bf *BigFloat) Hash() uint32 {
-	return hashGobEncoder(&bf.b)
+	return hashGobEncoder(bf.b)
 }
 
 func (bf *BigFloat) Compare(other Object) int {

--- a/core/procs.go
+++ b/core/procs.go
@@ -843,20 +843,20 @@ var procBoolean = func(args []Object) Object {
 
 var procNumerator = func(args []Object) Object {
 	bi := EnsureArgIsRatio(args, 0).r.Num()
-	return &BigInt{b: *bi}
+	return &BigInt{b: bi}
 }
 
 var procDenominator = func(args []Object) Object {
 	bi := EnsureArgIsRatio(args, 0).r.Denom()
-	return &BigInt{b: *bi}
+	return &BigInt{b: bi}
 }
 
 var procBigInt = func(args []Object) Object {
 	switch n := args[0].(type) {
 	case Number:
-		return &BigInt{b: *n.BigInt()}
+		return &BigInt{b: n.BigInt()}
 	case String:
-		bi := big.Int{}
+		bi := &big.Int{}
 		if _, ok := bi.SetString(n.S, 10); ok {
 			return &BigInt{b: bi}
 		}
@@ -869,9 +869,9 @@ var procBigInt = func(args []Object) Object {
 var procBigFloat = func(args []Object) Object {
 	switch n := args[0].(type) {
 	case Number:
-		return &BigFloat{b: *n.BigFloat()}
+		return &BigFloat{b: n.BigFloat()}
 	case String:
-		b := big.Float{}
+		b := &big.Float{}
 		if _, ok := b.SetString(n.S); ok {
 			return &BigFloat{b: b}
 		}
@@ -1177,7 +1177,7 @@ var procReaderReadLine = func(args []Object) Object {
 }
 
 var procNanoTime = func(args []Object) Object {
-	return &BigInt{b: *big.NewInt(time.Now().UnixNano())}
+	return &BigInt{b: big.NewInt(time.Now().UnixNano())}
 }
 
 var procMacroexpand1 = func(args []Object) Object {

--- a/core/read.go
+++ b/core/read.go
@@ -294,7 +294,7 @@ func invalidNumberError(reader *Reader, str string) error {
 }
 
 func scanBigInt(orig, str string, base int, reader *Reader) Object {
-	var bi *big.Int
+	var bi = &big.Int{}
 	if _, ok := bi.SetString(str, base); !ok {
 		panic(invalidNumberError(reader, str))
 	}
@@ -303,15 +303,15 @@ func scanBigInt(orig, str string, base int, reader *Reader) Object {
 }
 
 func scanRatio(str string, reader *Reader) Object {
-	var rat big.Rat
+	var rat = &big.Rat{}
 	if _, ok := rat.SetString(str); !ok {
 		panic(invalidNumberError(reader, str))
 	}
-	return MakeReadObject(reader, ratioOrIntWithOriginal(str, &rat))
+	return MakeReadObject(reader, ratioOrIntWithOriginal(str, rat))
 }
 
 func scanBigFloat(orig, str string, reader *Reader) Object {
-	var bf *big.Float
+	var bf = &big.Float{}
 	if _, ok := bf.SetPrec(256).SetString(str); !ok {
 		panic(invalidNumberError(reader, str))
 	}

--- a/core/read.go
+++ b/core/read.go
@@ -294,7 +294,7 @@ func invalidNumberError(reader *Reader, str string) error {
 }
 
 func scanBigInt(orig, str string, base int, reader *Reader) Object {
-	var bi big.Int
+	var bi *big.Int
 	if _, ok := bi.SetString(str, base); !ok {
 		panic(invalidNumberError(reader, str))
 	}
@@ -311,7 +311,7 @@ func scanRatio(str string, reader *Reader) Object {
 }
 
 func scanBigFloat(orig, str string, reader *Reader) Object {
-	var bf big.Float
+	var bf *big.Float
 	if _, ok := bf.SetPrec(256).SetString(str); !ok {
 		panic(invalidNumberError(reader, str))
 	}


### PR DESCRIPTION
The docs for big.Float, big.Int, and big.Rat specify that objects of those types shouldn't be copied (except via the appropriate `.Set()` method), but rather that pointers to them be used:

> shallow copies of <type>s are not supported and may lead to errors

It seems best (and fairly straightforward) to conform to those requirements.