### PR TITLE
Add control over markdown rendering options

### DIFF
--- a/docs/joker.markdown.html
+++ b/docs/joker.markdown.html
@@ -49,8 +49,14 @@
   <span class="var-kind Function">Function</span>
   <span class="var-added">v1.0</span>
   <pre class="var-usage"><div><code>(convert-string s)</code></div>
+<div><code>(convert-string s opts)</code></div>
 </pre>
-  <p class="var-docstr">Returns the HTML rendering of Markdown string s</p>
+  <p class="var-docstr">Returns the HTML rendering of Markdown string s `opts` is an optional map of boolean rendering options (all default to tru to `true`)<br>
+<br>
+  :with-hard-wraps? - Render newlines as &lt;br&gt;.<br>
+  :with-xhtml? - Render as XHTML.<br>
+  :with-unsafe? - When false, all raw html will be omitted from the output. When true html is passed through unchanged.<br>
+  </p>
   
   
 </li>

--- a/docs/joker.markdown.html
+++ b/docs/joker.markdown.html
@@ -51,7 +51,8 @@
   <pre class="var-usage"><div><code>(convert-string s)</code></div>
 <div><code>(convert-string s opts)</code></div>
 </pre>
-  <p class="var-docstr">Returns the HTML rendering of Markdown string s `opts` is an optional map of boolean rendering options (all default to tru to `true`)<br>
+  <p class="var-docstr">Returns the HTML rendering of Markdown string s.<br>
+  opts is an optional map of boolean rendering options (all default to true)<br>
 <br>
   :with-hard-wraps? - Render newlines as &lt;br&gt;.<br>
   :with-xhtml? - Render as XHTML.<br>

--- a/std/markdown.joke
+++ b/std/markdown.joke
@@ -4,7 +4,14 @@
   markdown)
 
 (defn ^String convert-string
-  "Returns the HTML rendering of Markdown string s"
+  "Returns the HTML rendering of Markdown string s `opts` is an optional map of boolean rendering options (all default to tru to `true`)
+
+  :with-hard-wraps? - Render newlines as <br>.
+  :with-xhtml? - Render as XHTML.
+  :with-unsafe? - When false, all raw html will be omitted from the output. When true html is passed through unchanged.
+  "
   {:added "1.0"
-  :go "convertString(s)"}
-  [^String s])
+   :go {1 "convertString(s)"
+        2 "convertStringOpts(s, opts)"}}
+   ([^String s])
+   ([^String s ^Object opts]))

--- a/std/markdown.joke
+++ b/std/markdown.joke
@@ -4,7 +4,8 @@
   markdown)
 
 (defn ^String convert-string
-  "Returns the HTML rendering of Markdown string s `opts` is an optional map of boolean rendering options (all default to tru to `true`)
+  "Returns the HTML rendering of Markdown string s.
+  opts is an optional map of boolean rendering options (all default to true)
 
   :with-hard-wraps? - Render newlines as <br>.
   :with-xhtml? - Render as XHTML.

--- a/std/markdown.joke
+++ b/std/markdown.joke
@@ -15,4 +15,4 @@
    :go {1 "convertString(s)"
         2 "convertStringOpts(s, opts)"}}
    ([^String s])
-   ([^String s ^Object opts]))
+   ([^String s ^Map opts]))

--- a/std/markdown/a_markdown.go
+++ b/std/markdown/a_markdown.go
@@ -17,6 +17,12 @@ func __convert_string_(_args []Object) Object {
 		_res := convertString(s)
 		return MakeString(_res)
 
+	case _c == 2:
+		s := ExtractString(_args, 0)
+		opts := ExtractObject(_args, 1)
+		_res := convertStringOpts(s, opts)
+		return MakeString(_res)
+
 	default:
 		PanicArity(_c)
 	}

--- a/std/markdown/a_markdown.go
+++ b/std/markdown/a_markdown.go
@@ -19,7 +19,7 @@ func __convert_string_(_args []Object) Object {
 
 	case _c == 2:
 		s := ExtractString(_args, 0)
-		opts := ExtractObject(_args, 1)
+		opts := ExtractMap(_args, 1)
 		_res := convertStringOpts(s, opts)
 		return MakeString(_res)
 

--- a/std/markdown/a_markdown_slow_init.go
+++ b/std/markdown/a_markdown_slow_init.go
@@ -16,7 +16,12 @@ func InternsOrThunks() {
 
 	markdownNamespace.InternVar("convert-string", convert_string_,
 		MakeMeta(
-			NewListFrom(NewVectorFrom(MakeSymbol("s"))),
-			`Returns the HTML rendering of Markdown string s`, "1.0").Plus(MakeKeyword("tag"), String{S: "String"}))
+			NewListFrom(NewVectorFrom(MakeSymbol("s")), NewVectorFrom(MakeSymbol("s"), MakeSymbol("opts"))),
+			`Returns the HTML rendering of Markdown string s `+"`"+`opts`+"`"+` is an optional map of boolean rendering options (all default to tru to `+"`"+`true`+"`"+`)
+
+  :with-hard-wraps? - Render newlines as <br>.
+  :with-xhtml? - Render as XHTML.
+  :with-unsafe? - When false, all raw html will be omitted from the output. When true html is passed through unchanged.
+  `, "1.0").Plus(MakeKeyword("tag"), String{S: "String"}))
 
 }

--- a/std/markdown/a_markdown_slow_init.go
+++ b/std/markdown/a_markdown_slow_init.go
@@ -17,7 +17,8 @@ func InternsOrThunks() {
 	markdownNamespace.InternVar("convert-string", convert_string_,
 		MakeMeta(
 			NewListFrom(NewVectorFrom(MakeSymbol("s")), NewVectorFrom(MakeSymbol("s"), MakeSymbol("opts"))),
-			`Returns the HTML rendering of Markdown string s `+"`"+`opts`+"`"+` is an optional map of boolean rendering options (all default to tru to `+"`"+`true`+"`"+`)
+			`Returns the HTML rendering of Markdown string s.
+  opts is an optional map of boolean rendering options (all default to true)
 
   :with-hard-wraps? - Render newlines as <br>.
   :with-xhtml? - Render as XHTML.

--- a/std/markdown/markdown_native.go
+++ b/std/markdown/markdown_native.go
@@ -6,7 +6,10 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/renderer/html"
+
+	. "github.com/candid82/joker/core"
 )
 
 func convertString(source string) string {
@@ -26,6 +29,54 @@ func convertString(source string) string {
 			html.WithXHTML(),
 			html.WithUnsafe(), // allow for raw markup
 		),
+	)
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(source), &buf); err != nil {
+		panic(err)
+	}
+	return buf.String()
+}
+
+func getKeywordFlag(opts Map, name string, def bool) bool {
+	ok, entry := opts.Get(MakeKeyword(name))
+	if !ok {
+		return def
+	}
+	val, ok := entry.(Boolean)
+	if !ok {
+		panic(RT.NewError("flags must be a boolean"))
+	}
+	return val.B
+}
+
+func convertStringOpts(source string, opts Object) string {
+	options, ok := opts.(Map)
+	if !ok {
+		panic(RT.NewError("Options must be a map"))
+	}
+
+	renderOptions := []renderer.Option{}
+	if flag := getKeywordFlag(options, "with-hard-wraps?", true); flag {
+		renderOptions = append(renderOptions, html.WithHardWraps())
+	}
+	if flag := getKeywordFlag(options, "with-xhtml?", true); flag {
+		renderOptions = append(renderOptions, html.WithXHTML())
+	}
+	if flag := getKeywordFlag(options, "with-unsafe?", true); flag {
+		renderOptions = append(renderOptions, html.WithUnsafe())
+	}
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			extension.GFM,
+			extension.Table,
+			extension.DefinitionList,
+			extension.Footnote,
+			extension.Typographer,
+		),
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+		goldmark.WithRendererOptions(renderOptions...),
 	)
 	var buf bytes.Buffer
 	if err := md.Convert([]byte(source), &buf); err != nil {

--- a/tests/eval/markdown.joke
+++ b/tests/eval/markdown.joke
@@ -1,0 +1,41 @@
+(ns joker.test-joker.markdown
+  (:require [joker.test :refer [deftest is are]]
+            [joker.markdown :as md]))
+
+(def input "one\ntwo")
+
+(deftest with-hard-wraps?
+  (is (= (md/convert-string input {:with-hard-wraps? true})
+         "<p>one<br />\ntwo</p>\n")
+      "add line breaks when true")
+  (is (= (md/convert-string input {:with-hard-wraps? false})
+         "<p>one\ntwo</p>\n")
+      "no line breaks when off")
+  (is (= (md/convert-string input)
+         "<p>one<br />\ntwo</p>\n")
+      "should default to on for backwards compatibility")
+  (is (= (md/convert-string input {:with-hard-wraps? true})
+         (md/convert-string input))
+      "no flag and 'true' should be the same")
+  (is (thrown-with-msg? EvalError
+                        #"must be a boolean"
+                        (md/convert-string input {:with-hard-wraps? "foo"}))))
+
+(deftest with-xhtml?
+  (is (= (md/convert-string input {:with-xhtml? true})
+         "<p>one<br />\ntwo</p>\n"))
+  (is (= (md/convert-string input {:with-xhtml? false})
+         "<p>one<br>\ntwo</p>\n"))
+  (is (= (md/convert-string input)
+         (md/convert-string input {:with-xhtml? true}))))
+
+
+(def unsafe-input "<script>alert('pwned!')</script>")
+
+(deftest with-unsafe?
+  (is (= (md/convert-string unsafe-input {:with-unsafe? true})
+         "<script>alert('pwned!')</script>"))
+  (is (= (md/convert-string unsafe-input {:with-unsafe? false})
+         "<!-- raw HTML omitted -->\n"))
+  (is (= (md/convert-string unsafe-input)
+         (md/convert-string unsafe-input {:with-unsafe? true}))))

--- a/tests/eval/markdown.joke
+++ b/tests/eval/markdown.joke
@@ -18,7 +18,7 @@
          (md/convert-string input))
       "no flag and 'true' should be the same")
   (is (thrown-with-msg? EvalError
-                        #"must be a boolean"
+                        #"Expected Boolean, got String"
                         (md/convert-string input {:with-hard-wraps? "foo"}))))
 
 (deftest with-xhtml?


### PR DESCRIPTION
I've been building a little static site generator with joker and was missing the ability to turn off the hard line wraps. I've added flags for the other rendering options just for good measure.

I hope the style is ok. I'm not sure what the right pattern is for throwing an exception from the native Go code when a type is wrong. If there is a nicer way I'll happily update it. 

Thanks!