### PR TITLE
Support explicit environment in joker.os/exec

### DIFF
--- a/std/os.joke
+++ b/std/os.joke
@@ -159,7 +159,7 @@
       :out - string capturing stdout of the program,
       :err - string capturing stderr of the program."
   {:added "1.0"
-   :go "sh(\"\", nil, nil, nil, name, arguments)"}
+   :go "sh(\"\", nil, nil, nil, nil, name, arguments)"}
   [^String name & ^String arguments])
 
 (defn sh-from
@@ -171,13 +171,16 @@
       :out - string capturing stdout of the program,
       :err - string capturing stderr of the program."
   {:added "1.0"
-   :go "sh(dir, nil, nil, nil, name, arguments)"}
+   :go "sh(dir, nil, nil, nil, nil, name, arguments)"}
   [^String dir ^String name & ^String arguments])
 
 (defn exec
   "Executes the named program with the given arguments. opts is a map with the following keys (all optional):
-  :args - vector of arguments (all arguments must be strings),
-  :dir - if specified, working directory will be set to this value before executing the program,
+  :args - vector of arguments (all arguments must be strings).
+  :dir - if specified, working directory will be set to this value before executing the program.
+  :env - if specified and true, the environment will be set to the current environment before executing the program. Otherwise,
+    the environment will be determined by the Go runtime which, if :dir is specified, might or might not map $PWD to the expected
+    value -- it might be the current $PWD but, as of Go 1.19, is expected to be set to the value of :dir.
   :stdin - if specified, provides stdin for the program. Can be either a string or an IOReader.
   If it's a string, the string's content will serve as stdin for the program. IOReader can be, for example,
   *in* (in which case Joker's stdin will be redirected to the program's stdin) or the value returned by (joker.os/open).
@@ -185,10 +188,10 @@
   to Joker's stdout) or the value returned by (joker.os/create).
   :stderr - the same as :stdout, but for stderr.
   Returns a map with the following keys:
-  :success - whether or not the execution was successful,
+  :success - whether or not the execution was successful.
   :err-msg (present iff :success if false) - string capturing error object returned by Go runtime
-  :exit - exit code of program (or attempt to execute it),
-  :out - string capturing stdout of the program (unless :stdout option was passed)
+  :exit - exit code of program (or attempt to execute it).
+  :out - string capturing stdout of the program (unless :stdout option was passed).
   :err - string capturing stderr of the program (unless :stderr option was passed)."
   {:added "1.0"
    :go "execute(name, opts)"}

--- a/std/os/a_os.go
+++ b/std/os/a_os.go
@@ -727,7 +727,7 @@ func __sh_(_args []Object) Object {
 		CheckArity(_args, 1, 999)
 		name := ExtractString(_args, 0)
 		arguments := ExtractStrings(_args, 1)
-		_res := sh("", nil, nil, nil, name, arguments)
+		_res := sh("", nil, nil, nil, nil, name, arguments)
 		return _res
 
 	default:
@@ -747,7 +747,7 @@ func __sh_from_(_args []Object) Object {
 		dir := ExtractString(_args, 0)
 		name := ExtractString(_args, 1)
 		arguments := ExtractStrings(_args, 2)
-		_res := sh(dir, nil, nil, nil, name, arguments)
+		_res := sh(dir, nil, nil, nil, nil, name, arguments)
 		return _res
 
 	default:

--- a/std/os/a_os_slow_init.go
+++ b/std/os/a_os_slow_init.go
@@ -91,8 +91,11 @@ func InternsOrThunks() {
 		MakeMeta(
 			NewListFrom(NewVectorFrom(MakeSymbol("name"), MakeSymbol("opts"))),
 			`Executes the named program with the given arguments. opts is a map with the following keys (all optional):
-  :args - vector of arguments (all arguments must be strings),
-  :dir - if specified, working directory will be set to this value before executing the program,
+  :args - vector of arguments (all arguments must be strings).
+  :dir - if specified, working directory will be set to this value before executing the program.
+  :env - if specified and true, the environment will be set to the current environment before executing the program. Otherwise,
+    the environment will be determined by the Go runtime which, if :dir is specified, might or might not map $PWD to the expected
+    value -- it might be the current $PWD but, as of Go 1.19, is expected to be set to the value of :dir.
   :stdin - if specified, provides stdin for the program. Can be either a string or an IOReader.
   If it's a string, the string's content will serve as stdin for the program. IOReader can be, for example,
   *in* (in which case Joker's stdin will be redirected to the program's stdin) or the value returned by (joker.os/open).
@@ -100,10 +103,10 @@ func InternsOrThunks() {
   to Joker's stdout) or the value returned by (joker.os/create).
   :stderr - the same as :stdout, but for stderr.
   Returns a map with the following keys:
-  :success - whether or not the execution was successful,
+  :success - whether or not the execution was successful.
   :err-msg (present iff :success if false) - string capturing error object returned by Go runtime
-  :exit - exit code of program (or attempt to execute it),
-  :out - string capturing stdout of the program (unless :stdout option was passed)
+  :exit - exit code of program (or attempt to execute it).
+  :out - string capturing stdout of the program (unless :stdout option was passed).
   :err - string capturing stderr of the program (unless :stderr option was passed).`, "1.0"))
 
 	osNamespace.InternVar("executable", executable_,

--- a/std/os/os_native.go
+++ b/std/os/os_native.go
@@ -37,7 +37,7 @@ const defaultFailedCode = 127 // seen from 'sh no-such-file' on OS X and Ubuntu
 
 func execute(name string, opts Map) Object {
 	var dir string
-	var args []string
+	var args, env []string
 	var stdin io.Reader
 	var stdout, stderr io.Writer
 	if ok, dirObj := opts.Get(MakeKeyword("dir")); ok && !dirObj.Equals(NIL) {
@@ -48,6 +48,11 @@ func execute(name string, opts Map) Object {
 		for !s.IsEmpty() {
 			args = append(args, EnsureObjectIsString(s.First(), "args: %s").S)
 			s = s.Rest()
+		}
+	}
+	if ok, envObj := opts.Get(MakeKeyword("env")); ok {
+		if b := EnsureObjectIsBoolean(envObj, ":env must be a Boolean: %s").B; b {
+			env = os.Environ()
 		}
 	}
 	if ok, stdinObj := opts.Get(MakeKeyword("stdin")); ok {
@@ -92,7 +97,7 @@ func execute(name string, opts Map) Object {
 			panic(RT.NewError("stderr option must be an IOWriter, got " + stderrObj.GetType().ToString(false)))
 		}
 	}
-	return sh(dir, stdin, stdout, stderr, name, args)
+	return sh(dir, stdin, stdout, stderr, env, name, args)
 }
 
 func readDir(dirname string) Object {

--- a/std/os/sh.go
+++ b/std/os/sh.go
@@ -12,10 +12,11 @@ import (
 	. "github.com/candid82/joker/core"
 )
 
-func sh(dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer, name string, args []string) Object {
+func sh(dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer, env []string, name string, args []string) Object {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Stdin = stdin
+	cmd.Env = env
 
 	var stdoutBuffer, stderrBuffer bytes.Buffer
 	if stdout != nil {

--- a/std/os/sh_plan9.go
+++ b/std/os/sh_plan9.go
@@ -8,10 +8,11 @@ import (
 	. "github.com/candid82/joker/core"
 )
 
-func sh(dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer, name string, args []string) Object {
+func sh(dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer, env []string, name string, args []string) Object {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Stdin = stdin
+	cmd.Env = env
 
 	var stdoutBuffer, stderrBuffer bytes.Buffer
 	if stdout != nil {

--- a/tests/run-eval-tests.joke
+++ b/tests/run-eval-tests.joke
@@ -25,7 +25,7 @@
   (let [dir (str "tests/eval/" test-dir "/")
         filename "input.joke"
         stdin (slurp-or (str dir "stdin.txt") *in*)
-        res (joker.os/exec joker-cmd {:dir dir :args [filename] :stdin stdin})
+        res (joker.os/exec joker-cmd {:dir dir :args [filename] :stdin stdin :env true})
         out (:out res)
         err (:err res)
         rc (:exit res)


### PR DESCRIPTION
This adds support for a `:env` hash key when calling `joker.os/exec`. When its value is `true`, the current environment (as might be returned by `joker.os/env` as a hash) is used for the new process's environment. When unspecified or its value is `false`, the behavior of Joker itself is unchanged; but the Go runtime might, as of 1.19, set the `PWD` environment variable, in that new environment, to the value of `:dir` (if specified), changing the behavior of some existing code.

Fixes #479 

It might make sense to someday either EOL this capability (ignore `:env`) or extend it to support a hash or even an array (which would be the lower-level array of strings containing `key=value` settings).

Note that this doesn't fix any existing code, using `joker.os/sh` or `joker.os/sh-from`, that depends on the new environment having the old value of `PWD`.