### PR TITLE
Keep on Linting After Parse Errors

### DIFF
--- a/core/procs.go
+++ b/core/procs.go
@@ -1782,10 +1782,12 @@ func ProcessReader(reader *Reader, filename string, phase Phase) error {
 		expr, err := TryParse(obj, parseContext)
 		if err != nil {
 			fmt.Fprintln(Stderr, err)
-			return err
 		}
 		if phase == PARSE {
 			continue
+		}
+		if err != nil {
+			return err
 		}
 		obj, err = TryEval(expr)
 		if err != nil {

--- a/tests/linter/macro-call/input.clj
+++ b/tests/linter/macro-call/input.clj
@@ -6,5 +6,5 @@
 (definterface)
 (proxy-super)
 (with-open)
+(deftype)
 (defrecord)
-

--- a/tests/linter/macro-call/output.txt
+++ b/tests/linter/macro-call/output.txt
@@ -6,4 +6,5 @@ tests/linter/macro-call/input.clj:5:1: Parse warning: Wrong number of args (0) p
 tests/linter/macro-call/input.clj:6:1: Parse warning: Wrong number of args (0) passed to core/definterface
 tests/linter/macro-call/input.clj:7:1: Parse warning: Wrong number of args (0) passed to core/proxy-super
 tests/linter/macro-call/input.clj:8:1: Parse warning: Wrong number of args (0) passed to core/with-open
-tests/linter/macro-call/input.clj:9:1: Eval error: Wrong number of args (0) passed to core/defrecord; expects at least 3
+tests/linter/macro-call/input.clj:9:1: Eval error: Wrong number of args (0) passed to core/deftype; expects at least 3
+tests/linter/macro-call/input.clj:10:1: Eval error: Wrong number of args (0) passed to core/defrecord; expects at least 3

--- a/tests/linter/ns-4/output.txt
+++ b/tests/linter/ns-4/output.txt
@@ -1,1 +1,2 @@
 tests/linter/ns-4/input.clj:2:14: Exception: :only/:refer value must be a sequential collection of symbols
+tests/linter/ns-4/input.clj:2:14: Parse warning: unused namespace tt

--- a/tests/linter/ns-6/output.txt
+++ b/tests/linter/ns-6/output.txt
@@ -1,3 +1,4 @@
 tests/linter/ns-6/input.clj:4:7: Parse warning: WARNING: map already refers to: #'joker.core/map in namespace test, being replaced by: #'test/map
 
 tests/linter/ns-6/input.clj:5:6: Eval error: WARNING: f already refers to: #'other.ns/f in namespace test
+tests/linter/ns-6/input.clj:2:14: Parse warning: unused namespace other.ns

--- a/tests/linter/ns-8/output.txt
+++ b/tests/linter/ns-8/output.txt
@@ -1,1 +1,2 @@
 tests/linter/ns-8/input.clj:2:18: Exception: Unsupported option(s) supplied: :default
+tests/linter/ns-8/input.clj:4:1: Parse error: Unable to resolve symbol: RaisedButton/t


### PR DESCRIPTION
The first commit herein, changing the `macro-call` linter test, illustrates what seems to be an inconsistency with regard to whether linting (or, more generally, parsing without evaluation) continues after an error.

This PR tries to clean up some such inconsistencies, but it's not 100% clear to me this is The Right Thing To Do. Still, it might be what people reasonably expect when linting (e.g. that a malformed macro invocation doesn't shut down further linting).

A potential problem with this is "runaway errors", such as when an early parsing error causes a deluge of downstream errors for code that's just fine once that early error is fixed.

The Go compiler mitigates such situations with a "too many errors" diagnostic after some number of errors. That might be worth considering, and I'm happy to implement that, even if what constitutes a "potentially fatal" diagnostic (contributing to such a count and potential aborting of further linting) versus a mere "error" might remain difficult to apprehend.