### PR TITLE
Create a_data.go in a reproducible way

### DIFF
--- a/core/gen_code/gen_code.go
+++ b/core/gen_code/gen_code.go
@@ -258,6 +258,7 @@ func init() {
 		"%s",`[1:],
 			ns))
 	}
+	sort.Strings(coreNamespaces)
 	dataContent := strings.Replace(dataTemplate, "{coreNamespaces}", strings.Join(coreNamespaces, "\n"), 1)
 	ioutil.WriteFile("a_data.go", []byte(dataContent), 0666)
 }


### PR DESCRIPTION
Create `a_data.go` in a reproducible way.
We sort to counter golang's random map iteration order.

Note that there is another issue left in the generation of `a_linter_all_data.go`.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).