### PR TITLE
Add day of year to joker.time

### DIFF
--- a/std/time.joke
+++ b/std/time.joke
@@ -132,6 +132,12 @@
    :go "inTimezone(t, tz)"}
   [^Time t ^String tz])
 
+(defn ^Int day-of-year
+	"Returns the day of the year specified by t, in the range [1,365] for non-leap years, and [1,366] in leap years."
+	{:added "1.3.3"
+	:go "t.YearDay()"}
+	[^Time t])
+
 (def
   ^{:doc "Number of nanoseconds in 1 nanosecond"
     :added "1.0"

--- a/std/time/a_time.go
+++ b/std/time/a_time.go
@@ -66,6 +66,23 @@ func __add_date_(_args []Object) Object {
 	return NIL
 }
 
+var __day_of_year__P ProcFn = __day_of_year_
+var day_of_year_ Proc = Proc{Fn: __day_of_year__P, Name: "day_of_year_", Package: "std/time"}
+
+func __day_of_year_(_args []Object) Object {
+	_c := len(_args)
+	switch {
+	case _c == 1:
+		t := ExtractTime(_args, 0)
+		_res := t.YearDay()
+		return MakeInt(_res)
+
+	default:
+		PanicArity(_c)
+	}
+	return NIL
+}
+
 var __format__P ProcFn = __format_
 var format_ Proc = Proc{Fn: __format__P, Name: "format_", Package: "std/time"}
 

--- a/std/time/a_time_slow_init.go
+++ b/std/time/a_time_slow_init.go
@@ -129,6 +129,11 @@ func InternsOrThunks() {
 			NewListFrom(NewVectorFrom(MakeSymbol("t"), MakeSymbol("years"), MakeSymbol("months"), MakeSymbol("days"))),
 			`Returns the time t + (years, months, days).`, "1.0").Plus(MakeKeyword("tag"), String{S: "Time"}))
 
+	timeNamespace.InternVar("day-of-year", day_of_year_,
+		MakeMeta(
+			NewListFrom(NewVectorFrom(MakeSymbol("t"))),
+			`Returns the day of the year specified by t, in the range [1,365] for non-leap years, and [1,366] in leap years.`, "1.3.3").Plus(MakeKeyword("tag"), String{S: "Int"}))
+
 	timeNamespace.InternVar("format", format_,
 		MakeMeta(
 			NewListFrom(NewVectorFrom(MakeSymbol("t"), MakeSymbol("layout"))),


### PR DESCRIPTION
A simple function in Go time’s package – but useful if you are using a “year-day” format in your script (e.g. I commonly use format like `2023_344.backup` for timestamp on files).

I did not see tests specific to the time package, but running the script manually looking ok:

```
user=> (joker.time/day-of-year (joker.time/now))
359
```