### PR TITLE
`[linter]` add abs to cljs

### DIFF
--- a/core/data/linter_clj.joke
+++ b/core/data/linter_clj.joke
@@ -303,7 +303,6 @@
   ([opts stream]))
 (defn PrintWriter-on [flush-fn close-fn])
 
-(defn abs ^Number [^Number num])
 (defn NaN? ^Boolean [^Number num])
 (defn infinite? ^Boolean [^Number num])
 

--- a/core/data/linter_cljx.joke
+++ b/core/data/linter_cljx.joke
@@ -215,6 +215,7 @@
 
 ;; Clojure core functions not supported by Joker
 
+(defn abs ^Number [^Number num])
 (defn inst-ms [inst])
 (defn inst? [x])
 (defn uuid? [x])


### PR DESCRIPTION
Similar to: https://github.com/candid82/joker/issues/489

and: https://github.com/candid82/joker/commit/1d154363b529976a0aeec74cededf6147f218fe5

```
harold@freeside:~$ cat test.cljs 
(ns test)

(abs -1)
harold@freeside:~$ joker --version
v1.3.1
harold@freeside:~$ joker --lint test.cljs 
test.cljs:3:2: Parse error: Unable to resolve symbol: abs
```

Not sure if this is the correct fix, but wanted to show respect for your time - still loving `joker` as my clojure(script) linter and refactoring assist tool, we fly because of this software.

Thank you!