### PR TITLE
json-seq: add the keywords option

### DIFF
--- a/std/json.joke
+++ b/std/json.joke
@@ -21,7 +21,11 @@
 
 (defn json-seq
   "Returns the json records from rdr as a lazy sequence.
-  rdr must be a string or implement io.Reader."
+  rdr must be a string or implement io.Reader.
+  Optional opts map may have the following keys:
+  :keywords? - if true, JSON keys will be converted from strings to keywords."
   {:added "1.0"
-  :go "jsonSeqOpts(rdr)"}
-  [^Object rdr])
+  :go {1 "jsonSeqOpts(rdr, EmptyArrayMap())"
+       2 "jsonSeqOpts(rdr, opts)"}}
+  ([^Object rdr])
+  ([^Object rdr ^Map opts]))

--- a/std/json/a_json.go
+++ b/std/json/a_json.go
@@ -14,7 +14,13 @@ func __json_seq_(_args []Object) Object {
 	switch {
 	case _c == 1:
 		rdr := ExtractObject(_args, 0)
-		_res := jsonSeqOpts(rdr)
+		_res := jsonSeqOpts(rdr, EmptyArrayMap())
+		return _res
+
+	case _c == 2:
+		rdr := ExtractObject(_args, 0)
+		opts := ExtractMap(_args, 1)
+		_res := jsonSeqOpts(rdr, opts)
 		return _res
 
 	default:

--- a/std/json/a_json_slow_init.go
+++ b/std/json/a_json_slow_init.go
@@ -16,9 +16,11 @@ func InternsOrThunks() {
 
 	jsonNamespace.InternVar("json-seq", json_seq_,
 		MakeMeta(
-			NewListFrom(NewVectorFrom(MakeSymbol("rdr"))),
+			NewListFrom(NewVectorFrom(MakeSymbol("rdr")), NewVectorFrom(MakeSymbol("rdr"), MakeSymbol("opts"))),
 			`Returns the json records from rdr as a lazy sequence.
-  rdr must be a string or implement io.Reader.`, "1.0"))
+  rdr must be a string or implement io.Reader.
+  Optional opts map may have the following keys:
+  :keywords? - if true, JSON keys will be converted from strings to keywords.`, "1.0"))
 
 	jsonNamespace.InternVar("read-string", read_string_,
 		MakeMeta(


### PR DESCRIPTION
Make the `json-seq` function accept the `keywords?` option for symmetry with `read-string`.