### PR TITLE
have read__ wrap io.Reader

### DIFF
--- a/core/procs.go
+++ b/core/procs.go
@@ -1147,7 +1147,7 @@ var procRead = func(args []Object) Object {
 	default:
 		panic(RT.NewArgTypeError(0, args[0], "io.RuneReader or io.Reader"))
 	}
-	return readFromReader(f)
+	return readFromReader(r)
 }
 
 var procReadString = func(args []Object) Object {

--- a/core/procs.go
+++ b/core/procs.go
@@ -1138,7 +1138,15 @@ func readFromReader(reader io.RuneReader) Object {
 }
 
 var procRead = func(args []Object) Object {
-	f := EnsureArgIsio_RuneReader(args, 0)
+	var r io.RuneReader
+	switch f := args[0].(type) {
+	case io.RuneReader:
+		r = f
+	case io.Reader:
+		r = bufio.NewReader(f)
+	default:
+		panic(RT.NewArgTypeError(0, args[0], "io.RuneReader or io.Reader"))
+	}
 	return readFromReader(f)
 }
 


### PR DESCRIPTION
today, if you write `(read (os/open f))` then Joker will crash telling you that it expected a RuneReader but that you gave it a File

so this PR implements a very small change to `read` that will wrap `io.Reader` (which File implements) in bufio.NewReader (which implements RuneReader)