### PR TITLE
Fix eduction definition.

### DIFF
--- a/core/data/linter_clj.joke
+++ b/core/data/linter_clj.joke
@@ -80,7 +80,7 @@
 
 (defn ensure [ref])
 (defn unchecked-remainder-int [x y])
-(defn eduction [xform* coll])
+(defn eduction [& xforms])
 (defn aset ([array idx val]) ([array idx idx2 & idxv]))
 (defn aset-float ([array idx val]) ([array idx idx2 & idxv]))
 (defn ->VecNode [edit arr])


### PR DESCRIPTION
`xform*` has no special syntactic meaning in Clojure/joker and thus valid uses like `(eduction (map inc) (map inc) coll)` get flagged for argument count mismatch. Looks like joker correctly adjusts this definition [for ClojureScript](https://github.com/candid82/joker/blob/53f815b06e61a633740bfbb70bc08c40251e391c/core/data/linter_cljs.joke#L46) but not Clojure.