### PR TITLE
Pass path to Joke executable as arg to eval/*/input.joke

### DIFF
--- a/tests/eval/large-forked-stdout/input.joke
+++ b/tests/eval/large-forked-stdout/input.joke
@@ -2,7 +2,7 @@
   (:require [joker.os :as os]
             [joker.string :as s]))
 
-(let [exe (str (get (joker.os/env) "PWD") "/joker")
+(let [exe (nth *command-line-args* 0)
       res (os/sh exe "lots-of-stderr.joke")]
   (print (:out res))
   (let [ev (s/split-lines (:err res))]

--- a/tests/run-eval-tests.joke
+++ b/tests/run-eval-tests.joke
@@ -25,7 +25,7 @@
   (let [dir (str "tests/eval/" test-dir "/")
         filename "input.joke"
         stdin (slurp-or (str dir "stdin.txt") *in*)
-        res (joker.os/exec joker-cmd {:dir dir :args [filename] :stdin stdin})
+        res (joker.os/exec joker-cmd {:dir dir :args [filename joker-cmd] :stdin stdin})
         out (:out res)
         err (:err res)
         rc (:exit res)


### PR DESCRIPTION
Fixes https://github.com/candid82/joker/issues/479 by not relying on `$PWD` being set as previously expected (before Go 1.19), which wasn't quite correct anyway, across a fork/exec.